### PR TITLE
HTTPServer _on_headers valid HTTP request expectation

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -321,31 +321,23 @@ class HTTPConnection(object):
     def _on_headers(self, data):
         eol = data.find("\r\n")
         start_line = data[:eol]
-        
         start_line_parts = start_line.split(" ")
-        
         if not len(start_line_parts):
             raise Exception("Malformed HTTP Request-Line: %s" % start_line)
-        
         method = start_line_parts[0]
         if method not in ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"]:
-            # Invalid HTTP method
             raise Exception("Invalid HTTP method in HTTP Request-Line: %s" % method)
-
         if len(start_line_parts) >= 2:        
             uri = start_line_parts[1]
         else:
-            # No URI, invalid request
-            raise Exception("Missing request URI in HTTP Request-Line: %s" % method)
-                
+            raise Exception("Missing request URI in HTTP Request-Line")
         if len(start_line_parts) >= 3:
             version = start_line_parts[2]
         else:      
-            # No version assume 1.0
-            version =  "HTTP/1.0"
-            
+            version =  "HTTP/1.0" # No version assume 1.0
         if not version.startswith("HTTP/"):
             raise Exception("Malformed HTTP version in HTTP Request-Line")
+
         headers = httputil.HTTPHeaders.parse(data[eol:])
         self._request = HTTPRequest(
             connection=self, method=method, uri=uri, version=version,


### PR DESCRIPTION
When trying to bypass the typical use case of a high-performance webserver such as nginx or cherokee in front of tornado, one is more likely to see malformed HTTP requests.  In my case I was trying out a tornado app behind a F5 load balancer.  The F5 health-check monitor sends a malformed HTTP request omitting a HTTP version.

This patch tries to make the start_line processing a little more forgiving.  It makes sure each parameter is there, throwing an exception for any missing or invalid element except for version.  If version is missing it sets the version to HTTP/1.0.
