### PR TITLE
Handle POST requests with empty bodies correctly.

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -330,7 +330,7 @@ class HTTPConnection(object):
             headers=headers, remote_ip=self.address[0])
 
         content_length = headers.get("Content-Length")
-        if content_length:
+        if content_length and int(content_length):
             content_length = int(content_length)
             if content_length > self.stream.max_buffer_size:
                 raise Exception("Content-Length too long")


### PR DESCRIPTION
The HTTP server didn't handle requests with the content-length header set to 0 correctly. I updated the conditional to include this edge case.
