### PR TITLE
Resubmission of default filename for the StaticFileHandler

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1227,17 +1227,28 @@ class StaticFileHandler(RequestHandler):
     want browsers to cache a file indefinitely, send them to, e.g.,
     /static/images/myimage.png?v=xxx.
     """
-    def __init__(self, application, request, path):
+    def __init__(self, application, request, path, default_filename=None):
         RequestHandler.__init__(self, application, request)
         self.root = os.path.abspath(path) + os.path.sep
+        self.default_filename = default_filename
 
     def head(self, path):
         self.get(path, include_body=False)
 
     def get(self, path, include_body=True):
         abspath = os.path.abspath(os.path.join(self.root, path))
-        if not abspath.startswith(self.root):
+        # os.path.abspath strips a trailing /
+        # it needs to be temporarily added back for requests to root/
+        if not (abspath + os.path.sep).startswith(self.root):
             raise HTTPError(403, "%s is not in root static directory", path)
+        if os.path.isdir(abspath) and self.default_filename is not None:
+            # need to look at the request.path here for when path is empty
+            # but there is some prefix to the path that was already
+            # trimmed by the routing
+            if not self.request.path.endswith(os.path.sep):
+                self.redirect(self.request.path + os.path.sep)
+                return
+            abspath = os.path.join(abspath, self.default_filename)
         if not os.path.exists(abspath):
             raise HTTPError(404)
         if not os.path.isfile(abspath):


### PR DESCRIPTION
allows an app to configure a handler so that if a request to '/dir', the handler will return '/dir/index.html' if it exists. the default filename, the 'index.html' part is configurable when creating the Handler object.

Using the default filename is optional; if it's not used behavior should remain unchanged.

This is a resubmission of pull request #149.  Resubmission is based on feedback from bdarnell.  Differences are:
- change name of parameter to be default_filename instead of default_file, which is clearer
- removed an unnecessary check of the path param which was residue from an earlier set of work and is no longer necessary
