### PR TITLE
In nginx, it suggests using X-Real-IP (and not X-Real-Ip) - Fix for request.remote_ip with xheaders

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -431,8 +431,13 @@ class HTTPRequest(object):
         self.body = body or ""
         if connection and connection.xheaders:
             # Squid uses X-Forwarded-For, others use X-Real-Ip
-            self.remote_ip = self.headers.get(
-                "X-Real-Ip", self.headers.get("X-Forwarded-For", remote_ip))
+            for h in ("X-Real-Ip",
+                      "X-Real-IP",
+                      "X-Forwarded-For"):
+                self.remote_ip = self.headers.get(h, None)
+                if self.remote_ip is not None:
+                    break
+
             self.protocol = self.headers.get("X-Scheme", protocol) or "http"
         else:
             self.remote_ip = remote_ip


### PR DESCRIPTION
I added support for X-Real-IP in HTTPRequest.  

If you look at nginx docs, it suggests using X-Real-IP instead (and the current rev of Tornado only supports X-Forwaded-For and X-Real-Ip.

http://wiki.nginx.org/NginxHttpProxyModule#Synopsis

Thanks,
Mike
