### PR TITLE
More flexibility for handling exceptions in AsyncHTTPClient

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -350,8 +350,11 @@ class AsyncHTTPClient(object):
         except (KeyboardInterrupt, SystemExit):
             raise
         except:
-            logging.error("Exception in callback %r", info["callback"],
-                          exc_info=True)
+            self.handle_callback_exception(info["callback"])
+
+
+    def handle_callback_exception(self, callback):
+        self.io_loop.handle_callback_exception(callback)
 
 # For backwards compatibility: Tornado 1.0 included a new implementation of
 # AsyncHTTPClient that has since replaced the original.  Define an alias


### PR DESCRIPTION
Hi,

Currently there's no way to handle an exception raised from an AsyncHTTPClient request handler, the exception is just logged. This patch adds support for handling the exception by subclassing AsyncHTTPClient or IOLoop. By doing the second thing, the application is able to handle all the exception raised by callback in just a single place. I know there are multiple ways for doing this and my approach might not be the best one. Please, feel free to request improvements before merging this patch.

Best regards,
Alberto
