### PR TITLE
SSL error in iostream and infinite loop

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -391,6 +391,9 @@ class SSLIOStream(IOStream):
             elif err.args[0] in (ssl.SSL_ERROR_EOF,
                                  ssl.SSL_ERROR_ZERO_RETURN):
                 return self.close()
+            elif err.args[0] == ssl.SSL_ERROR_SSL:
+                logging.warning("SSL Error on %d: %s", self.socket.fileno(), err)
+                return self.close()
             raise
         except socket.error, err:
             if err.args[0] == errno.ECONNABORTED:


### PR DESCRIPTION
If the client doesn't send a certificate, then tornado turns into an infinite loop.
(with the option ssl.CERT_REQUIRED )

http://groups.google.com/group/python-tornado/browse_thread/thread/de51d962898939e3

> IOStream._handle_events needs a try/except block similar to the one in
> _run_callback.  I'm not sure whether this would replace the one in
> _run_callback or if we need one in both places.
> 
> -Ben
