### PR TITLE
callback_uri in authenticate_redirect

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -77,7 +77,7 @@ class OpenIdMixin(object):
         all those attributes for your app, you can request fewer with
         the ax_attrs keyword argument.
         """
-        callback_uri = callback_uri or self.request.path
+        callback_uri = callback_uri or self.request.uri
         args = self._openid_args(callback_uri, ax_attrs=ax_attrs)
         self.redirect(self._OPENID_ENDPOINT + "?" + urllib.urlencode(args))
 


### PR DESCRIPTION
I would like to suggest the patch below for tornado/auth.py. When there is no callback_uri specified Tornado is using self.request.path to redirect, but that chops off all the arguments of the original query. If /subpage requires a login the next=/subpage argument will contain the place to continue but that information is lost when we call authenticate_redirect and the user will be redirected to root. The suggested patch solves this problem.

For a test program please try http://gist.github.com/653698, without this patch a request to localhost:8888/test redirects to localhost:8888/ after authentication, with the patch it continues on /test as it should be.

/Attila Babo
