### PR TITLE
HTTP Basic authentication

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -166,12 +166,14 @@ class RequestHandler(object):
         """
         pass
 
-    def clear(self):
+    def clear(self, extra_headers=None):
         """Resets all headers and content for this response."""
         self._headers = {
             "Server": "TornadoServer/%s" % tornado.version,
             "Content-Type": "text/html; charset=UTF-8",
         }
+        if extra_headers:
+            self._headers.update(extra_headers)
         if not self.request.supports_http_1_1():
             if self.request.headers.get("Connection") == "Keep-Alive":
                 self.set_header("Connection", "Keep-Alive")
@@ -579,7 +581,7 @@ class RequestHandler(object):
             self._log()
         self._finished = True
 
-    def send_error(self, status_code=500, **kwargs):
+    def send_error(self, status_code=500, extra_headers=None, **kwargs):
         """Sends the given HTTP error code to the browser.
 
         We also send the error HTML for the given error code as returned by
@@ -591,7 +593,7 @@ class RequestHandler(object):
             if not self._finished:
                 self.finish()
             return
-        self.clear()
+        self.clear(extra_headers)
         self.set_status(status_code)
         message = self.get_error_html(status_code, **kwargs)
         self.finish(message)


### PR DESCRIPTION
I've had to make these changes in order to implement HTTP Basic authentication in a subclass of RequestHandler. The RFC says that a server may send a WWW-Authenticate header along with the 401 (Unauthorized) status code. However RequestHandler.clear (called from send_error) clears the headers. These changes should not break anyone's code since send_error doesn't have an *args parameter.
