### PR TITLE
Removing an unused import in chatdemo.py

### DIFF
--- a/demos/chat/chatdemo.py
+++ b/demos/chat/chatdemo.py
@@ -17,7 +17,6 @@
 import logging
 import tornado.auth
 import tornado.escape
-import tornado.httpserver
 import tornado.ioloop
 import tornado.options
 import tornado.web


### PR DESCRIPTION
`tornado.httpserver` is not used by `chatdemo.py`, so it doesn't need to be imported.
