### PR TITLE
Fix call to ErrorHandler __init__.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1160,7 +1160,7 @@ class Application(object):
                         args = [unquote(s) for s in match.groups()]
                     break
             if not handler:
-                handler = ErrorHandler(self, request, 404)
+                handler = ErrorHandler(self, 404)
 
         # In debug mode, re-compile templates and reload static files on every
         # request so you don't need to restart to see changes


### PR DESCRIPTION
There was a change early this week to the args on the **init** in ErrorHandler, but the call to create it wasn't updated.
