### PR TITLE
Error handler creation. web.py:1171

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1160,7 +1160,7 @@ class Application(object):
                         args = [unquote(s) for s in match.groups()]
                     break
             if not handler:
-                handler = ErrorHandler(self, request, 404)
+                handler = ErrorHandler(self, request, status_code=404)
 
         # In debug mode, re-compile templates and reload static files on every
         # request so you don't need to restart to see changes


### PR DESCRIPTION
The last argument on the ErrorHandler creation call needed to be a kv arg with key status_code. The call was failing with: TypeError: **init**() takes exactly 3 arguments (4 given) previously.
