### PR TITLE
replaced _read_buffer and _write_buffer to use cStringIO on iostream.py

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -338,7 +338,7 @@ class IOStream(object):
                 # of bytes it was able to process.
                 buffered_string = self._write_buffer.getvalue()
                 num_bytes = self.socket.send(buffered_string[:128 * 1024])
-                self._write_buffer.reset()
+                self._write_buffer = StringIO()
                 self._write_buffer.write(buffered_string[num_bytes:])
             except socket.error, e:
                 if e.args[0] in (errno.EWOULDBLOCK, errno.EAGAIN):
@@ -355,7 +355,7 @@ class IOStream(object):
 
     def _consume(self, loc):
         buffered_string = self._read_buffer.getvalue()
-        self._read_buffer.reset()
+        self._read_buffer = StringIO()
         self._read_buffer.write(buffered_string[loc:])
         return buffered_string[:loc]
 


### PR DESCRIPTION
Following conversation here: http://groups.google.com/group/python-tornado/browse_thread/thread/5fd283ff5d043deb

I just recently had to deal with large file upload as well. The solution here is to use cStringIO on _read_buffer (as Ben suggested). I changed _write_buffer as well for consistency sake.

Uploading large file is noticeably faster now (through observation not benchmarks).

Existing iostream test still pass.
