### PR TITLE
Added missing "stream" in call chain for get_ssl_certificate()

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -517,8 +517,8 @@ class HTTPRequest(object):
         http://docs.python.org/library/ssl.html#sslsocket-objects
         """
         try:
-            return self.connection.socket.getpeercert()
-        except:
+            return self.connection.stream.socket.getpeercert()
+        except ssl.SSLError:
             return None
 
     def __repr__(self):


### PR DESCRIPTION
The HTTPRequest.get_ssl_certificate contains an error when calling getpeercert(). Also is catches all exception making it hard to find the error (AttributeError). Changed so it only catches SSLErrors. 
