### PR TITLE
Tornado XSRF-protection bypass

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -733,8 +733,6 @@ class RequestHandler(object):
 
         See http://en.wikipedia.org/wiki/Cross-site_request_forgery
         """
-        if self.request.headers.get("X-Requested-With") == "XMLHttpRequest":
-            return
         token = self.get_argument("_xsrf", None)
         if not token:
             raise HTTPError(403, "'_xsrf' argument missing from POST")


### PR DESCRIPTION
Fix the XSRF-protection bypass described in [1, 2]. The presence of the X-Requested-With: XMLHttpRequest header is no longer sufficient, due to a discovery by Felix Grobert that allows the spoofing of such header.

[1] http://www.djangoproject.com/weblog/2011/feb/08/security/
[2] http://weblog.rubyonrails.org/2011/2/8/csrf-protection-bypass-in-ruby-on-rails
