### PR TITLE
Removing the *.png pattern for the 'demos' line

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include demos *.py *.yaml *.html *.css *.png *.js *.xml *.sql README
+recursive-include demos *.py *.yaml *.html *.css *.js *.xml *.sql README
 include tornado/epoll.c


### PR DESCRIPTION
Because there aren't any .png files in the 'demos' hierarchy, this was causing a warning when the 'egg_info' setup command was run.
