### PR TITLE
Small bug fix: make AsyncTestCase call super method in tearDown

### DIFF
--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -11,5 +11,33 @@ class AsyncTestCaseTest(AsyncTestCase, LogTrapTestCase):
         except ZeroDivisionError:
             pass
 
+class SetUpTearDownTest(unittest.TestCase):
+    def test_set_up_tear_down(self):
+        """
+        This test makes sure that AsyncTestCase calls super methods for
+        setUp and tearDown.
+
+        InheritBoth is a subclass of both AsyncTestCase and
+        SetUpTearDown, with the ordering so that the super of
+        AsyncTestCase will be SetUpTearDown.
+        """
+        events = []
+        result = unittest.TestResult()
+
+        class SetUpTearDown(unittest.TestCase):
+            def setUp(self):
+                events.append('setUp')
+
+            def tearDown(self):
+                events.append('tearDown')
+
+        class InheritBoth(AsyncTestCase, SetUpTearDown):
+            def test(self):
+                events.append('test')
+
+        InheritBoth('test').run(result)
+        expected = ['setUp', 'test', 'tearDown']
+        self.assertEqual(expected, events)
+
 if __name__ == '__main__':
-    unittest.main
+    unittest.main()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -112,6 +112,7 @@ class AsyncTestCase(unittest.TestCase):
                     logging.debug("error closing fd %d", fd, exc_info=True)
             self.io_loop._waker_reader.close()
             self.io_loop._waker_writer.close()
+        super(AsyncTestCase, self).tearDown()
 
     def get_new_ioloop(self):
         '''Creates a new IOLoop for this test.  May be overridden in


### PR DESCRIPTION
I ran into a problem when trying to mix in one of my unittest add-on classes with AsyncTestCase.  My tearDown method wasn't getting called because AsyncTestCase wasn't calling the super method in tearDown.
