### PR TITLE
don't send None arguments when optional group is unmatched

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1196,7 +1196,7 @@ class Application(object):
                     if kwargs:
                         args = []
                     else:
-                        args = [unquote(s) for s in match.groups()]
+                        args = [unquote(s) for s in match.groups() if s]
                     break
             if not handler:
                 handler = ErrorHandler(self, request, status_code=404)


### PR DESCRIPTION
I have this request handler:

```
(r'/system/([0-9]+)?', SystemHandler)

class SystemHandler(tornado.web.RequestHandler):
    def get(self, system_id):
        """ Return system identified by system_id"""
        pass
    def post(self):
         """Create new system"""
         # do something
         return system_id
```

GETing to `/system/3` works good.

POSTing to `/system/` fails right now because the method is passed a None argument. I think it shouldn't be passed any argument at all. The commit fixes this.
