### PR TITLE
Make type in tornado.options.define equal type of default in some cases

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -90,6 +90,8 @@ def define(name, default=None, type=str, help=None, metavar=None,
     options_file = frame.f_code.co_filename
     file_name = frame.f_back.f_code.co_filename
     if file_name == options_file: file_name = ""
+    if type is str and default is not None:
+        type = default.__class__
     options[name] = _Option(name, file_name=file_name, default=default,
                             type=type, help=help, metavar=metavar,
                             multiple=multiple)


### PR DESCRIPTION
type in tornado.options.define defaults to type of default, if no type is given (type is str). This simplifies defines:

```
from tornado.options import define
define('port', 8888) # would be: define('port', 8888, int)
```

It seems more intuitive to me and reduces number of mistakes. This is also a behaviour I would expect.
This only applies when default is not None, so there's no way a type would be NoneType (unless explicitly given).
