### PR TITLE
Added ``kwargs`` property to HTTPError class instance.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1246,10 +1246,11 @@ class Application(object):
 
 class HTTPError(Exception):
     """An exception that will turn into an HTTP error response."""
-    def __init__(self, status_code, log_message=None, *args):
+    def __init__(self, status_code, log_message=None, *args, **kwargs):
         self.status_code = status_code
         self.log_message = log_message
         self.args = args
+        self.kwargs = kwargs
 
     def __str__(self):
         message = "HTTP %d: %s" % (


### PR DESCRIPTION
I was playing with HTTPError handling in one of my Tornado applications and I found this patch quite useful, since `args` argument is printable.

Now you can pass any number of additional parameters to a HTTPError instance, which enables more sophisticated error handling. One example usage scenario is when you want to distinguish between AJAX and normal requests (e.g. by passing `ajax=True`) - the former would result in the application responding with JSON string (with proper headers set), while in the latter case the app would serve normal error page.
