### PR TITLE
Added support for javascript files served on https

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -451,7 +451,7 @@ class RequestHandler(object):
             paths = []
             unique_paths = set()
             for path in js_files:
-                if not path.startswith("/") and not path.startswith("http:"):
+                if not path.startswith("/") and not path.startswith("http:") and not path.startswith("https:"):
                     path = self.static_url(path)
                 if path not in unique_paths:
                     paths.append(path)


### PR DESCRIPTION
with current implementation

def javascript_files(self):
        return ["https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.12/jquery-ui.js"]

will return this error:

[E 110501 18:48:21 web:797] Could not open static file 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.12/jquery-ui.js'
