### PR TITLE
clean up some unused variables/imports found with pyflakes

### DIFF
--- a/demos/appengine/markdown.py
+++ b/demos/appengine/markdown.py
@@ -50,7 +50,6 @@ __author__ = "Trent Mick"
 
 import os
 import sys
-from pprint import pprint
 import re
 import logging
 try:
@@ -66,7 +65,6 @@ import codecs
 #---- Python version compat
 
 if sys.version_info[:2] < (2,4):
-    from sets import Set as set
     def reversed(sequence):
         for i in sequence[::-1]:
             yield i
@@ -485,11 +483,11 @@ class Markdown(object):
                 # Delimiters for next comment block.
                 try:
                     start_idx = text.index("<!--", start)
-                except ValueError, ex:
+                except ValueError:
                     break
                 try:
                     end_idx = text.index("-->", start_idx) + 3
-                except ValueError, ex:
+                except ValueError:
                     break
 
                 # Start position for next comment block search.
@@ -1130,7 +1128,6 @@ class Markdown(object):
     def _list_item_sub(self, match):
         item = match.group(4)
         leading_line = match.group(1)
-        leading_space = match.group(2)
         if leading_line or "\n\n" in item or self._last_li_endswith_two_eols:
             item = self._run_block_gamut(self._outdent(item))
         else:
@@ -1591,7 +1588,6 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
     if DEBUG: 
         print "dedent: dedent(..., tabsize=%d, skip_first_line=%r)"\
               % (tabsize, skip_first_line)
-    indents = []
     margin = None
     for i, line in enumerate(lines):
         if i == 0 and skip_first_line: continue

--- a/demos/blog/markdown.py
+++ b/demos/blog/markdown.py
@@ -50,7 +50,6 @@ __author__ = "Trent Mick"
 
 import os
 import sys
-from pprint import pprint
 import re
 import logging
 try:
@@ -66,7 +65,6 @@ import codecs
 #---- Python version compat
 
 if sys.version_info[:2] < (2,4):
-    from sets import Set as set
     def reversed(sequence):
         for i in sequence[::-1]:
             yield i
@@ -485,11 +483,11 @@ class Markdown(object):
                 # Delimiters for next comment block.
                 try:
                     start_idx = text.index("<!--", start)
-                except ValueError, ex:
+                except ValueError:
                     break
                 try:
                     end_idx = text.index("-->", start_idx) + 3
-                except ValueError, ex:
+                except ValueError:
                     break
 
                 # Start position for next comment block search.
@@ -1130,7 +1128,6 @@ class Markdown(object):
     def _list_item_sub(self, match):
         item = match.group(4)
         leading_line = match.group(1)
-        leading_space = match.group(2)
         if leading_line or "\n\n" in item or self._last_li_endswith_two_eols:
             item = self._run_block_gamut(self._outdent(item))
         else:
@@ -1591,7 +1588,6 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
     if DEBUG: 
         print "dedent: dedent(..., tabsize=%d, skip_first_line=%r)"\
               % (tabsize, skip_first_line)
-    indents = []
     margin = None
     for i, line in enumerate(lines):
         if i == 0 and skip_first_line: continue

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -1,7 +1,6 @@
 import calendar
 import email.utils
 import httplib
-import os
 import time
 import weakref
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -163,7 +163,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
         def wrapper(*args, **kwargs):
             try:
                 return callback(*args, **kwargs)
-            except Exception, e:
+            except Exception:
                 logging.error("Uncaught exception in %s",
                               self.request.path, exc_info=True)
                 self._abort()

--- a/website/markdown/inlinepatterns.py
+++ b/website/markdown/inlinepatterns.py
@@ -215,7 +215,6 @@ class HtmlPattern (Pattern):
     """ Store raw inline html and return a placeholder. """
     def handleMatch (self, m):
         rawhtml = m.group(2)
-        inline = True
         place_holder = self.markdown.htmlStash.store(rawhtml)
         return place_holder
 

--- a/website/website.py
+++ b/website/website.py
@@ -17,7 +17,6 @@
 import markdown
 import os
 import os.path
-import time
 import tornado.web
 import tornado.wsgi
 import wsgiref.handlers


### PR DESCRIPTION
These are some very simple cleanups to random parts of the code, that I found with pyflakes. The diff mostly consists of deleted lines. I think these all pretty straightforward; there were some other questionable unused things (e.g. importing log levels from the `logging` module) that I decided to leave.

Also, there are a few places where the code is definitely incorrect that pylfakes found, which I did not attempt to fix (although I encourage one of you to!). A small sample:

```
evan@zeno ~/code/tornado (unused_imports) $ pyflakes . | grep undefined
./tornado/test/httpserver_test.py:26: undefined name 'SSLTest'
./website/markdown/blockprocessors.py:358: undefined name 'message'
./website/markdown/blockprocessors.py:358: undefined name 'CRITICAL'
./website/markdown/odict.py:159: undefined name 'Error'
./website/markdown/odict.py:162: undefined name 'Error'
./website/markdown/treeprocessors.py:188: undefined name 'prefix'
```

Anyway, hope this commit looks OK to you.
