### PR TITLE
add text tracebacks on 500s when in debug mode

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -70,6 +70,7 @@ import stat
 import sys
 import time
 import tornado
+import traceback
 import types
 import urllib
 import urlparse
@@ -663,11 +664,16 @@ class RequestHandler(object):
         If this error was caused by an uncaught exception, the
         exception object can be found in kwargs e.g. kwargs['exception']
         """
-        return "<html><title>%(code)d: %(message)s</title>" \
-               "<body>%(code)d: %(message)s</body></html>" % {
-            "code": status_code,
-            "message": httplib.responses[status_code],
-        }
+        if self.settings.get("debug"):
+            # in debug mode, try to send a traceback
+            self.set_header('Content-Type', 'text/plain')
+            return traceback.format_exc()
+        else:
+            return "<html><title>%(code)d: %(message)s</title>" \
+                   "<body>%(code)d: %(message)s</body></html>" % {
+                "code": status_code,
+                "message": httplib.responses[status_code],
+            }
 
     @property
     def locale(self):


### PR DESCRIPTION
Hi,

This is a simple change that sends a text traceback as the default 500 response, when the application has `debug` set to a truthy value. If `debug` is not set, the current generic 500 response is still sent.

I can add pygments highlighting support to the traceback (i.e. guarded by `ImportError` checks), but that may impact the default memory footprint of `tornado.web` adversely, so I've avoided doing that for now.
