### PR TITLE
Add a way of customizing cache control behavior for static files.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1492,11 +1492,9 @@ class StaticFileHandler(RequestHandler):
                 self.set_status(304)
                 return
 
-        if not include_body:
-            return
-
-        with open(abspath, "rb") as file:
-            self.write(file.read())
+        if include_body:
+            with open(abspath, "rb") as file:
+                self.write(file.read())
 
     def set_extra_headers(self, path, modified, mime_type):
         """For subclass to add extra headers to the response"""


### PR DESCRIPTION
This current implementation of aggressive caching works well with `static_url` helper, however since the caching behavior is hard-coded, it's harder to interface it with other third-party libraries.

For example [webassets](http://elsdoerfer.name/docs/webassets) offers two versioning schemes for static files: `?xxx` and `path.XXX.ext`. Both are incompatible with the current implementation of the aggressive caching feature found in Tornado 2.x. Naturally, one might write a UIMethod which translates `?xxx` into `?v=xxx`, but it's a bit awkward.
