### PR TITLE
read_some function for IOStream

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -36,11 +36,12 @@ except ImportError:
 class IOStream(object):
     r"""A utility class to write to and read from a non-blocking socket.
 
-    We support three methods: write(), read_until(), and read_bytes().
-    All of the methods take callbacks (since writing and reading are
-    non-blocking and asynchronous). read_until() reads the socket until
-    a given delimiter, and read_bytes() reads until a specified number
-    of bytes have been read from the socket.
+    We support four methods: write(), read_until(), read_bytes(), and
+    read_some(). All of the methods take callbacks (since writing and
+    reading are non-blocking and asynchronous). read_until() reads the
+    socket until a given delimiter, read_bytes() reads until a specified
+    number of bytes have been read from the socket, and read_some() reads
+    until one or more bytes are available.
 
     The socket parameter may either be connected or unconnected.  For
     server operations the socket is the result of calling socket.accept().


### PR DESCRIPTION
This new function, `read_some`, causes `IOStream` to call the callback when some data is available. If there is data in the buffer, it is returned. If there is not, the socket is marked readable and the callback is called with all available data when some becomes available.

This function enables efficient streaming without advance knowledge of number of bytes or delimiters.
