### PR TITLE
Close simple_httpclient IOStreams on success

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -339,6 +339,7 @@ class _HTTPConnection(object):
                                 buffer=buffer,
                                 effective_url=self.request.url)
         self.callback(response)
+        self.stream.close()
         self.callback = None
 
     def _on_chunk_length(self, data):


### PR DESCRIPTION
Noticed that a max_clients around 50 would cause us to run out of file descriptors. lsof showed that TCP connections would remain in the established state versus being closed. stream.close is called in error states but not success. Thus call stream.close after passing the response to the callback. Result was seeing the TCP connections being properly closed as well as no change in fetching data.
