### PR TITLE
fixed unicode string in template expression made encoding error

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -121,7 +121,7 @@ class Template(object):
         self.file = _File(_parse(reader, self))
         self.code = self._generate_python(loader, compress_whitespace)
         try:
-            self.compiled = compile(self.code, "<template %s>" % self.name,
+            self.compiled = compile('#coding: utf-8\n' + self.code, "<template %s>" % self.name,
                                     "exec")
         except Exception:
             formatted_code = _format_code(self.code).rstrip()


### PR DESCRIPTION
An unicode string in template _Expression such as {{u'中ニッホン' }} would display as garbage. This was caused by that the built-in compile() function assumes the generated python code was ascii encoded. Since compile() won't receive an 'encoding' argument，we should solved this like a regular python source file - adding commen '#coding: utf-8' to the head of generated source code.
