### PR TITLE
Add template keyword to output block unchanged

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -533,6 +533,17 @@ def _format_code(code):
 
 
 def _parse(reader, template, in_block=None):
+    # Skip everything if we're in a verbatim block
+    if in_block == "verbatim":
+        block_end = reader.find("{% end %}")
+        if block_end == -1 or block_end + 1 == reader.remaining():
+            raise ParseError("Missing {%% end %%} block for verbatim")
+        unparsed_text = reader.consume(block_end)
+        # Consume the end block
+        # NOTE: the magic number 9 comes from: len('{% end %}') == 9
+        reader.consume(9)
+        return unparsed_text
+
     body = _ChunkList([])
     while True:
         # Find next template directive
@@ -658,7 +669,7 @@ def _parse(reader, template, in_block=None):
             body.chunks.append(block)
             continue
 
-        elif operator in ("apply", "block", "try", "if", "for", "while"):
+        elif operator in ("apply", "block", "try", "if", "for", "while", "verbatim"):
             # parse inner body recursively
             block_body = _parse(reader, template, operator)
             if operator == "apply":
@@ -669,6 +680,8 @@ def _parse(reader, template, in_block=None):
                 if not suffix:
                     raise ParseError("block missing name on line %d" % line)
                 block = _NamedBlock(suffix, block_body, template)
+            elif operator == "verbatim":
+                block = _Text(block_body)
             else:
                 block = _ControlBlock(contents, block_body)
             body.chunks.append(block)


### PR DESCRIPTION
Using javascript templates is tricky because it often requires you to use similar syntax to Tornado templates. While you can use the {{! and {{% syntax, this is often pretty cumbersome for large chunks of javascript templates. I propose we have a verbatim/raw/cdata keyword that would output my template code unchanged.

For more information, see this thread: http://groups.google.com/group/python-tornado/browse_thread/thread/8d0383a76324e0a6/741315ab35621caa?lnk=gst&q=templates#

Add "verbatim" template keyword that will output the text within the block unchanged
