### PR TITLE
Stabilization of the period of ioloop.PeriodicCallback.

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -434,8 +434,8 @@ class PeriodicCallback(object):
     def start(self):
         """Starts the timer."""
         self._running = True
-        timeout = time.time() + self.callback_time / 1000.0
-        self.io_loop.add_timeout(timeout, self._run)
+        self._next_timeout = time.time()
+        self._schedule_next()
 
     def stop(self):
         """Stops the timer."""
@@ -447,8 +447,12 @@ class PeriodicCallback(object):
             self.callback()
         except Exception:
             logging.error("Error in periodic callback", exc_info=True)
+        self._schedule_next()
+
+    def _schedule_next(self):
         if self._running:
-            self.start()
+            self._next_timeout += self.callback_time / 1000.0
+            self.io_loop.add_timeout(self._next_timeout, self._run)
 
 
 class _EPoll(object):


### PR DESCRIPTION
The execution of callbacks by ioloop.PeriodicCallback was not trully periodic because the timeout for the following event was computed by adding callback_time to the actual time the previous callback finished. This piece of code demonstrates that:

```
import time
import tornado.ioloop

def callback():
    print time.time()
    for i in range(1, 1000000):
        a = 2 * i

sched = tornado.ioloop.PeriodicCallback(callback, 3000)
sched.start()
tornado.ioloop.IOLoop.instance().start()
```

The period should be 3 seconds, but it is slightly more, due to the time the callback takes to execute plus the delay between the instant the callback is planned to be executed and the actual time it is executed.

As a user of PeriodicCallback, after having read its documentation, I expected callbacks to be trully periodic, being callback_time their period. The commit I propose schedules the next timeout with respect to when the previous timeout was scheduled. This makes it trully periodic.

Note, however, that my solution has a problem when the time it takes the callback to execute is systematically greater than callback_time: the queue of scheduled events would grow indefinitely. It is clearly a problem in the client code, but if we wanted to protect PeriodicCallback against that, I beleive this other patch would at least keep the size of the queue under control by dropping missed periods:

```
     def _schedule_next(self):
         if self._running:
-            self._next_timeout += self.callback_time / 1000.0
+            current_time = time.time()
+            while self._next_timeout < current_time:
+                self._next_timeout += self.callback_time / 1000.0
             self.io_loop.add_timeout(self._next_timeout, self._run)
```

I haven't included it in the commit because I'm not really sure this case should be addressed.
