### PR TITLE
Avoid naming conflict with 'modules' template parameter

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -414,7 +414,7 @@ class _Expression(_Node):
 
 class _Module(_Expression):
     def __init__(self, expression):
-        super(_Module, self).__init__("modules." + expression,
+        super(_Module, self).__init__("_modules." + expression,
                                       raw=True)
 
 class _Text(_Node):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -106,8 +106,8 @@ class RequestHandler(object):
         self._transforms = None  # will be set in _execute
         self.ui = _O((n, self._ui_method(m)) for n, m in
                      application.ui_methods.iteritems())
-        self.ui["modules"] = _O((n, self._ui_module(n, m)) for n, m in
-                                application.ui_modules.iteritems())
+        self.ui["modules"] = self.ui["_modules"] = _O((n, self._ui_module(n, m)) for n, m in
+                                                      application.ui_modules.iteritems())
         self.clear()
         # Check since connection is not available in WSGI
         if hasattr(self.request, "connection"):


### PR DESCRIPTION
Add extra `_modules` reference to modules list in template parameters, which is used by the `{% module ... %}` directive to avoid naming conflicts with Python modules named `modules` (yes, I ran into this).

Presumably, in a later version, the `modules` reference can be deprecated in favor of `_modules`?
