### PR TITLE
Keep-alives and connect_timeout bug

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -139,7 +139,7 @@ class _HTTPConnection(object):
         # Timeout handle returned by IOLoop.add_timeout
         self._timeout = None
         self._connect_timeout = None
-        if self.request.headers.get('Connection') == 'close'
+        if self.request.headers.get('Connection') == 'close':
             self.keep_alive = False 
         else:
             self.keep_alive = True
@@ -178,7 +178,7 @@ class _HTTPConnection(object):
             # Ignore keep_alive logic if explicitly requesting non-presistent connections
             if self.keep_alive:
                 self.stream_key = (host, port, parsed.scheme)
-                if self.client.stream_map.has_key(self.stream_key)
+                if self.client.stream_map.has_key(self.stream_key):
                     while not self.client.stream_map[self.stream_key].empty():
                         self.stream = self.client.stream_map[self.stream_key].get_nowait()
                         # Ditch closed streams and get a new one
@@ -191,7 +191,7 @@ class _HTTPConnection(object):
                                 self.stream.set_close_callback(self._on_close)
                                 self._on_connect(parsed)
                                 return
-               else:
+                else:
                     self.client.stream_map[self.stream_key]  = Queue.Queue()
 
             addrinfo = socket.getaddrinfo(host, port, af, socket.SOCK_STREAM,


### PR DESCRIPTION
Added support for keep-alive in SimpleAsyncClient, also fixed bug where Async connections would close due to connection timeout even after the connection had been established

Decided to not go with the suggested implementation of keeping a pool of _HTTPConnections as it seemed cumbersome to maintain all the state of an object that would (potentially) be overwritten every time.  Decided instead on keeping a queue of streams (essentially sockets) that are reused as soon as they become available.

Streams are keyed in the stream_map with a (scheme,host,port) tuple (or some permutation, i forget)

Client defaults to keep_alive, dead sockets are cycled through if they're dead and not used, when a stream is no longer in use it drops references to the current _HTTPConnection and readies itself for the next one.

Any suggestions/problems/fixes let me know.
