### PR TITLE
For the HTTPClients, adding  OPTIONS and TRACE, which are less-used HTTP 

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -593,7 +593,7 @@ def _curl_setup_request(curl, request, buffer, headers):
         "PUT": pycurl.UPLOAD,
         "HEAD": pycurl.NOBODY,
     }
-    custom_methods = set(["DELETE"])
+    custom_methods = set(["DELETE", "OPTIONS", "TRACE", "PURGE"])
     for o in curl_options.values():
         curl.setopt(o, False)
     if request.method in curl_options:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -126,7 +126,8 @@ class SimpleAsyncHTTPClient(object):
 
 
 class _HTTPConnection(object):
-    _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE"])
+    _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE",
+        "OPTIONS", "TRACE", "PURGE"])
 
     def __init__(self, io_loop, client, request, callback):
         self.start_time = time.time()


### PR DESCRIPTION
For the HTTPClients, adding  OPTIONS and TRACE, which are less-used HTTP methods, and PURGE which is a custom method used by different proxies such as Squid or Varnish.
