### PR TITLE
tornado.web.https_only decorator

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1708,7 +1708,7 @@ def authenticated(method):
 
 
 def https_only(method):
-        """Decorate methods with this to ensure request will be sent only via HTTPS."""
+    """Decorate methods with this to ensure request will be sent only via HTTPS."""
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         if self.request.protocol != "https":


### PR DESCRIPTION
Sometimes is necessary to be sure that some handlers will be called only via the HTTPS scheme.
This relatively small check usually ends with redirect to the same URL with the correct scheme and this is exactly what this decorator does.
