### PR TITLE
Move 'cookies' property from RequestHandler to HTTPRequest

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -24,6 +24,7 @@ This module also defines the `HTTPRequest` class which is exposed via
 `tornado.web.RequestHandler.request`.
 """
 
+import Cookie
 import errno
 import logging
 import os
@@ -508,6 +509,19 @@ class HTTPRequest(object):
     def supports_http_1_1(self):
         """Returns True if this request supports HTTP/1.1 semantics"""
         return self.version == "HTTP/1.1"
+
+    @property
+    def cookies(self):
+        """A dictionary of Cookie.Morsel objects."""
+        if not hasattr(self, "_cookies"):
+            self._cookies = Cookie.SimpleCookie()
+            if "Cookie" in self.headers:
+                try:
+                    self._cookies.load(
+                        native_str(self.headers["Cookie"]))
+                except Exception:
+                    self._cookies = None
+        return self._cookies
 
     def write(self, chunk, callback=None):
         """Writes the given chunk to the response stream."""

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -162,6 +162,10 @@ class TypeCheckHandler(RequestHandler):
         self.check_type('header_key', self.request.headers.keys()[0], str)
         self.check_type('header_value', self.request.headers.values()[0], str)
 
+        self.check_type('cookie_key', self.request.cookies.keys()[0], str)
+        self.check_type('cookie_value', self.request.cookies.values()[0].value, str)
+        # secure cookies
+
         self.check_type('arg_key', self.request.arguments.keys()[0], str)
         self.check_type('arg_value', self.request.arguments.values()[0][0], bytes_type)
 
@@ -190,11 +194,12 @@ class HTTPServerTest(AsyncHTTPTestCase, LogTrapTestCase):
         self.assertEqual(data, {u"foo": [u"\u00e9"]})
 
     def test_types(self):
-        response = self.fetch("/typecheck?foo=bar")
+        headers = {"Cookie": "foo=bar"}
+        response = self.fetch("/typecheck?foo=bar", headers=headers)
         data = json_decode(response.body)
         self.assertEqual(data, {})
 
-        response = self.fetch("/typecheck", method="POST", body="foo=bar")
+        response = self.fetch("/typecheck", method="POST", body="foo=bar", headers=headers)
         data = json_decode(response.body)
         self.assertEqual(data, {})
 

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -239,10 +239,6 @@ class TypeCheckHandler(RequestHandler):
         # type str for non-body data mainly for historical reasons.
         self.check_type('argument', self.get_argument('foo'), unicode)
 
-        self.check_type('cookie_key', self.cookies.keys()[0], str)
-        self.check_type('cookie_value', self.cookies.values()[0].value, str)
-        # secure cookies
-    
         self.check_type('xsrf_token', self.xsrf_token, bytes_type)
         self.check_type('xsrf_form_html', self.xsrf_form_html(), str)
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -316,23 +316,10 @@ class RequestHandler(object):
         """
         return _unicode(value)
 
-    @property
-    def cookies(self):
-        """A dictionary of Cookie.Morsel objects."""
-        if not hasattr(self, "_cookies"):
-            self._cookies = Cookie.SimpleCookie()
-            if "Cookie" in self.request.headers:
-                try:
-                    self._cookies.load(
-                        escape.native_str(self.request.headers["Cookie"]))
-                except Exception:
-                    self.clear_all_cookies()
-        return self._cookies
-
     def get_cookie(self, name, default=None):
         """Gets the value of the cookie with the given name, else default."""
-        if name in self.cookies:
-            return self.cookies[name].value
+        if name in self.request.cookies:
+            return self.request.cookies[name].value
         return default
 
     def set_cookie(self, name, value, domain=None, expires=None, path="/",
@@ -377,7 +364,7 @@ class RequestHandler(object):
 
     def clear_all_cookies(self):
         """Deletes all the cookies the user sent with this request."""
-        for name in self.cookies.iterkeys():
+        for name in self.request.cookies.iterkeys():
             self.clear_cookie(name)
 
     def set_secure_cookie(self, name, value, expires_days=30, **kwargs):


### PR DESCRIPTION
The `cookies` property seems to belong more properly to `HTTPRequest`, since it's derived from the request headers. This also exposes it as a useful API to programs which don't subclass `Application`, relying solely on the `httpserver` module.

Tests are also updated.
