### PR TITLE
Create a global template context in RequestHandler

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -321,9 +321,18 @@ class MultiHeaderHandler(RequestHandler):
         self.add_header("x-multi", 3)
         self.add_header("x-multi", "4")
 
+class SetTemplateContextHandler(RequestHandler):
+    
+    def initialize(self):
+        self.set_template_context("name", "tornado")
+    
+    def get(self):
+        self.render("template_context.html")
+
 class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
     def get_app(self):
         loader = DictLoader({
+                "template_context.html": "{{ name }}",
                 "linkify.html": "{% module linkify(message) %}",
                 "page.html": """\
 <html><head></head><body>
@@ -344,6 +353,7 @@ class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
             url("/optional_path/(.+)?", OptionalPathHandler),
             url("/flow_control", FlowControlHandler),
             url("/multi_header", MultiHeaderHandler),
+            url("/template_context", SetTemplateContextHandler),
             ]
         return Application(urls,
                            template_loader=loader,
@@ -429,6 +439,9 @@ js_embed()
         self.assertEqual(response.headers["x-overwrite"], "2")
         self.assertEqual(response.headers.get_list("x-multi"), ["3", "4"])
 
+    def test_template_context(self):
+        response = self.fetch("/template_context")
+        self.assertEqual(response.body, b("tornado"))
 
 class ErrorResponseTest(AsyncHTTPTestCase, LogTrapTestCase):
     def get_app(self):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -120,6 +120,17 @@ class RequestHandler(object):
         if hasattr(self.request, "connection"):
             self.request.connection.stream.set_close_callback(
                 self.on_connection_close)
+        # Base template context
+        self.template_context = dict(
+            handler=self,
+            request=self.request,
+            current_user=self.current_user,
+            locale=self.locale,
+            _=self.locale.translate,
+            static_url=self.static_url,
+            xsrf_form_html=self.xsrf_form_html,
+            reverse_url=self.application.reverse_url
+        )
         self.initialize(**kwargs)
 
     def initialize(self):
@@ -480,6 +491,10 @@ class RequestHandler(object):
             self.set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = utf8(chunk)
         self._write_buffer.append(chunk)
+    
+    def set_template_context(self, name, value):
+        """Sets the given template context name and value."""
+        self.template_context[name] = value
 
     def render(self, template_name, **kwargs):
         """Renders the template with the given arguments as the response."""
@@ -582,16 +597,7 @@ class RequestHandler(object):
             loader = self.create_template_loader(template_path)
             RequestHandler._templates[template_path] = loader
         t = RequestHandler._templates[template_path].load(template_name)
-        args = dict(
-            handler=self,
-            request=self.request,
-            current_user=self.current_user,
-            locale=self.locale,
-            _=self.locale.translate,
-            static_url=self.static_url,
-            xsrf_form_html=self.xsrf_form_html,
-            reverse_url=self.application.reverse_url
-        )
+        args = self.template_context        
         args.update(self.ui)
         args.update(kwargs)
         return t.generate(**args)


### PR DESCRIPTION
Move the base template args from RequestHandler.render_string() to RequestHandler.template_context. 

RequestHandler.set_template_context for template_context processing.

Useful to set a global context around all requests.
