### PR TITLE
Move cookie signing functionality to httputil module

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1,10 +1,9 @@
 from tornado.escape import json_decode, utf8, to_unicode, recursive_unicode, native_str
-from tornado.httputil import _create_signature
 from tornado.iostream import IOStream
 from tornado.template import DictLoader
 from tornado.testing import LogTrapTestCase, AsyncHTTPTestCase
 from tornado.util import b, bytes_type
-from tornado.web import RequestHandler, _O, authenticated, Application, asynchronous, url, HTTPError, StaticFileHandler
+from tornado.web import RequestHandler, _O, authenticated, Application, asynchronous, url, HTTPError, StaticFileHandler, _create_signature
 
 import binascii
 import logging


### PR DESCRIPTION
Most of the content of `RequestHandler.create_signed_value()` and `RequestHandler.get_secure_cookie()` has been refactored into `httputil.create_signed_value()` and `httputil.decode_signed_value()`, respectively, which both take a `secret` parameter to break the dependency on the `cookie_secret` application setting. The `RequestHandler` methods are now just wrappers around these for backwards-compatibility.

What do you think of the function names? I also considered `sign_value()` and `unsign_value()` - is there a standard term for the latter action?
