### PR TITLE
javascript not being gzipped

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1620,7 +1620,7 @@ class GZipContentEncoding(OutputTransform):
     See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
     """
     CONTENT_TYPES = set([
-        "text/plain", "text/html", "text/css", "text/xml",
+        "text/plain", "text/html", "text/css", "text/xml", "application/javascript", 
         "application/x-javascript", "application/xml", "application/atom+xml",
         "text/javascript", "application/json", "application/xhtml+xml"])
     MIN_LENGTH = 5


### PR DESCRIPTION
javascript was not being gzipped because CONTENT_TYPES of GzipContentEncoding was missing "application/javascript" for some strange reason - this is what mimetypes.guess_type returns in my version of python (2.7.1) on os x and is the recommended mime type for js

still strange behaviour remains - HEAD request does not return content-type gzip (which it probably should), but at least GET requests now gzip javascript.
