### PR TITLE
HTTPResponse request_time not set in simple_httpclient

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -206,6 +206,7 @@ class _HTTPConnection(object):
     def _on_timeout(self):
         self._timeout = None
         self._run_callback(HTTPResponse(self.request, 599,
+                                        request_time=time.time() - self.start_time,
                                         error=HTTPError(599, "Timeout")))
         self.stream.close()
 
@@ -289,11 +290,14 @@ class _HTTPConnection(object):
             yield
         except Exception, e:
             logging.warning("uncaught exception", exc_info=True)
-            self._run_callback(HTTPResponse(self.request, 599, error=e))
+            self._run_callback(HTTPResponse(self.request, 599, error=e, 
+                                request_time=time.time() - self.start_time,
+                                ))
 
     def _on_close(self):
         self._run_callback(HTTPResponse(
                 self.request, 599,
+                request_time=time.time() - self.start_time,
                 error=HTTPError(599, "Connection closed")))
 
     def _on_headers(self, data):
@@ -362,6 +366,7 @@ class _HTTPConnection(object):
             return
         response = HTTPResponse(original_request,
                                 self.code, headers=self.headers,
+                                request_time=time.time() - self.start_time,
                                 buffer=buffer,
                                 effective_url=self.request.url)
         self._run_callback(response)

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -74,6 +74,7 @@ class HTTPClientCommonTestCase(AsyncHTTPTestCase, LogTrapTestCase):
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers["Content-Type"], "text/plain")
         self.assertEqual(response.body, b("Hello world!"))
+        self.assertEqual(int(response.request_time), 0)
 
         response = self.fetch("/hello?name=Ben")
         self.assertEqual(response.body, b("Hello Ben!"))

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -150,11 +150,13 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, LogTrapTestCase):
                                    connect_timeout=0.1)
             response = self.wait()
             self.assertEqual(response.code, 599)
+            self.assertEqual(int(response.request_time * 10), 1)
             self.assertEqual(str(response.error), "HTTP 599: Timeout")
 
     def test_request_timeout(self):
         response = self.fetch('/hang', request_timeout=0.1)
         self.assertEqual(response.code, 599)
+        self.assertEqual(int(response.request_time * 10), 1)
         self.assertEqual(str(response.error), "HTTP 599: Timeout")
 
     def test_ipv6(self):


### PR DESCRIPTION
in 1.2.1 with curl asynchttpclient a variable request_time was set on the HTTPResponse to give information about how long the request took. with v2.0 that variable is no longer set when using simple_httpclient.

where it was set in 1.2.1 for curl asynchttpclient - https://github.com/facebook/tornado/blob/v1.2.1/tornado/httpclient.py#L356

The primary location in simple_httpclient where this needs to be set https://github.com/facebook/tornado/blob/master/tornado/simple_httpclient.py#L337 (although it should be set everywhere a httpresponse object is created)
