### PR TITLE
adding 'cookies' property to wsgi.HTTPRequest

### DIFF
--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -29,6 +29,7 @@ provides WSGI support in two ways:
   and Tornado handlers in a single server.
 """
 
+import Cookie
 import cgi
 import httplib
 import logging
@@ -158,6 +159,19 @@ class HTTPRequest(object):
     def supports_http_1_1(self):
         """Returns True if this request supports HTTP/1.1 semantics"""
         return self.version == "HTTP/1.1"
+
+    @property
+    def cookies(self):
+        """A dictionary of Cookie.Morsel objects."""
+        if not hasattr(self, "_cookies"):
+            self._cookies = Cookie.SimpleCookie()
+            if "Cookie" in self.headers:
+                try:
+                    self._cookies.load(
+                        native_str(self.headers["Cookie"]))
+                except Exception:
+                    self._cookies = None
+        return self._cookies
 
     def full_url(self):
         """Reconstructs the full URL for this request."""


### PR DESCRIPTION
Moving 'cookies' property from RequestHandler in web.py to HTTPRequest in httpserver.py in commit 4a4d87173b07fc5415e2 (20110817) broke cookies in WSGI applications (including App Engine).  I simply copied the relevant code to wsgi.py - don't know if anyone wants to DRY this up or add tests before merging.
