### PR TITLE
Log "stacktrace" of templace source lines when an exception is raised for more convenient debugging

### DIFF
--- a/tornado/test/template_test.py
+++ b/tornado/test/template_test.py
@@ -1,11 +1,12 @@
-import logging
-
 from tornado.escape import utf8, native_str
 from tornado.template import Template, DictLoader, ParseError
-from tornado.testing import LogHandler, LogTestCase, LogTrapTestCase
-from tornado.util import b, bytes_type, ObjectDict
+from tornado.testing import LogCaptureTestCase, LogTrapTestCase
+from tornado.util import b, bytes_type, ObjectDict, LogCaptureHandler
 
-class TemplateTest(LogTrapTestCase, LogTestCase):
+def _error_log(loader, name, line_number):
+    return (name, line_number, loader.templates[name].template_string.split('\n')[line_number-1])
+
+class TemplateTest(LogTrapTestCase, LogCaptureTestCase):
     def test_simple(self):
         template = Template("Hello {{ name }}!")
         self.assertEqual(template.generate(name="Ben"),
@@ -100,65 +101,67 @@ class TemplateTest(LogTrapTestCase, LogTestCase):
 two{{1/0}}
 three
         """})
-        with LogHandler() as handler:
+        with LogCaptureHandler() as handler:
             try:
                 loader.load("test.html").generate()
             except ZeroDivisionError:
                 pass
-            self.assertInLog(handler, lambda record: self.assertEqual(record.args[1:], ("test.html", 2, "two{{1/0}}")))
+            self.assertInLog(handler, lambda record: self.assertEqual(record.args[2:], _error_log(loader, "test.html", 2)))
 
     def test_error_line_number_directive(self):
         loader = DictLoader({"test.html": """one
 two{%if 1/0%}
 three{%end%}
         """})
-        with LogHandler() as handler:
+        with LogCaptureHandler() as handler:
             try:
                 loader.load("test.html").generate()
             except ZeroDivisionError:
                 pass
-            self.assertInLog(handler, lambda record: self.assertEqual(record.args[1:], ("test.html", 2, "two{%if 1/0%}")))
+            self.assertInLog(handler, lambda record: self.assertEqual(record.args[2:], _error_log(loader, "test.html", 2)))
 
     def test_error_line_number_module(self):
         loader = DictLoader({
             "base.html": "{% module Template('sub.html') %}",
             "sub.html": "{{1/0}}",
         }, namespace={"_modules": ObjectDict({"Template": lambda path, **kwargs: loader.load(path).generate(**kwargs)})})
-        with LogHandler() as handler:
+        with LogCaptureHandler() as handler:
             try:
                 loader.load("base.html").generate()
             except ZeroDivisionError:
                 pass
-            self.assertInLog(handler, lambda record: self.assertEqual(record.args[1:],
-                                ("base.html", 1, "{% module Template('sub.html') %}",
-                                 "sub.html", 1, "{{1/0}}")))
+            self.assertInLog(handler, lambda record: self.assertEqual(record.args[0], "base.html") and
+                                self.assertEqual(record.args[2], "sub.html") and
+                                self.assertEqual(record.args[4:],
+                                    _error_log(loader, "base.html", 1) +
+                                    _error_log(loader, "sub.html", 1)))
 
     def test_error_line_number_include(self):
         loader = DictLoader({
             "base.html": "{% include 'sub.html' %}",
             "sub.html": "{{1/0}}",
         })
-        with LogHandler() as handler:
+        with LogCaptureHandler() as handler:
             try:
                 loader.load("base.html").generate()
             except ZeroDivisionError:
                 pass
-            self.assertInLog(handler, lambda record: self.assertEqual(record.args[1:],
-                                ("base.html", 1, "{% include 'sub.html' %}",
-                                 "sub.html", 1, "{{1/0}}")))
+            self.assertInLog(handler, lambda record: self.assertEqual(record.args[2:],
+                                _error_log(loader, "base.html", 1) +
+                                _error_log(loader, "sub.html", 1)))
 
     def test_error_line_number_extends_base_error(self):
         loader = DictLoader({
             "base.html": "{{1/0}}",
             "sub.html": "{% extends 'base.html' %}",
         })
-        with LogHandler() as handler:
+        with LogCaptureHandler() as handler:
             try:
                 loader.load("sub.html").generate()
             except ZeroDivisionError:
                 pass
-            self.assertInLog(handler, lambda record: self.assertEqual(record.args[1:],
-                                ("base.html", 1, "{{1/0}}")))
+            self.assertInLog(handler, lambda record: self.assertEqual(record.args[2:],
+                                _error_log(loader, "base.html", 1)))
 
     def test_error_line_number_extends_sub_error(self):
         loader = DictLoader({
@@ -169,14 +172,14 @@ three{%end%}
 {{1/0}}
 {% end %}
             """})
-        with LogHandler() as handler:
+        with LogCaptureHandler() as handler:
             try:
                 loader.load("sub.html").generate()
             except ZeroDivisionError:
                 pass
-            self.assertInLog(handler, lambda record: self.assertEqual(record.args[1:],
-                                ("base.html", 1, "{% block 'block' %}{% end %}",
-                                 "sub.html", 4, "{{1/0}}")))
+            self.assertInLog(handler, lambda record: self.assertEqual(record.args[2:],
+                                _error_log(loader, "base.html", 1) +
+                                _error_log(loader, "sub.html", 4)))
 
 
 class AutoEscapeTest(LogTrapTestCase):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -21,12 +21,10 @@ information.
 from __future__ import with_statement
 
 from cStringIO import StringIO
-from logging.handlers import MemoryHandler
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpserver import HTTPServer
 from tornado.stack_context import StackContext, NullContext
 import contextlib
-import json
 import logging
 import sys
 import time
@@ -297,7 +295,7 @@ class LogTrapTestCase(unittest.TestCase):
             handler.stream = old_stream
 
 
-class LogTestCase(unittest.TestCase):
+class LogCaptureTestCase(unittest.TestCase):
     def assertInLog(self, handler, asserts):
         for record in handler.buffer:
             try:
@@ -316,23 +314,6 @@ class LogTestCase(unittest.TestCase):
                 pass
             else:
                 self.fail("No matching record found in log: %s" % handler.prettyPrintBuffer())
-
-
-class LogHandler(MemoryHandler):
-    def __init__(self):
-        MemoryHandler.__init__(self, capacity=0, flushLevel=100)
-        self.logger = logging.getLogger()
-
-    def __enter__(self):
-        self.logger.addHandler(self)
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.logger.removeHandler(self)
-        self.close()
-
-    def prettyPrintBuffer(self):
-        return json.dumps([record.__dict__ for record in self.buffer], sort_keys=True, indent=4)
 
 
 def main():

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -1,5 +1,9 @@
 """Miscellaneous utility functions."""
 
+from logging.handlers import MemoryHandler
+import json
+import logging
+
 class ObjectDict(dict):
     """Makes a dictionary behave like an object."""
     def __getattr__(self, name):
@@ -10,6 +14,23 @@ class ObjectDict(dict):
 
     def __setattr__(self, name, value):
         self[name] = value
+
+
+class LogCaptureHandler(MemoryHandler):
+    def __init__(self):
+        MemoryHandler.__init__(self, capacity=0, flushLevel=100)
+        self.logger = logging.getLogger()
+
+    def __enter__(self):
+        self.logger.addHandler(self)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.logger.removeHandler(self)
+        self.close()
+
+    def prettyPrintBuffer(self):
+        return json.dumps([record.__dict__ for record in self.buffer], sort_keys=True, indent=4)
 
 
 def import_object(name):


### PR DESCRIPTION
Currently, when an exception is raised in a template, the generated Python code is printed to the log, which the line number in the stacktrace entry can be cross-referenced with. This is quite tedious, especially when multiple templates are included within each other, since there is no indication of which of the template files the exception originated in.

This patch logs a "stacktrace" through the template source files for the exception, where each entry displays the template filename, line number, and line text. For example:

``` python
loader = DictLoader({
    "base.html": "{% include 'sub.html' %}",
    "sub.html": "foo\n{{1/0}}",
})
loader.load("base.html").generate()
```

Output:

```
ERROR:root:
 1  def _execute():
 2      _buffer = []
 3      _append = _buffer.append
 4      _append('foo\n')
 5      _tmp = 1/0
 6      if isinstance(_tmp, _string_types): _tmp = _utf8(_tmp)
 7      else: _tmp = _utf8(str(_tmp))
 8      _tmp = _utf8(xhtml_escape(_tmp))
 9      _append(_tmp)
10      return _utf8('').join(_buffer)

base.html:1:{% include 'sub.html' %}
sub.html:2:{{1/0}}

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "tornado/template.py", line 240, in generate
    return execute()
  File "<template base.html>", line 5, in _execute
ZeroDivisionError: integer division or modulo by zero
```

Note the two middle lines beginning with "base.html" and "sub.html", respectively (information is delimited by a colon).  This works not only with `{% include %}` directives, but also `{% module %}` and `{% extends %}` (test cases included).  Both `{{...}}` and `{%...%}` (e.g. `{% if 1/0 %}`) constructs are traced correctly.  A stacktrace is printed even if the exception occurred in a function called by a template, e.g., UI modules.
