### PR TITLE
Use real httpserver.HTTPRequest in WSGI apps instead of mock

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -30,6 +30,7 @@ import Cookie
 import logging
 import socket
 import time
+import urlparse
 
 from tornado.escape import native_str, parse_qs_bytes
 from tornado import httputil
@@ -245,8 +246,10 @@ class HTTPConnection(object):
                 # Unix (or other) socket; fake the remote address
                 remote_ip = '0.0.0.0'
 
+            path, sep, query = uri.partition('?')
             self._request = HTTPRequest(
-                connection=self, method=method, uri=uri, version=version,
+                connection=self, method=method, path=path, query=query,
+                arguments=httputil.parse_query(query), version=version,
                 headers=headers, remote_ip=remote_ip)
 
             content_length = headers.get("Content-Length")
@@ -345,13 +348,19 @@ class HTTPRequest(object):
        An HTTP request is attached to a single HTTP connection, which can
        be accessed through the "connection" attribute. Since connections
        are typically kept open in HTTP/1.1, multiple requests can be handled
-       sequentially on a single connection.
+       sequentially on a single connection. This attribute is set to ``None``
+       in WSGI applications, which do not support asynchronous requests.
     """
-    def __init__(self, method, uri, version="HTTP/1.0", headers=None,
-                 body=None, remote_ip=None, protocol=None, host=None,
-                 files=None, connection=None):
+    def __init__(self, method, path, query="", arguments=None, version="HTTP/1.0",
+                 headers=None, body="", remote_ip=None, protocol=None,
+                 host=None, files=None, connection=None):
         self.method = method
-        self.uri = uri
+        self.uri = path
+        if query:
+            self.uri += '?' + query
+        self.path = path
+        self.query = query
+        self.arguments = arguments or {}
         self.version = version
         self.headers = headers or httputil.HTTPHeaders()
         self.body = body or ""
@@ -378,16 +387,10 @@ class HTTPRequest(object):
         self.host = host or self.headers.get("Host") or "127.0.0.1"
         self.files = files or {}
         self.connection = connection
+
         self._start_time = time.time()
         self._finish_time = None
-
-        self.path, sep, self.query = uri.partition('?')
-        arguments = parse_qs_bytes(self.query)
-        self.arguments = {}
-        for name, values in arguments.iteritems():
-            values = [v for v in values if v]
-            if values:
-                self.arguments[name] = values
+        self._cookies = None
 
     def supports_http_1_1(self):
         """Returns True if this request supports HTTP/1.1 semantics"""
@@ -396,7 +399,7 @@ class HTTPRequest(object):
     @property
     def cookies(self):
         """A dictionary of Cookie.Morsel objects."""
-        if not hasattr(self, "_cookies"):
+        if self._cookies is None:
             self._cookies = Cookie.SimpleCookie()
             if "Cookie" in self.headers:
                 try:

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -224,6 +224,14 @@ def parse_body_arguments(content_type, body, arguments, files):
             logging.warning("Invalid multipart/form-data")
 
 
+def parse_query(query):
+    arguments = {}
+    for name, values in parse_qs_bytes(query).iteritems():
+        values = [v for v in values if v]
+        if values: arguments[name] = values
+    return arguments
+
+
 def parse_multipart_form_data(boundary, data, arguments, files):
     """Parses a multipart/form-data body.
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -123,7 +123,7 @@ class RequestHandler(object):
         self.ui["modules"] = self.ui["_modules"]
         self.clear()
         # Check since connection is not available in WSGI
-        if getattr(self.request, "connection", None):
+        if self.request.connection is not None:
             self.request.connection.stream.set_close_callback(
                 self.on_connection_close)
         self.initialize(**kwargs)
@@ -689,7 +689,7 @@ class RequestHandler(object):
                 content_length = sum(len(part) for part in self._write_buffer)
                 self.set_header("Content-Length", content_length)
 
-        if hasattr(self.request, "connection"):
+        if self.request.connection is not None:
             # Now that the request is finished, clear the callback we
             # set on the IOStream (which would otherwise prevent the
             # garbage collection of the RequestHandler when there


### PR DESCRIPTION
A large amount of parsing code that the two classes had in common (duplicated, generally in constructors) has been refactored into utility functions so that only minimal logic is implemented. Also, some attributes that were previously set based on multiple conditions in constructors have become properties.
