### PR TITLE
Add {# ... #} construct to comment out entire sections

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -92,6 +92,9 @@ to the current autoescape setting and inserted into the output.  Other
 template directives use ``{% %}``.  These tags may be escaped as ``{{!``
 and ``{%!`` if you need to include a literal ``{{`` or ``{%`` in the output.
 
+To comment out a section so that it is omitted from the output, surround it
+with ``{# ... #}``.
+
 ``{% apply *function* %}...{% end %}``
     Applies a function to the output of all template code between ``apply``
     and ``end``::
@@ -637,7 +640,7 @@ def _parse(reader, template, in_block=None):
                 return body
             # If the first curly brace is not the start of a special token,
             # start searching from the character after it
-            if reader[curly + 1] not in ("{", "%"):
+            if reader[curly + 1] not in ("{", "%", "#"):
                 curly += 1
                 continue
             # When there are more than 2 curlies in a row, use the
@@ -663,6 +666,15 @@ def _parse(reader, template, in_block=None):
         if reader.remaining() and reader[0] == "!":
             reader.consume(1)
             body.chunks.append(_Text(start_brace))
+            continue
+
+        # Comment
+        if start_brace == "{#":
+            end = reader.find("#}")
+            if end == -1:
+                raise ParseError("Missing end expression #} on line %d" % line)
+            contents = reader.consume(end).strip()
+            reader.consume(2)
             continue
 
         # Expression

--- a/tornado/test/template_test.py
+++ b/tornado/test/template_test.py
@@ -18,6 +18,11 @@ class TemplateTest(LogTrapTestCase):
         template = Template("2 + 2 = {{ 2 + 2 }}")
         self.assertEqual(template.generate(), b("2 + 2 = 4"))
 
+    def test_comment(self):
+        template = Template("Hello{# TODO i18n #} {{ name }}!")
+        self.assertEqual(template.generate(name=utf8("Ben")),
+                         b("Hello Ben!"))
+
     def test_include(self):
         loader = DictLoader({
                 "index.html": '{% include "header.html" %}\nbody text',
@@ -89,7 +94,7 @@ class TemplateTest(LogTrapTestCase):
         self.assertEqual(template.generate(x=5), b("yes"))
         self.assertEqual(template.generate(x=3), b("no"))
 
-    def test_comment(self):
+    def test_comment_directive(self):
         template = Template(utf8("{% comment blah blah %}foo"))
         self.assertEqual(template.generate(), b("foo"))
 


### PR DESCRIPTION
The current `{% comment "..." %}` directive is unwieldy, and must be repeated for every line to be commented out.
