### PR TITLE
Make HTTPHeaders.__contains__() case-insensitive, like the rest of the object

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -132,6 +132,10 @@ class HTTPHeaders(dict):
         dict.__delitem__(self, norm_name)
         del self._as_list[norm_name]
 
+    def __contains__(self, name):
+        norm_name = HTTPHeaders._normalize_name(name)
+        return dict.__contains__(self, norm_name)
+
     def get(self, name, default=None):
         return dict.get(self, HTTPHeaders._normalize_name(name), default)
 


### PR DESCRIPTION
I have a situation like the following:

```
def _proper_headers_exist(request):
    keys = (
        'X-H1',
        'X-H2'
    )

    for key in keys:
        if key not in request.headers:
            raise HTTPError(500, 'An error occured.')
```

I cannot guarantee that clients will have the proper case for their headers.
So I made the HTTPHeaders class case-insensitive for the 'in' test.
