### PR TITLE
unified null HTTPRequest body as "" 

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -676,7 +676,7 @@ def _format_code(code):
     return "".join([format % (i + 1, line) for (i, line) in enumerate(lines)])
 
 
-def _parse(reader, template, in_block=None):
+def _parse(reader, template, in_block=None, in_loop=None):
     body = _ChunkList([])
     while True:
         # Find next template directive
@@ -815,7 +815,11 @@ def _parse(reader, template, in_block=None):
 
         elif operator in ("apply", "block", "try", "if", "for", "while"):
             # parse inner body recursively
-            block_body = _parse(reader, template, operator)
+            if operator in ("for", "while"):
+                block_body = _parse(reader, template, operator, operator)
+            else:
+                block_body = _parse(reader, template, operator, in_loop)
+
             if operator == "apply":
                 if not suffix:
                     raise ParseError("apply missing method name on line %d" % line)
@@ -827,6 +831,12 @@ def _parse(reader, template, in_block=None):
             else:
                 block = _ControlBlock(contents, line, block_body)
             body.chunks.append(block)
+            continue
+
+        elif operator in ("break", "continue"):
+            if not in_loop:
+                raise ParseError("%s outside %s block" % (operator, set(["for", "while"])))
+            body.chunks.append(_Statement(contents, line))
             continue
 
         else:


### PR DESCRIPTION
The way to handle null request.boy is different in httpclient.HTTPRequest and httpserver.HTTPRequest.
None or "" body will be convert to "" in httpserver.HTTPRequest, but not in httpclient.HTTPRequest.

So below code will raise an assert exception, it only work when body is changed to None, I think "" also should be treat as a null request body.

```
   SimpleAsyncHTTPClient().fetch(
            HTTPRequest(url=url,
                        method="GET",
                        body="",
                        headers=headers,
                        follow_redirects=False),
            callback)
```
