### PR TITLE
handle 303 redirects correctly

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -361,7 +361,8 @@ class _HTTPConnection(object):
             if self.code == 303:
                 new_request.method = "GET"
                 new_request.body = None
-                for h in ["Content-Length", "Content-Type"]:
+                for h in ["Content-Length", "Content-Type", 
+                    "Content-Encoding", "Transfer-Encoding"]:
                     try:
                         del self.request.headers[h]
                     except KeyError:

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -44,12 +44,12 @@ class ContentLengthHandler(RequestHandler):
         self.set_header("Content-Length", self.get_argument("value"))
         self.write("ok")
 
-class PRGPostHandler(RequestHandler):
+class SeeOther303PostHandler(RequestHandler):
     def post(self):
-        self.set_header("Location", "/prg_get")
+        self.set_header("Location", "/303_get")
         self.set_status(303)
 
-class PRGGetHandler(RequestHandler):    
+class SeeOther303GetHandler(RequestHandler):    
     def get(self):
         self.write("ok")
         
@@ -66,8 +66,8 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, LogTrapTestCase):
             url("/hang", HangHandler),
             url("/hello", HelloWorldHandler),
             url("/content_length", ContentLengthHandler),
-            url("/prg_post", PRGPostHandler),
-            url("/prg_get", PRGGetHandler),
+            url("/303_post", SeeOther303PostHandler),
+            url("/303_get", SeeOther303GetHandler),
             ], gzip=True)
 
     def test_singleton(self):
@@ -147,10 +147,10 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, LogTrapTestCase):
         self.assertTrue(response.headers["Location"].endswith("/countdown/1"))
 
     def test_303_redirect(self):
-       response = self.fetch("/prg_post", method="POST", body="")
+       response = self.fetch("/303_post", method="POST", body="")
        self.assertEqual(200, response.code)
-       self.assertTrue(response.request.url.endswith("/prg_post"))
-       self.assertTrue(response.effective_url.endswith("/prg_get"))
+       self.assertTrue(response.request.url.endswith("/303_post"))
+       self.assertTrue(response.effective_url.endswith("/303_get"))
        #request is the original request, is a POST still
        self.assertEqual("POST", response.request.method)
         


### PR DESCRIPTION
I was using the tornado http client to test a site build with tornado that did Post-Redirect-Get for resource. To ge the client to switch from a POST to a GET for the redirect I used a 303 redirect, but the client made another POST. 

see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4

In response to a 303 the client SHOULD make a GET to the Location,
was using the original method.
