### PR TITLE
close websocket even if connection is broken

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -502,7 +502,7 @@ class WebSocketProtocol8(WebSocketProtocol):
         if self.client_terminated and self._waiting:
             tornado.ioloop.IOLoop.instance().remove_timeout(self._waiting)
             self.stream.close()
-        else if not self._started_closing_handshake:
+        elif not self._started_closing_handshake:
             self._started_closing_handshake = True
             self._waiting = tornado.ioloop.IOLoop.instance().add_timeout(time.time() + 5, self._abort)
             self._write_frame(True, 0x8, b(""))


### PR DESCRIPTION
if iostream is already closed, websocket will never close properly since currently close will always attempt to write websocket close frame marker

example:
https://gist.github.com/1318510
