### PR TITLE
Add Content-Length and Etag headers on HEAD requests for StaticFileHandler

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1485,6 +1485,10 @@ class StaticFileHandler(RequestHandler):
 
         if not include_body:
             self.set_header("Content-Length", os.path.getsize(abspath))
+            with open(abspath, "rb") as file:
+                hasher = hashlib.sha1()
+                hasher.update(file.read())
+                self.set_header("Etag", '"%s"' % hasher.hexdigest())
             return
         file = open(abspath, "rb")
         try:


### PR DESCRIPTION
Normally Tornado would autocompute the Content-Length header based on the length of the message body. But in case of a HEAD request the message body is empty, thus the Content-Length header would have a value of zero. This is incorrect, since the headers in a HEAD request should be exactly the same as in the equivalent GET request. This small patch fixes the bug.

Edit: I did the same also for the Etag header, just copying the code from the compute_etag() method of RequestHandler.
