### PR TITLE
Prevent duplicate callbacks when PeriodicCallback is stopped and restarted before _next_timeout

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -455,6 +455,7 @@ class PeriodicCallback(object):
         self.callback_time = callback_time
         self.io_loop = io_loop or IOLoop.instance()
         self._running = False
+        self._timeout = None
 
     def start(self):
         """Starts the timer."""
@@ -465,6 +466,9 @@ class PeriodicCallback(object):
     def stop(self):
         """Stops the timer."""
         self._running = False
+        if self._timeout is not None:
+            self.io_loop.remove_timeout(self._timeout)
+            self._timeout = None
 
     def _run(self):
         if not self._running: return
@@ -479,7 +483,7 @@ class PeriodicCallback(object):
             current_time = time.time()
             while self._next_timeout <= current_time:
                 self._next_timeout += self.callback_time / 1000.0
-            self.io_loop.add_timeout(self._next_timeout, self._run)
+            self._timeout = self.io_loop.add_timeout(self._next_timeout, self._run)
 
 
 class _EPoll(object):


### PR DESCRIPTION
Since start() sets _running to True and always adds a new Timeout to the ioloop, any old Timeouts that are waiting for their deadline to occur have effectively been reactivated (when they execute, _running is now True).  Both the old and the new Timeouts will schedule successive Timeouts during their callback, so the duplication will continue until the PeriodicCallback is stopped for long enough.

By holding onto the Timeout, it can be actively removed from the ioloop when stop() is called. 

Simple repro:

```
import time
from tornado import ioloop

def print_time():
    print int(time.time())

periodic = ioloop.PeriodicCallback(print_time, 5000)
periodic.start()
periodic.stop()
periodic.start()

ioloop.IOLoop.instance().start()
```
