### PR TITLE
Invalid Cookie header crashes get_cookie

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -68,7 +68,7 @@ class CookieTest(AsyncHTTPTestCase, LogTrapTestCase):
 
         class GetCookieHandler(RequestHandler):
             def get(self):
-                self.write(self.get_cookie("foo"))
+                self.write(self.get_cookie("foo", "default"))
 
         class SetCookieDomainHandler(RequestHandler):
             def get(self):
@@ -104,6 +104,9 @@ class CookieTest(AsyncHTTPTestCase, LogTrapTestCase):
 
         response = self.fetch("/get", headers={"Cookie": 'foo="bar"'})
         self.assertEqual(response.body, b("bar"))
+
+        response = self.fetch("/get", headers={"Cookie": "/=exception;"})
+        self.assertEqual(response.body, b("default"))
 
     def test_set_cookie_domain(self):
         response = self.fetch("/set_domain")

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -322,7 +322,7 @@ class RequestHandler(object):
 
     def get_cookie(self, name, default=None):
         """Gets the value of the cookie with the given name, else default."""
-        if name in self.request.cookies:
+        if self.request.cookies is not None and name in self.request.cookies:
             return self.request.cookies[name].value
         return default
 


### PR DESCRIPTION
A broken Cookie header, say "Cookie: /=exception;", causes self.request.cookies to be None. get_cookie() just tests this with 'in' right now, which causes a crash when self.request.cookies is None. The fix is just checking for the None case first in get_cookie().
