### PR TITLE
minor ioloop changes

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -172,7 +172,7 @@ class IOLoop(object):
                 try:
                     os.close(fd)
                 except Exception:
-                    logging.debug("error closing fd %d", fd, exc_info=True)
+                    logging.debug("error closing fd %s", fd, exc_info=True)
         self._waker.close()
         self._impl.close()
 
@@ -312,10 +312,10 @@ class IOLoop(object):
                         # Happens when the client closes the connection
                         pass
                     else:
-                        logging.error("Exception in I/O handler for fd %d",
+                        logging.error("Exception in I/O handler for fd %s",
                                       fd, exc_info=True)
                 except Exception:
-                    logging.error("Exception in I/O handler for fd %d",
+                    logging.error("Exception in I/O handler for fd %s",
                                   fd, exc_info=True)
         # reset the stopped flag so another start/stop pair can be issued
         self._stopped = False


### PR DESCRIPTION
Two small changes:
1. a typo, where a variable was called 'milliseconds', but the value it holds is in seconds (insignificant, but confused me more than I would like to admit).
2. use '%s' instead of '%d' when formatting log messages.

This second one is relevant to me, as maintainer of pyzmq, because there our poll implementation accepts ZMQ sockets instead of file descriptors, so formatting the log messages will fail.  This is the only remaining impediment to using the tornado ioloop itself with our poller, rather than monkeypatching IOLoop when trying to integrate zmq sockets with an existing tornado app.
