### PR TITLE
Netutil base protocol implementation

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -228,7 +228,7 @@ class TCPServer(object):
 class BaseProtocol(object):
     """Base class for implementing handlers for TCP connections.
     
-    Example of how to use ``BaseProtocol`` for impelementing simple 
+    Example of how to use ``BaseProtocol`` to implement a simple 
     Echo server (just return to client each received line):
     
         class EchoProtocol(BaseProtocol):


### PR DESCRIPTION
If we will use `netutil.TCPServer` for implementing some functionality, we will have to use inheritance and write duplicated code more and more times... (example of such application you can find here https://gist.github.com/1387470). 

The keynote here that there are many situation when we don't want to create server class (inherited from `netutil.TCPServer`), we just want to use custom handler as wrapper for  incoming `IOStream`. We can easily avoid this problem, code example in docstring to `BaseProtocol`. Duplicate this example here:

```
class EchoProtocol(BaseProtocol):
    def _on_connect(self):
        self._wait()

    def _wait(self):
        self.stream.read_unit(b('\n'), self._on_read)

    def _on_read(self, line):
        self.stream.write(line, callback=self._wait)

server = TCPServer(protocol=EchoProtocol)
server.listen(8888)
IOLoop.instance().start() 
```

It also possible to implement this approach for `httpserver.HTTPConnection` (request_callback, no_keep_alive and xheaders can be read from server param). But I don't know if it will bring many benefits (only one - standard approach).
