### PR TITLE
Additional sanity checks for websockets transport handshake

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -390,7 +390,7 @@ class WebSocketProtocol8(WebSocketProtocol):
         raised
         """
         fields = ("Host", "Sec-Websocket-Key", "Sec-Websocket-Version")
-        if (not all(map(lambda f: self.request.headers.get(f), fields))):
+        if not all(map(lambda f: self.request.headers.get(f), fields)):
             raise ValueError("Missing/Invalid WebSocket headers")
 
     def _challenge_response(self):


### PR DESCRIPTION
Following is true for all version of the websockets:
2. The Method of the request MUST be GET and the HTTP version MUST
be at least 1.1.
5. The request MUST contain an "Upgrade" header field whose value
is equal to "websocket".
6. The request MUST contain a "Connection" header field whose value
MUST include the "Upgrade" token.

Previous implementation was closing connection if some of the headers were invalid instead of sending proper response code, which caused troubles for older browsers as they did not get any response and didn't know how to react.
