### PR TITLE
Set-Cookie problem for mac safari

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -38,7 +38,7 @@ class HTTPHeaders(dict):
     >>> h.add("Set-Cookie", "A=B")
     >>> h.add("Set-Cookie", "C=D")
     >>> h["set-cookie"]
-    'A=B,C=D'
+    'A=B, C=D'
     >>> h.get_list("set-cookie")
     ['A=B', 'C=D']
 
@@ -65,7 +65,7 @@ class HTTPHeaders(dict):
         self._last_key = norm_name
         if norm_name in self:
             # bypass our override of __setitem__ since it modifies _as_list
-            dict.__setitem__(self, norm_name, self[norm_name] + ',' + value)
+            dict.__setitem__(self, norm_name, self[norm_name] + ', ' + value)
             self._as_list[norm_name].append(value)
         else:
             self[norm_name] = value


### PR DESCRIPTION
I found a bug when I trying to write a proxy using tornado

When fetch the page, the headers["Set-Cookie"] returns data like:
A=B,C=D

when I using it in self.set_header("Set-Cookie", "..."), mac safari will reject it.
So cookie is not set to the browser.

I made a little change, Set-Cookie should looks like:
A=B, C=D

So all the browser will accept it.
