### PR TITLE
Option name can't be dashed

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -155,6 +155,8 @@ def parse_config_file(path):
     for name in config:
         if name in options:
             options[name].set(config[name])
+        elif name.replace('_', '-') in options:
+            options[name.replace('_', '-')].set(config[name])
 
 
 def print_help(file=sys.stdout):

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -126,7 +126,6 @@ def parse_command_line(args=None):
             break
         arg = args[i].lstrip("-")
         name, equals, value = arg.partition("=")
-        name = name.replace('-', '_')
         if not name in options:
             print_help()
             raise Error('Unrecognized command line option: %r' % name)
@@ -187,6 +186,8 @@ class _Options(dict):
         return cls._instance
 
     def __getattr__(self, name):
+        if '_' in name and name.replace('_', '-') in self:
+            name = name.replace('_', '-')
         if isinstance(self.get(name), _Option):
             return self[name].value()
         raise AttributeError("Unrecognized option %r" % name)


### PR DESCRIPTION
>>> from tornado.options import options, define, parse_command_line
>>> define("mysql-host", default="127.0.0.1")
>>> parse_command_line("progname --mysql-host=localhost".split())
Usage:  [OPTIONS]

Options:
  --help                           show this help information
  --log_file_max_size              max size of log files before rollover
  --log_file_num_backups           number of log files to keep
  --log_file_prefix=PATH           Path prefix for log files. Note that if you are running multiple tornado processes, log_file_prefix must be different for each of them (e.g. include the port number)
  --log_to_stderr                  Send log output to stderr (colorized if possible). By default use stderr if --log_file_prefix is not set and no other logging is configured.
  --logging=info|warning|error|none Set the Python log level. If 'none', tornado won't touch the logging configuration.
<stdin>
  --mysql-host                     

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/tornado/options.py", line 125, in parse_command_line
    raise Error('Unrecognized command line option: %r' % name)
tornado.options.Error: Unrecognized command line option: 'mysql_host'

With patch:

>>> from tornado.options import options, define, parse_command_line
>>> define("mysql-host", default="127.0.0.1")
>>> parse_command_line("progname --mysql-host=localhost".split())
[]
>>> options.mysql_host
u'localhost'
>>> options['mysql-host'].value()
u'localhost'