### PR TITLE
xheaders xss - Fix for bug #392

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -322,7 +322,7 @@ class HTTPRequest(object):
     .. attribute:: protocol
 
        The protocol used, either "http" or "https".  If `HTTPServer.xheaders`
-       is seet, will pass along the protocol used by a load balancer if
+       is set, will pass along the protocol used by a load balancer if
        reported via an ``X-Scheme`` header.
 
     .. attribute:: host


### PR DESCRIPTION
I just wrote a simple validation function that uses the  `socket.inet_pton()` function. Since that module was already imported, it seemed the best way to solve while not adding much overhead.
