### PR TITLE
make locale more easy to use

### DIFF
--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -470,3 +470,7 @@ LOCALE_NAMES = {
     "zh_CN": {"name_en": u"Chinese (Simplified)", "name": u"\u4e2d\u6587(\u7b80\u4f53)"},
     "zh_TW": {"name_en": u"Chinese (Traditional)", "name": u"\u4e2d\u6587(\u7e41\u9ad4)"},
 }
+
+locale = get(_default_locale)
+def _(message):
+    return locale.translate(message)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -739,6 +739,7 @@ class RequestHandler(object):
             if not self._locale:
                 self._locale = self.get_browser_locale()
                 assert self._locale
+        locale.locale = self._locale
         return self._locale
 
     def get_user_locale(self):


### PR DESCRIPTION
before this pull request, every translate must be in a handler. but now you can write like this:

```
from tornado.locale import _

_("hello")
```

@bdarnell  I can't figure out a good name.
