### PR TITLE
bump version number to reflect next release

### DIFF
--- a/tornado/__init__.py
+++ b/tornado/__init__.py
@@ -17,4 +17,4 @@
 """The Tornado web server and tools."""
 
 version = "2.1.1git"
-version_info = (2, 1, 1)
+version_info = (2, 1, 1, 'git')


### PR DESCRIPTION
Current tornado version_info still reports `(2,1,1)`.  I think it is customary to bump the dev version to the next release, so that it is identifiable as newer than the released code.

If you do want to continue with the current pattern ('2.1.1git' means code _after_ 2.1.1), then I suppose the check for "code at or older than 2.1.1" would be:

```
tornado.version_info <= (2,1,1) and tornado.__version__ != "2.1.1git"
```

The reason this is relevant to me is we need exactly this quantity in IPython, because we ship the tiny websocket 426 bugfix (#385), so that we can still work with released tornado.

Of course, do reject if this is your style of choice, but I would like confirmation that the above code is 'the right way' to check for tornado versions before changing the checks in our code, in case it was a simple oversight.
