### PR TITLE
Update tornado.gen to handle the case of single arg, kwargs for return value (asyncmongo)

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -346,7 +346,9 @@ class Runner(object):
 
     def result_callback(self, key):
         def inner(*args, **kwargs):
-            if kwargs or len(args) > 1:
+            if kwargs and len(args) == 1:
+                result = (args[0], kwargs)
+            elif kwargs or len(args) > 1:
                 result = Arguments(args, kwargs)
             elif args:
                 result = args[0]


### PR DESCRIPTION
I saw the changes made for issue #351 which is now closed. This is another update for the same use case, asyncmongo. Basically what you're getting returned from asyncmongo requests using gen is

((response,), {"error": val}) or an Arguments object where .args is (response,).

What this change does is for cases like asyncmongo you will get 

(response, {"error": val})

So you can do

(response, error) = yield tornado.gen.Task(db.collection.find, {"key": val})

then you can work with the response object directly.

Exact use case is for www.chatfor.us I was having to do something like

(response, error) = yield.tornado.gen.Task(db.chats.find_one, {"_id", bson.ObjectId(id)})
self.chat = response[0]

With this change I can do
(self.chat, error) = yield.tornado.gen.Task(db.chats.find_one, {"_id", bson.ObjectId(id)})

I chose to return a tuple rather than Arguments object because I believe the expectation for the Arguments object is that .args should always be a tuple.
