### PR TITLE
Send Basic Auth Through Curl When Password is Empty

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -386,7 +386,7 @@ def _curl_setup_request(curl, request, buffer, headers):
     if request.auth_username is not None:
         userpwd = "%s:%s" % (request.auth_username, request.auth_password or '')
         curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_BASIC)
-        curl.setopt(pycurl.USERPWD, userpwd.encode('ascii'))
+        curl.setopt(pycurl.USERPWD, utf8(userpwd))
         logging.debug("%s %s (username: %r)", request.method, request.url,
                       request.auth_username)
     else:


### PR DESCRIPTION
Related to #441. This causes the CurlAsyncHTTPClient to send the Basic Auth headers when the username is not None. Password will be set to an empty string if it is otherwise None.

Also fixes an encoding issues I was experiencing. Pycurl wasn't accepting ut8 for the userpwd parameter. I had to encode it as ascii.
