### PR TITLE
Add more tests to httputil.py

### DIFF
--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -162,6 +162,18 @@ Foo--1234--''').replace(b("\n"), b("\r\n"))
         parse_multipart_form_data(b("1234"), data, args, files)
         self.assertEqual(files, {})
 
+    def test_content_disposition_header_without_name_parameter(self):
+        data = b("""\
+--1234
+Content-Disposition: form-data; filename="ab.txt"
+
+Foo
+--1234--""").replace(b("\n"), b("\r\n"))
+        args = {}
+        files = {}
+        parse_multipart_form_data(b("1234"), data, args, files)
+        self.assertEqual(files, {})
+
 
 class HTTPHeadersTest(unittest.TestCase):
     def test_multi_line(self):


### PR DESCRIPTION
These tests cover corner cases that were without test coverage on tornado/httputil.py

There are just 2 lines in this file without test coverate yet:

```
import doctest
doctest.testmod()
```

when `__name__ == '__main__'`

Is this feature still needed? Considering now that tornado has unit tests and 'tornado.httputil.doctests' function is covered on runtests.py?
