### PR TITLE
Websocket implementation optimizations and other minor changes

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -96,7 +96,9 @@ class WebSocketHandler(tornado.web.RequestHandler):
         # Websocket only supports GET method
         if self.request.method != "GET":
             self.stream.write(tornado.escape.utf8(
-                "HTTP/1.1 405 Method Not Allowed\r\n\r\n"
+                "HTTP/1.1 405 Method Not Allowed\r\n"
+                "Allow: GET\r\n"
+                "\r\n"
             ))
             self.stream.close()
             return


### PR DESCRIPTION
List of changes:
1. Use bytearray on python 2.6+ and fallback to array.array("B") for python 2.5
2. Minor style cleanup for single vs double quote for strings
3. Optional automatic utf-8 decoding for string messages
4. Explicit abort_connection() method - drops TCP connection without starting close handshake
5. WebSocketProtocol13 performance optimizations
