### PR TITLE
coerce kwarg keys to str

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1343,7 +1343,7 @@ class Application(object):
 
                         if spec.regex.groupindex:
                             kwargs = dict(
-                                (k, unquote(v))
+                                (str(k), unquote(v))
                                 for (k, v) in match.groupdict().iteritems())
                         else:
                             args = [unquote(s) for s in match.groups()]


### PR DESCRIPTION
If handler regex is unicode, the keys of groupdict are unicode, but should be
str, as Python < 2.6.5 does not accept unicode keys in:

```
_execute(*args, **kwargs)
```

Since they are for keyword args, they will be valid identifiers, and thus ascii.
