### PR TITLE
HTTPClient __init__ support for `max_simultaneous_connections`

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -54,11 +54,11 @@ class HTTPClient(object):
         except httpclient.HTTPError, e:
             print "Error:", e
     """
-    def __init__(self, async_client_class=None):
+    def __init__(self, async_client_class=None, **kwargs):
         self._io_loop = IOLoop()
         if async_client_class is None:
             async_client_class = AsyncHTTPClient
-        self._async_client = async_client_class(self._io_loop)
+        self._async_client = async_client_class(self._io_loop, **kwargs)
         self._response = None
         self._closed = False
 


### PR DESCRIPTION
I recently ran into a problem while upgrading some old code using tornado 1.2.1 to tornado 2.2 where i was setting the `max_simultaneous_connections` parameter at instantiation time for `HTTPClient()`, but that no longer works.

Upon investigation, I found that In 2.2 there isn't a way to set this value when instantiating `HTTPClient()` directly because these kwargs are not passed along
