### PR TITLE
Fixed: Subsequent calls to AsyncTestCase.wait() now clear previously set timeouts.

### DIFF
--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, division, with_statement
 import unittest
+import time
 from tornado.testing import AsyncTestCase, LogTrapTestCase
 
 
@@ -14,6 +15,15 @@ class AsyncTestCaseTest(AsyncTestCase, LogTrapTestCase):
         except ZeroDivisionError:
             pass
 
+    def test_subsequent_wait_calls(self):
+        """
+        This test makes sure that a second call to wait()
+        clears the first timeout.
+        """
+        self.io_loop.add_timeout(time.time() + 0.001, self.stop)
+        self.wait(timeout = 0.002)
+        self.io_loop.add_timeout(time.time() + 0.003, self.stop)
+        self.wait(timeout = 0.01)
 
 class SetUpTearDownTest(unittest.TestCase):
     def test_set_up_tear_down(self):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -107,6 +107,7 @@ class AsyncTestCase(unittest.TestCase):
         self.__running = False
         self.__failure = None
         self.__stop_args = None
+        self.__timeout = None
 
     def setUp(self):
         super(AsyncTestCase, self).setUp()
@@ -173,7 +174,9 @@ class AsyncTestCase(unittest.TestCase):
                     except Exception:
                         self.__failure = sys.exc_info()
                     self.stop()
-                self.io_loop.add_timeout(time.time() + timeout, timeout_func)
+                if self.__timeout is not None:
+                    self.io_loop.remove_timeout(self.__timeout)
+                self.__timeout = self.io_loop.add_timeout(time.time() + timeout, timeout_func)
             while True:
                 self.__running = True
                 with NullContext():


### PR DESCRIPTION
See: http://groups.google.com/group/python-tornado/browse_thread/thread/cc77a08b15c39a14
