### PR TITLE
Made redirect_handler_class/error_handler_class configurable.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1336,8 +1336,10 @@ class Application(object):
         args = []
         kwargs = {}
         handlers = self._get_host_handlers(request)
+        redirect_handler_class = self.settings.get("redirect_handler_class",
+                                            RedirectHandler)
         if not handlers:
-            handler = RedirectHandler(
+            handler = redirect_handler_class(
                 self, request, url="http://" + self.default_host + "/")
         else:
             for spec in handlers:
@@ -1365,7 +1367,9 @@ class Application(object):
                             args = [unquote(s) for s in match.groups()]
                     break
             if not handler:
-                handler = ErrorHandler(self, request, status_code=404)
+                error_handler_class = self.settings.get("error_handler_class",
+                                                    ErrorHandler)
+                handler = error_handler_class(self, request, status_code=404)
 
         # In debug mode, re-compile templates and reload static files on every
         # request so you don't need to restart to see changes


### PR DESCRIPTION
There are two new fields in Application.settings that are used in
tornado.web for the redirect/error handler classes. These default
to web.RedirectHandler and web.ErrorHandler. These are now handled
in the same was the static_handler_class is. This allows for
subclasses of Application and RequestHandler to customize this
logic more easily.
