### PR TITLE
Add ability to watch entire directories

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -79,6 +79,18 @@ def watch(filename):
     All imported modules are watched by default.
     """
     _watched_files.add(filename)
+    
+def watch_dir(dirname, include_subdirs=True):
+    """Add a dir and all of its files to the watch list.
+    
+    Any file or subdirectory that begins with a period is ignored.
+    """
+    for _root, _dirs, _files in os.walk(dirname):
+        for _file in _files:
+            if not _file.startswith('.'): watch('%s/%s' % (_root, _file))
+        if include_subdirs:
+            for _dir in _dirs:
+                if not _dir.startswith('.'): watch_dir('%s/%s' % _root, _dir)
 
 _reload_hooks = []
 


### PR DESCRIPTION
It would be nice if it were possible to watch an directory for changes to reload rather than having to specify individual files. This particularly comes in handy for directories of static files. My particular use case is watching multiple directories of CSS and JavaScript files so that when changed I could recompile them without having to restart the server.
