### PR TITLE
Allow OPTIONS method to SimpleAsyncHTTPClient

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -121,7 +121,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
 
 
 class _HTTPConnection(object):
-    _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE"])
+    _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"])
 
     def __init__(self, io_loop, client, request, release_callback,
                  final_callback, max_buffer_size):

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -56,6 +56,12 @@ class HeadHandler(RequestHandler):
         self.set_header("Content-Length", "7")
 
 
+class OptionsHandler(RequestHandler):
+    def options(self):
+        self.set_header("Access-Control-Allow-Origin", "*")
+        self.write("ok")
+
+
 class NoContentHandler(RequestHandler):
     def get(self):
         if self.get_argument("error", None):
@@ -97,6 +103,7 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, LogTrapTestCase):
             url("/hello", HelloWorldHandler),
             url("/content_length", ContentLengthHandler),
             url("/head", HeadHandler),
+            url("/options", OptionsHandler),
             url("/no_content", NoContentHandler),
             url("/303_post", SeeOther303PostHandler),
             url("/303_get", SeeOther303GetHandler),
@@ -234,6 +241,13 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, LogTrapTestCase):
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers["content-length"], "7")
         self.assertFalse(response.body)
+
+    def test_options_request(self):
+        response = self.fetch("/options", method="OPTIONS")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers["content-length"], "2")
+        self.assertEqual(response.headers["access-control-allow-origin"], "*")
+        self.assertEqual(response.body, "ok")
 
     def test_no_content(self):
         response = self.fetch("/no_content")


### PR DESCRIPTION
SimpleAsyncHTTPClient does not allow OPTIONS requests. This is a pain when you are trying to write test cases for CORS. This simple patch adds OPTIONS to the supported _SUPPORTED_METHODS in
_HTTPConnection and a test case to go along with it.
