### PR TITLE
arguments dict keys are bytes when using WSGIApplication with Python 3

### DIFF
--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -43,7 +43,7 @@ import urllib
 from tornado import escape
 from tornado import httputil
 from tornado import web
-from tornado.escape import native_str, utf8
+from tornado.escape import native_str, utf8, parse_qs_bytes
 from tornado.util import b
 
 try:
@@ -146,7 +146,7 @@ class HTTPRequest(object):
         self.files = {}
         content_type = self.headers.get("Content-Type", "")
         if content_type.startswith("application/x-www-form-urlencoded"):
-            for name, values in cgi.parse_qs(self.body).iteritems():
+            for name, values in parse_qs_bytes(native_str(self.body)).iteritems():
                 self.arguments.setdefault(name, []).extend(values)
         elif content_type.startswith("multipart/form-data"):
             if 'boundary=' in content_type:


### PR DESCRIPTION
In Python 3.2 when using WSGIApplication, requests of content type "application/x-www-form-urlencoded" have their arguments dictionary end up with the keys being bytes instead of str.

These changes fix this issue for me on Python 3.2.

I haven't run the tests or tried these changes with Python 2. No time for that at the moment but I'll do that in a few weeks if this lingers.
