### PR TITLE
we dont need post_args in url, post_args will be sended in http body.

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -1069,7 +1069,7 @@ class FacebookGraphMixin(OAuth2Mixin):
         if access_token:
             all_args["access_token"] = access_token
             all_args.update(args)
-            all_args.update(post_args or {})
+            
         if all_args:
             url += "?" + urllib.urlencode(all_args)
         callback = self.async_callback(self._on_facebook_request, callback)


### PR DESCRIPTION
Idk why post args are passed in url, if we have post_args, the method is set to POST so the parameters will be passed via body, i have tested only facebook.
