### PR TITLE
make commandline args override config file args when multiple=True

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -223,8 +223,7 @@ class _Option(object):
             str: self._parse_string,
         }.get(self.type, self.type)
         if self.multiple:
-            if self._value is None:
-                self._value = []
+            self._value = []
             for part in value.split(","):
                 if self.type in (int, long):
                     # allow ranges of the form X:Y (inclusive at both ends)


### PR DESCRIPTION
make commandline args override config file args when multiple=True instead of appending to config file args

Currently, when you have an option x where multiple=True, and you have x = ['hi'] in the config file, and you pass --x=bye in the commandline, options.x will be set to ['hi', 'bye'].

I think it's weird and inconsistent to have commandline args append to config file args when multiple=True, when they override config file args when multiple=False.
