### PR TITLE
pretty up --help formatting

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -184,7 +184,7 @@ def print_help(file=sys.stdout):
             if option.default is not None and option.default != '':
                 description += " (default %s)" % option.default
             lines = textwrap.wrap(description, 79 - 35)
-            if len(prefix) > 30:
+            if len(prefix) > 30 or len(lines) == 0:
                 lines.insert(0, '')
             print >> file, "  --%-30s %s" % (prefix, lines[0])
             for line in lines[1:]:


### PR DESCRIPTION
(This is a copy of an older pull request - now isolated into a separate feature branch from my repo so my
subsequent unrelated edits are not included.)

This patch addresses some of the same issues as pull request #404.

There were several annoying problems with --help formatting:
- Printing of default values of options
- Run on text wrapped to left margin instead of respecting option column indent.
- Left column too long (like --logging) runs into the right column descriptions
- Filenames printed with un-normalized paths (like './myfile.py')

I also add a little vertical white space to set off the differrent file section headings from their contents.
