### PR TITLE
tornado.ioloop.IOLoop.instance() should be threadsafe

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -104,6 +104,9 @@ class IOLoop(object):
     WRITE = _EPOLLOUT
     ERROR = _EPOLLERR | _EPOLLHUP
 
+    # Global lock for creating global IOLoop instance
+    _instance_lock = threading.Lock()
+
     def __init__(self, impl=None):
         self._impl = impl or _poll()
         if hasattr(self._impl, 'fileno'):
@@ -142,7 +145,10 @@ class IOLoop(object):
                     self.io_loop = io_loop or IOLoop.instance()
         """
         if not hasattr(IOLoop, "_instance"):
-            IOLoop._instance = IOLoop()
+            with IOLoop._instance_lock:
+                if not hasattr(IOLoop, "_instance"):
+                    # New instance after double check
+                    IOLoop._instance = IOLoop()
         return IOLoop._instance
 
     @staticmethod


### PR DESCRIPTION
`tornado.ioloop.IOLoop.instance()` should be threadsafe (for example -- using pattern "double-checked locking")

if `tornado.ioloop.IOLoop.instance()` will NOT be threadsafe, then next function will be NOT threadsafe too:

```
def my_other_thread_function_a():
    tornado.ioloop.IOLoop.instance().add_callback(my_function_b)
```

so, despite the fact that `add_callback()` is threadsafe -- there is no simple way to use `add_callback()` from other thread

pattern "double-checked locking" -- will not reduce speed of access to instance
