### PR TITLE
parse_command_line should be idempotent - remove side effects

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -145,10 +145,9 @@ def parse_command_line(args=None):
         print_help()
         sys.exit(0)
 
-    # Set up log level and pretty console logging by default
+    # Set up log level
     if options.logging != 'none':
         logging.getLogger().setLevel(getattr(logging, options.logging.upper()))
-        enable_pretty_logging()
 
     return remaining
 
@@ -324,10 +323,7 @@ class Error(Exception):
 
 
 def enable_pretty_logging():
-    """Turns on formatted logging output as configured.
-
-    This is called automatically by `parse_command_line`.
-    """
+    """Turns on formatted logging output as configured. """
     root_logger = logging.getLogger()
     if options.log_file_prefix:
         channel = logging.handlers.RotatingFileHandler(


### PR DESCRIPTION
I had a problem with parse_command_line - it could not be called twice without doubling up the logging setup by the pretty logging.

(the reason I need to call it twice is that the directory for reading the conf file, can be an option on the command line, yet options in the conf file, can be over-ridden by the command line.  So I call in this order:

```
parse_command_line()
parse_config_file(options.conf_file)
parse_command_line()
```
