### PR TITLE
Add support for the HTTP PATCH method.

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -262,7 +262,7 @@ class HTTPConnection(object):
     def _on_request_body(self, data):
         self._request.body = data
         content_type = self._request.headers.get("Content-Type", "")
-        if self._request.method in ("POST", "PUT"):
+        if self._request.method in ("POST", "PATCH", "PUT"):
             if content_type.startswith("application/x-www-form-urlencoded"):
                 arguments = parse_qs_bytes(native_str(self._request.body))
                 for name, values in arguments.iteritems():

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -123,7 +123,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
 
 
 class _HTTPConnection(object):
-    _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE"])
+    _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PATCH", "PUT", "DELETE"])
 
     def __init__(self, io_loop, client, request, release_callback,
                  final_callback, max_buffer_size):
@@ -278,7 +278,7 @@ class _HTTPConnection(object):
         if self.request.user_agent:
             self.request.headers["User-Agent"] = self.request.user_agent
         if not self.request.allow_nonstandard_methods:
-            if self.request.method in ("POST", "PUT"):
+            if self.request.method in ("POST", "PATCH", "PUT"):
                 assert self.request.body is not None
             else:
                 assert self.request.body is None

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -98,7 +98,8 @@ class RequestHandler(object):
     should override the class variable SUPPORTED_METHODS in your
     RequestHandler class.
     """
-    SUPPORTED_METHODS = ("GET", "HEAD", "POST", "DELETE", "PUT", "OPTIONS")
+    SUPPORTED_METHODS = ("GET", "HEAD", "POST", "DELETE", "PATCH", "PUT",
+                         "OPTIONS")
 
     _template_loaders = {}  # {path: template.BaseLoader}
     _template_loader_lock = threading.Lock()
@@ -163,6 +164,9 @@ class RequestHandler(object):
         raise HTTPError(405)
 
     def delete(self, *args, **kwargs):
+        raise HTTPError(405)
+
+    def patch(self, *args, **kwargs):
         raise HTTPError(405)
 
     def put(self, *args, **kwargs):


### PR DESCRIPTION
`PATCH` is a proposed standard described by [RFC 5789](http://tools.ietf.org/html/rfc5789).
