### PR TITLE
Enable percent-decoding of URI path before matching to RequestHandler regexes

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -35,6 +35,7 @@ import calendar
 import email.utils
 import httplib
 import time
+import urllib
 import weakref
 
 from tornado.escape import utf8
@@ -280,7 +281,8 @@ class HTTPRequest(object):
         self.proxy_port = proxy_port
         self.proxy_username = proxy_username
         self.proxy_password = proxy_password
-        self.url = url
+        # Quote UTF-8 encoded characters, not URI-reserved ones
+        self.url = urllib.quote_plus(utf8(url), safe="!*'();:@&=+$,/?#[]%")
         self.method = method
         self.headers = headers
         self.body = utf8(body)

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -22,6 +22,7 @@ import logging
 import urllib
 import re
 
+from tornado.escape import utf8
 from tornado.util import b, ObjectDict
 
 
@@ -186,7 +187,9 @@ def url_concat(url, args):
         return url
     if url[-1] not in ('?', '&'):
         url += '&' if ('?' in url) else '?'
-    return url + urllib.urlencode(args)
+    if hasattr(args, 'items'):
+        args = args.items()
+    return url + urllib.urlencode([(utf8(k), utf8(v)) for k, v in args])
 
 
 class HTTPFile(ObjectDict):

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -54,6 +54,13 @@ class TestUrlConcat(unittest.TestCase):
                 )
         self.assertEqual(url, "https://localhost/path?a=1&b=2&y=y&z=z")
 
+    def test_url_concat_unicode_params(self):
+        url = url_concat(
+                "https://localhost/path",
+                [(u'y', u'\u00e9'), (u'\u00e9', u'z')],
+                )
+        self.assertEqual(url, "https://localhost/path?y=%C3%A9&%C3%A9=z")
+
     def test_url_concat_no_params(self):
         url = url_concat(
             "https://localhost/path?r=1&t=2",


### PR DESCRIPTION
The encoding to decode from is specified through the new `path_encoding` Application setting. If left unspecified, the current behavior is assumed (no percent-decoding).

HTTPClient now percent-encodes URL characters not in either the reserved or unreserved sets (essentially, anything outside the ASCII range), so URL strings containing Unicode can now be fetched.

The `url_concat` utility function now encodes arguments to UTF-8 before percent-encoding them.

Tests updated.
