### PR TITLE
Timing Issue in web.py/httpserver.py

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -684,8 +684,7 @@ class RequestHandler(object):
             self.request.connection.stream.set_close_callback(None)
 
         if not self.application._wsgi:
-            self.flush(include_footers=True)
-            self.request.finish()
+            self.flush(include_footers=True, callback=self.request.finish)
             self._log()
         self._finished = True
         self.on_finish()


### PR DESCRIPTION
Timing issue with web.py
        It was possible to have _finish_request called twice with the same
        request but then fails because the request is set to None.

```
    Example:
    From web.py 686
    self.flush()
    self.request.finish()

    self.flush calls the HTTPConnections write which trigers the
    _on_write_complete callback

    Simultaneously self.request.finish() lands on line 189 of httpserver
    self._request_finished = True

    Then the callback is executed and falls through to self._finish_request()
    Then self._finish_request() is called on line 191 of httpserver

    This gives a ton of None Type doesn't have attribute errors.

    Running self.request.finish as a callback in web.py 687 ensures that
    self._request_finished == False on line 205 of httpserver
```
