### PR TITLE
Excluding url for xsrf check ( callbaks from external system )

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -998,7 +998,8 @@ class RequestHandler(object):
             # If XSRF cookies are turned on, reject form submissions without
             # the proper cookie
             if self.request.method not in ("GET", "HEAD", "OPTIONS") and \
-               self.application.settings.get("xsrf_cookies"):
+               self.application.settings.get("xsrf_cookies") and \
+               self.request.path not in self.application.settings.get("xsrf_cookies_exclude_urls", []):
                 self.check_xsrf_cookie()
             self.prepare()
             if not self._finished:


### PR DESCRIPTION
I have on my own site payment options

Payment systems make callback use method post for special links

If I have options xsrf_cookies in settings enabled (settings['xsrf_cookies'] = True), then payment systems get 403 error
