### PR TITLE
Better connection check in RequestHandler

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -123,7 +123,7 @@ class RequestHandler(object):
         self.ui["modules"] = self.ui["_modules"]
         self.clear()
         # Check since connection is not available in WSGI
-        if hasattr(self.request, "connection"):
+        if getattr(self.request, "connection", None):
             self.request.connection.stream.set_close_callback(
                 self.on_connection_close)
         self.initialize(**kwargs)


### PR DESCRIPTION
RequestHandler checks only if the connection is an attribute to the request object. By default HTTPRequest has connection=None which going to make the RequestHandler to fail in adding a stream close callback.
