### PR TITLE
Restore context for all read methods

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -366,7 +366,7 @@ class IOStream(object):
 
     def _set_read_callback(self, callback):
         assert not self._read_callback, "Already reading"
-        self._read_callback = callback
+        self._read_callback = stack_context.wrap(callback)
 
     def _try_inline_read(self):
         """Attempt to complete the current read operation from buffered data.


### PR DESCRIPTION
Prior to 2db0aceb32f5c042f5306e72a4679580b4359f34 this was being done
properly, but the refactor removed `stack_context.wrap` causing some issues
in our upstream context managers.
