### PR TITLE
Add support for RFC5988 Link header

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -436,6 +436,12 @@ class HeaderInjectionHandler(RequestHandler):
             self.finish(b("ok"))
 
 
+class LinkHandler(RequestHandler):
+    def get(self):
+        self.link("http://example.com/uri", [('rel', '"previous"'), ('title', '"previous chapter"')])
+        self.hint("/hinted")
+
+
 class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
     COOKIE_SECRET = "WebTest.COOKIE_SECRET"
 
@@ -464,6 +470,7 @@ class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
             url("/redirect", RedirectHandler),
             url("/empty_flush", EmptyFlushCallbackHandler),
             url("/header_injection", HeaderInjectionHandler),
+            url("/link", LinkHandler),
             ]
         self.app = Application(urls,
                                template_loader=loader,
@@ -578,6 +585,10 @@ js_embed()
     def test_header_injection(self):
         response = self.fetch("/header_injection")
         self.assertEqual(response.body, b("ok"))
+
+    def test_link(self):
+        response = self.fetch("/link")
+        self.assertEqual(response.headers["Link"], '<http://example.com/uri>;rel="previous";title="previous chapter",</hinted>;rel="subresource"')
 
 
 class ErrorResponseTest(AsyncHTTPTestCase, LogTrapTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -447,6 +447,24 @@ class RequestHandler(object):
         return decode_signed_value(self.application.settings["cookie_secret"],
                                    name, value, max_age_days=max_age_days)
 
+    def link(self, uri, params):
+        """Add a link to the Link header. See http://tools.ietf.org/html/rfc5988
+        for a description.
+
+        :arg string uri: URI of the link
+        :arg list params: List of (name, value) link parameters
+        """
+        self.add_header('Link', ('<%s>;' % uri)+';'.join(['%s=%s' % pair for pair in params]))
+
+    def hint(self, uri, rel='"subresource"'):
+        """Convenience function for hinting to the client that the given URI
+        is related to this resource.
+
+        :arg string uri: URI of the link
+        :arg string rel: Relation type of the link
+        """
+        self.link(uri, [('rel', rel)])
+
     def redirect(self, url, permanent=False, status=None):
         """Sends a redirect to the given (optionally relative) URL.
 


### PR DESCRIPTION
Add RequestHandler.link, RequestHandler.hint. This allows applications to easily hint to the client which resources are related to a response, to cut down on request latency, as recommended by http://dev.chromium.org/spdy/link-headers-and-server-hint.