### PR TITLE
Refactor TCPServer and HTTPServer to support TLS NPN

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -27,21 +27,17 @@ This module also defines the `HTTPRequest` class which is exposed via
 from __future__ import absolute_import, division, with_statement
 
 import Cookie
+import functools
+import httplib
 import logging
 import socket
 import time
 
+from tornado import httputil, iostream, netutil, stack_context
 from tornado.escape import utf8, native_str, parse_qs_bytes
-from tornado import httputil
-from tornado import iostream
-from tornado.netutil import TCPServer
-from tornado import stack_context
-from tornado.util import b, bytes_type
-
-try:
-    import ssl  # Python 2.6+
-except ImportError:
-    ssl = None
+from tornado.netutil import ssl
+from tornado.tcpserver import TCPServer
+from tornado.util import b
 
 
 class HTTPServer(TCPServer):
@@ -59,9 +55,10 @@ class HTTPServer(TCPServer):
 
         def handle_request(request):
            message = "You requested %s\n" % request.uri
-           request.write("HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s" % (
-                         len(message), message))
-           request.finish()
+           request.connection.write_preamble(
+               status_code=200,
+               headers=[("Content-Length", str(len(message)))])
+           request.connection.write(message, finished=True)
 
         http_server = httpserver.HTTPServer(handle_request)
         http_server.listen(8888)
@@ -72,76 +69,48 @@ class HTTPServer(TCPServer):
     in `HTTPServer` is HTTP/1.1 keep-alive connections. We do not, however,
     implement chunked encoding, so the request callback must provide a
     ``Content-Length`` header or implement chunked encoding for HTTP/1.1
-    requests for the server to run correctly for HTTP/1.1 clients. If
-    the request handler is unable to do this, you can provide the
-    ``no_keep_alive`` argument to the `HTTPServer` constructor, which will
-    ensure the connection is closed on every request no matter what HTTP
-    version the client is using.
+    requests for the server to run correctly for HTTP/1.1 clients.
 
-    If ``xheaders`` is ``True``, we support the ``X-Real-Ip`` and ``X-Scheme``
-    headers, which override the remote IP and HTTP scheme for all requests.
-    These headers are useful when running Tornado behind a reverse proxy or
-    load balancer.
+    For initialization patterns, see `TCPServer`.
 
-    `HTTPServer` can serve SSL traffic with Python 2.6+ and OpenSSL.
-    To make this server serve SSL traffic, send the ssl_options dictionary
-    argument with the arguments required for the `ssl.wrap_socket` method,
-    including "certfile" and "keyfile"::
+    :arg dict ssl_options: Keyword arguments to be passed to `ssl.wrap_socket`.
 
-       HTTPServer(applicaton, ssl_options={
-           "certfile": os.path.join(data_dir, "mydomain.crt"),
-           "keyfile": os.path.join(data_dir, "mydomain.key"),
-       })
-
-    `HTTPServer` initialization follows one of three patterns (the
-    initialization methods are defined on `tornado.netutil.TCPServer`):
-
-    1. `~tornado.netutil.TCPServer.listen`: simple single-process::
-
-            server = HTTPServer(app)
-            server.listen(8888)
-            IOLoop.instance().start()
-
-       In many cases, `tornado.web.Application.listen` can be used to avoid
-       the need to explicitly create the `HTTPServer`.
-
-    2. `~tornado.netutil.TCPServer.bind`/`~tornado.netutil.TCPServer.start`:
-       simple multi-process::
-
-            server = HTTPServer(app)
-            server.bind(8888)
-            server.start(0)  # Forks multiple sub-processes
-            IOLoop.instance().start()
-
-       When using this interface, an `IOLoop` must *not* be passed
-       to the `HTTPServer` constructor.  `start` will always start
-       the server on the default singleton `IOLoop`.
-
-    3. `~tornado.netutil.TCPServer.add_sockets`: advanced multi-process::
-
-            sockets = tornado.netutil.bind_sockets(8888)
-            tornado.process.fork_processes(0)
-            server = HTTPServer(app)
-            server.add_sockets(sockets)
-            IOLoop.instance().start()
-
-       The `add_sockets` interface is more complicated, but it can be
-       used with `tornado.process.fork_processes` to give you more
-       flexibility in when the fork happens.  `add_sockets` can
-       also be used in single-process servers if you want to create
-       your listening sockets in some way other than
-       `tornado.netutil.bind_sockets`.
+    All other keyword arguments are passed to `HTTPServerProtocol`.
 
     """
-    def __init__(self, request_callback, no_keep_alive=False, io_loop=None,
-                 xheaders=False, ssl_options=None, **kwargs):
+    def __init__(self, request_callback, io_loop=None, ssl_options=None,
+                 no_keep_alive=False, xheaders=False):
+        protocol = HTTPServerProtocol(request_callback,
+            no_keep_alive=no_keep_alive, xheaders=xheaders)
+        npn_protocols = None
+        if ssl_options and netutil.SUPPORTS_NPN:
+            npn_protocols = [('http/1.1', protocol)]
+        TCPServer.__init__(self,
+                           protocol=protocol,
+                           npn_protocols=npn_protocols,
+                           io_loop=io_loop,
+                           ssl_options=ssl_options)
+
+
+class HTTPServerProtocol(object):
+    """A server protocol handler implementing the HTTP specification, meant
+    to be instantiated and passed to the `TCPServer` constructor.
+
+    :arg bool no_keep_alive: If ``True``, ensures the connection is closed on
+        every request no matter what HTTP version the client is using.
+
+    :arg bool xheaders: If ``True``, we support the ``X-Real-Ip`` and
+        ``X-Scheme`` headers, which override the remote IP and HTTP scheme for
+        all requests. These headers are useful when running Tornado behind a
+        reverse proxy or load balancer.
+
+    """
+    def __init__(self, request_callback, no_keep_alive=False, xheaders=False):
         self.request_callback = request_callback
         self.no_keep_alive = no_keep_alive
         self.xheaders = xheaders
-        TCPServer.__init__(self, io_loop=io_loop, ssl_options=ssl_options,
-                           **kwargs)
 
-    def handle_stream(self, stream, address):
+    def __call__(self, stream, address, server):
         HTTPConnection(stream, address, self.request_callback,
                        self.no_keep_alive, self.xheaders)
 
@@ -151,45 +120,67 @@ class _BadRequestException(Exception):
     pass
 
 
-class HTTPConnection(object):
-    """Handles a connection to an HTTP client, executing HTTP requests.
-
-    We parse HTTP headers and bodies, and execute the request callback
-    until the HTTP conection is closed.
-    """
-    def __init__(self, stream, address, request_callback, no_keep_alive=False,
-                 xheaders=False):
+class BaseHTTPConnection(object):
+    def __init__(self, stream, address, request_callback, xheaders=False):
         self.stream = stream
         self.address = address
         self.request_callback = request_callback
-        self.no_keep_alive = no_keep_alive
         self.xheaders = xheaders
-        self._request = None
-        self._request_finished = False
+
+
+class HTTPConnection(BaseHTTPConnection):
+    """Handles a connection to an HTTP client, executing HTTP requests.
+
+    Parses HTTP headers and bodies, and executes the request callback,
+    providing itself as an interface for writing the response.
+
+    """
+    def __init__(self, stream, address, request_callback, no_keep_alive=False,
+                 xheaders=False):
+        BaseHTTPConnection.__init__(self, stream, address, request_callback,
+                                    xheaders)
+        self.no_keep_alive = no_keep_alive
         # Save stack context here, outside of any request.  This keeps
         # contexts from one request from leaking into the next.
         self._header_callback = stack_context.wrap(self._on_headers)
         self.stream.read_until(b("\r\n\r\n"), self._header_callback)
-        self._write_callback = None
 
-    def write(self, chunk, callback=None):
-        """Writes a chunk of output to the stream."""
+        self._request = None
+        self._request_finished = False
+
+    def set_close_callback(self, callback):
+        self.stream.set_close_callback(callback)
+
+    def write(self, chunk, finished=False, callback=None):
+        """Writes a chunk of the response body to the stream."""
         assert self._request, "Request closed"
         if not self.stream.closed():
-            self._write_callback = stack_context.wrap(callback)
-            self.stream.write(chunk, self._on_write_complete)
+            self.stream.write(chunk, functools.partial(self._on_write_complete,
+                              callback=stack_context.wrap(callback)))
+        if finished:
+            self._finish()
 
-    def finish(self):
+    def write_preamble(self, status_code, reason=None, version="HTTP/1.1",
+                       headers=None, finished=False, callback=None):
+        """Writes the response status line and headers to the stream."""
+        lines = [utf8(version + " " +
+                      str(status_code) +
+                      " " + (reason or
+                             httplib.responses.get(status_code, '')))]
+        lines.extend([(utf8(n) + b(": ") + utf8(v)) for n, v in headers or []])
+        self.write(b("\r\n").join(lines) + b("\r\n\r\n"), callback=callback)
+        if finished:
+            self._finish()
+
+    def _finish(self):
         """Finishes the request."""
         assert self._request, "Request closed"
         self._request_finished = True
         if not self.stream.writing():
             self._finish_request()
 
-    def _on_write_complete(self):
-        if self._write_callback is not None:
-            callback = self._write_callback
-            self._write_callback = None
+    def _on_write_complete(self, callback=None):
+        if callback is not None:
             callback()
         # _on_write_complete is enqueued on the IOLoop whenever the
         # IOStream's write buffer becomes empty, but it's possible for
@@ -247,7 +238,7 @@ class HTTPConnection(object):
 
             self._request = HTTPRequest(
                 connection=self, method=method, uri=uri, version=version,
-                headers=headers, remote_ip=remote_ip)
+                headers=headers, remote_ip=remote_ip, xheaders=self.xheaders)
 
             content_length = headers.get("Content-Length")
             if content_length:
@@ -289,6 +280,7 @@ class HTTPConnection(object):
                         break
                 else:
                     logging.warning("Invalid multipart/form-data")
+        self._request._finish_time = time.time()
         self.request_callback(self._request)
 
 
@@ -357,22 +349,31 @@ class HTTPRequest(object):
        File uploads are available in the files property, which maps file
        names to lists of :class:`HTTPFile`.
 
+    .. attribute:: xheaders
+
+       If ``True``, we support the ``X-Real-Ip`` and ``X-Scheme`` headers,
+       which override the remote IP and HTTP scheme for all requests. These
+       headers are useful when running Tornado behind a reverse proxy or load
+       balancer.
+
     .. attribute:: connection
 
        An HTTP request is attached to a single HTTP connection, which can
        be accessed through the "connection" attribute. Since connections
        are typically kept open in HTTP/1.1, multiple requests can be handled
        sequentially on a single connection.
+
     """
     def __init__(self, method, uri, version="HTTP/1.0", headers=None,
                  body=None, remote_ip=None, protocol=None, host=None,
-                 files=None, connection=None):
+                 files=None, xheaders=False, priority=None, framing='http',
+                 connection=None):
         self.method = method
         self.uri = uri
         self.version = version
         self.headers = headers or httputil.HTTPHeaders()
         self.body = body or ""
-        if connection and connection.xheaders:
+        if xheaders:
             # Squid uses X-Forwarded-For, others use X-Real-Ip
             self.remote_ip = self.headers.get(
                 "X-Real-Ip", self.headers.get("X-Forwarded-For", remote_ip))
@@ -392,6 +393,7 @@ class HTTPRequest(object):
                 self.protocol = "https"
             else:
                 self.protocol = "http"
+
         self.host = host or self.headers.get("Host") or "127.0.0.1"
         self.files = files or {}
         self.connection = connection
@@ -423,19 +425,12 @@ class HTTPRequest(object):
                     self._cookies = {}
         return self._cookies
 
-    def write(self, chunk, callback=None):
-        """Writes the given chunk to the response stream."""
-        assert isinstance(chunk, bytes_type)
-        self.connection.write(chunk, callback=callback)
-
-    def finish(self):
-        """Finishes this HTTP request on the open connection."""
-        self.connection.finish()
-        self._finish_time = time.time()
-
     def full_url(self):
         """Reconstructs the full URL for this request."""
-        return self.protocol + "://" + self.host + self.uri
+        url = self.protocol + "://" + self.host + self.path
+        if self.query:
+            url += '?' + self.query
+        return url
 
     def request_time(self):
         """Returns the amount of time it took for this request to execute."""

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -22,18 +22,14 @@ import collections
 import errno
 import logging
 import os
+import re
 import socket
 import sys
-import re
 
 from tornado import ioloop
 from tornado import stack_context
+from tornado.netutil import ssl, wrap_socket
 from tornado.util import b, bytes_type
-
-try:
-    import ssl  # Python 2.6+
-except ImportError:
-    ssl = None
 
 
 class IOStream(object):
@@ -211,6 +207,10 @@ class IOStream(object):
         if self._write_buffer:
             self._add_io_state(self.io_loop.WRITE)
         self._maybe_add_error_listener()
+
+    def set_connect_callback(self, callback):
+        """Call the given callback when the stream is established."""
+        self._connect_callback = stack_context.wrap(callback)
 
     def set_close_callback(self, callback):
         """Call the given callback when the stream is closed."""
@@ -622,10 +622,13 @@ class SSLIOStream(IOStream):
         it will be used as additional keyword arguments to ssl.wrap_socket.
         """
         self._ssl_options = kwargs.pop('ssl_options', {})
+        self._ssl_options['do_handshake_on_connect'] = False
+        self._npn_protocols = kwargs.pop('npn_protocols', None)
         super(SSLIOStream, self).__init__(*args, **kwargs)
         self._ssl_accepting = True
         self._handshake_reading = False
         self._handshake_writing = False
+        self._add_io_state(self.io_loop.READ)
 
     def reading(self):
         return self._handshake_reading or super(SSLIOStream, self).reading()
@@ -673,9 +676,7 @@ class SSLIOStream(IOStream):
         super(SSLIOStream, self)._handle_write()
 
     def _handle_connect(self):
-        self.socket = ssl.wrap_socket(self.socket,
-                                      do_handshake_on_connect=False,
-                                      **self._ssl_options)
+        self.socket = wrap_socket(self.socket, self._ssl_options, self._npn_protocols)
         # Don't call the superclass's _handle_connect (which is responsible
         # for telling the application that the connection is complete)
         # until we've completed the SSL handshake (so certificates are

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -5,8 +5,9 @@ from tornado.escape import utf8, _unicode, native_str
 from tornado.httpclient import HTTPRequest, HTTPResponse, HTTPError, AsyncHTTPClient, main
 from tornado.httputil import HTTPHeaders
 from tornado.iostream import IOStream, SSLIOStream
+from tornado.netutil import ssl
 from tornado import stack_context
-from tornado.util import b
+from tornado.util import b, BytesIO
 
 import base64
 import collections
@@ -21,16 +22,6 @@ import sys
 import time
 import urlparse
 import zlib
-
-try:
-    from io import BytesIO  # python 3
-except ImportError:
-    from cStringIO import StringIO as BytesIO  # python 2
-
-try:
-    import ssl  # python 2.6+
-except ImportError:
-    ssl = None
 
 _DEFAULT_CA_CERTS = os.path.dirname(__file__) + '/ca-certificates.crt'
 

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+#
+# Copyright 2011 Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, with_statement
+
+import errno
+import logging
+import socket
+
+from tornado import process
+from tornado.ioloop import IOLoop
+from tornado.iostream import IOStream, SSLIOStream
+from tornado.netutil import add_accept_handler, bind_sockets, ssl, wrap_socket
+
+
+class TCPServer(object):
+    r"""A non-blocking, single-threaded TCP server.
+
+    `TCPServer` takes a ``protocol`` argument that is called when an incoming
+    connection is opened.
+
+    `TCPServer` can serve SSL traffic with Python 2.6+ and OpenSSL.
+    To make this server serve SSL traffic, send the ssl_options dictionary
+    argument with the arguments required for the `ssl.wrap_socket` method,
+    including "certfile" and "keyfile"::
+
+       TCPServer(ssl_options={
+           "certfile": os.path.join(data_dir, "mydomain.crt"),
+           "keyfile": os.path.join(data_dir, "mydomain.key"),
+       })
+
+    `TCPServer` supports TLS NPN if Python 3.3+ and OpenSSL 1.0.1+ are
+    installed. The ``npn_protocols`` argument specifies a list of ``(name,
+    handler)`` tuples in order of preference. Once NPN is completed, the
+    handler for the selected name will be called. If the client does not
+    support NPN, the handler passed in the ``protocol`` argument will be used
+    instead. This parameter requires ``ssl_options`` to be passed as well.
+
+    `TCPServer` initialization follows one of three patterns:
+
+    1. `listen`: simple single-process::
+
+            server = TCPServer()
+            server.listen(8888)
+            IOLoop.instance().start()
+
+    2. `bind`/`start`: simple multi-process::
+
+            server = TCPServer()
+            server.bind(8888)
+            server.start(0)  # Forks multiple sub-processes
+            IOLoop.instance().start()
+
+       When using this interface, an `IOLoop` must *not* be passed
+       to the `TCPServer` constructor.  `start` will always start
+       the server on the default singleton `IOLoop`.
+
+    3. `add_sockets`: advanced multi-process::
+
+            sockets = bind_sockets(8888)
+            tornado.process.fork_processes(0)
+            server = TCPServer()
+            server.add_sockets(sockets)
+            IOLoop.instance().start()
+
+       The `add_sockets` interface is more complicated, but it can be
+       used with `tornado.process.fork_processes` to give you more
+       flexibility in when the fork happens.  `add_sockets` can
+       also be used in single-process servers if you want to create
+       your listening sockets in some way other than
+       `bind_sockets`.
+
+    """
+    def __init__(self, protocol, io_loop=None, npn_protocols=None,
+                 ssl_options=None):
+        self.protocol = protocol
+        self.io_loop = io_loop
+        assert not ssl_options or ssl, "Python 2.6+ and OpenSSL required for SSL"
+        assert ssl_options or not npn_protocols, "npn_protocols requires ssl_options"
+        self.npn_protocols = npn_protocols
+        self.ssl_options = ssl_options
+        if self.ssl_options:
+            self.ssl_options.update({
+                'server_side': True,
+                'do_handshake_on_connect': False
+            })
+        self._sockets = {}  # fd -> socket object
+        self._pending_sockets = []
+        self._started = False
+
+    def listen(self, port, address=""):
+        """Starts accepting connections on the given port.
+
+        This method may be called more than once to listen on multiple ports.
+        `listen` takes effect immediately; it is not necessary to call
+        `TCPServer.start` afterwards.  It is, however, necessary to start
+        the `IOLoop`.
+        """
+        sockets = bind_sockets(port, address=address)
+        self.add_sockets(sockets)
+
+    def add_sockets(self, sockets):
+        """Makes this server start accepting connections on the given sockets.
+
+        The ``sockets`` parameter is a list of socket objects such as
+        those returned by `bind_sockets`.
+        `add_sockets` is typically used in combination with that
+        method and `tornado.process.fork_processes` to provide greater
+        control over the initialization of a multi-process server.
+        """
+        if self.io_loop is None:
+            self.io_loop = IOLoop.instance()
+
+        for sock in sockets:
+            self._sockets[sock.fileno()] = sock
+            add_accept_handler(sock, self._handle_connection,
+                               io_loop=self.io_loop)
+
+    def add_socket(self, socket):
+        """Singular version of `add_sockets`.  Takes a single socket object."""
+        self.add_sockets([socket])
+
+    def bind(self, port, address=None, family=socket.AF_UNSPEC, backlog=128):
+        """Binds this server to the given port on the given address.
+
+        To start the server, call `start`. If you want to run this server
+        in a single process, you can call `listen` as a shortcut to the
+        sequence of `bind` and `start` calls.
+
+        Address may be either an IP address or hostname.  If it's a hostname,
+        the server will listen on all IP addresses associated with the
+        name.  Address may be an empty string or None to listen on all
+        available interfaces.  Family may be set to either ``socket.AF_INET``
+        or ``socket.AF_INET6`` to restrict to ipv4 or ipv6 addresses, otherwise
+        both will be used if available.
+
+        The ``backlog`` argument has the same meaning as for
+        `socket.listen`.
+
+        This method may be called multiple times prior to `start` to listen
+        on multiple ports or interfaces.
+        """
+        sockets = bind_sockets(port, address=address, family=family,
+                               backlog=backlog)
+        if self._started:
+            self.add_sockets(sockets)
+        else:
+            self._pending_sockets.extend(sockets)
+
+    def start(self, num_processes=1):
+        """Starts this server in the IOLoop.
+
+        By default, we run the server in this process and do not fork any
+        additional child process.
+
+        If num_processes is ``None`` or <= 0, we detect the number of cores
+        available on this machine and fork that number of child
+        processes. If num_processes is given and > 1, we fork that
+        specific number of sub-processes.
+
+        Since we use processes and not threads, there is no shared memory
+        between any server code.
+
+        Note that multiple processes are not compatible with the autoreload
+        module (or the ``debug=True`` option to `tornado.web.Application`).
+        When using multiple processes, no IOLoops can be created or
+        referenced until after the call to ``TCPServer.start(n)``.
+        """
+        assert not self._started
+        self._started = True
+        if num_processes != 1:
+            process.fork_processes(num_processes)
+        sockets = self._pending_sockets
+        self._pending_sockets = []
+        self.add_sockets(sockets)
+
+    def stop(self):
+        """Stops listening for new connections.
+
+        Requests currently in progress may still continue after the
+        server is stopped.
+        """
+        for fd, sock in self._sockets.iteritems():
+            self.io_loop.remove_handler(fd)
+            sock.close()
+
+    def _handle_connection(self, connection, address):
+        if self.ssl_options is not None:
+            try:
+                npn_protocols = None
+                if self.npn_protocols is not None:
+                    npn_protocols = [name for name, _ in self.npn_protocols]
+                connection = wrap_socket(connection, self.ssl_options,
+                                         npn_protocols)
+            except ssl.SSLError, err:
+                if err.args[0] == ssl.SSL_ERROR_EOF:
+                    return connection.close()
+                else:
+                    raise
+            except socket.error, err:
+                if err.args[0] == errno.ECONNABORTED:
+                    return connection.close()
+                else:
+                    raise
+
+            stream = SSLIOStream(connection, io_loop=self.io_loop)
+            if self.npn_protocols is not None:
+                def on_connect():
+                    handler = self.protocol
+                    selected_name = connection.selected_npn_protocol()
+                    if selected_name:
+                        for name, protocol in self.npn_protocols:
+                            if name == selected_name:
+                                handler = protocol
+                                break
+                    self._run_protocol(handler, stream, address)
+                stream.set_connect_callback(on_connect)
+                return
+        else:
+            stream = IOStream(connection, io_loop=self.io_loop)
+        self._run_protocol(self.protocol, stream, address)
+
+    def _run_protocol(self, handler, stream, address):
+        try:
+            handler(stream, address, self)
+        except Exception:
+            logging.error("Error in connection callback", exc_info=True)

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -2,6 +2,11 @@
 
 from __future__ import absolute_import, division, with_statement
 
+try:
+    from io import BytesIO  # python 3
+except ImportError:
+    from cStringIO import StringIO as BytesIO  # python 2
+
 
 class ObjectDict(dict):
     """Makes a dictionary behave like an object."""


### PR DESCRIPTION
* TLS NPN means that one of many protocols can be selected after a TCP connection is established. A layer of indirection was added to `TCPServer` to allow it to delegate handling of a TCP connection to whichever protocol handler was negotiated. If the `npn_protocols` parameter (a list of `(name, handler)` tuples in order of preference) was passed to the constructor, the connection is over TLS, and NPN succeeded, the handler for the chosen name will be called. Otherwise, the `protocol` constructor parameter will be called. For example, `SPDYServer` is essentially:

```
  class SPDYServer(TCPServer):
      def __init__(self, request_callback):
          http_protocol = HTTPServerProtocol(request_callback)
          TCPServer.__init__(self, http_protocol,
              npn_protocols=[
                  ('spdy/2', SPDYServerProtocol(request_callback)),
                  ('http/1.1', http_protocol)])
```

* `TCPServer` was moved from `netutil` to its own module, `tcpserver`.

* Since utilizing NPN support in Python 3.3 requires the `ssl.SSLContext` class, which isn't available in Python 2.x, the `wrap_socket()` top-level function was added to `netutil` to abstract away these details. In addition, the `SUPPORTS_NPN` constant was added as a convenience for determining if the system supported NPN.

* Previously, `web.RequestHandler` formatted the HTTP response itself and wrote it directly to the `IOStream`. This responsibility has been moved to the `HTTPRequest.connection` object, which must provide the `write_preamble()` and `write()` methods - the former writes the response status line and headers, while the latter writes a chunk of the response body.

* Although `IOStream.connect()` already takes a callback parameter, in `SSLIOStream` it's not called until the SSL handshake is completed (which contains TLS NPN) - and `TCPServer`, which doesn't call `connect()`, won't know which protocol handler to execute until that happens. To fix this, a `set_connect_callback` method was added to `IOStream`.

* Snippets that conditionally imported `BytesIO` and `ssl` were moved into `util` and `netutil`, respectively. These symbols are now imported from there.

From the SPDY fork