### PR TITLE
The template reverse_url function does not url-escape the result

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -436,6 +436,11 @@ class HeaderInjectionHandler(RequestHandler):
             self.finish(b("ok"))
 
 
+class ReverseURLUnescaped(RequestHandler):
+    def get(self, *args):
+        self.render("reverse_url_unescaped.html")
+
+
 class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
     COOKIE_SECRET = "WebTest.COOKIE_SECRET"
 
@@ -451,6 +456,7 @@ class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
                 "entry.html": """\
 {{ set_resources(embedded_css=".entry { margin-bottom: 1em; }", embedded_javascript="js_embed()", css_files=["/base.css", "/foo.css"], javascript_files="/common.js", html_head="<meta>", html_body='<script src="/analytics.js"/>') }}
 <div class="entry">...</div>""",
+                "reverse_url_unescaped.html": "{{reverse_url('reverse', 'foo@example.com')}}",
                 })
         urls = [
             url("/typecheck/(.*)", TypeCheckHandler, name='typecheck'),
@@ -464,6 +470,7 @@ class WebTest(AsyncHTTPTestCase, LogTrapTestCase):
             url("/redirect", RedirectHandler),
             url("/empty_flush", EmptyFlushCallbackHandler),
             url("/header_injection", HeaderInjectionHandler),
+            url("/reverse_url_unescaped/(.*)", ReverseURLUnescaped, name='reverse')
             ]
         self.app = Application(urls,
                                template_loader=loader,
@@ -578,6 +585,10 @@ js_embed()
     def test_header_injection(self):
         response = self.fetch("/header_injection")
         self.assertEqual(response.body, b("ok"))
+
+    def test_reverse_url_unescaped(self):
+        response = self.fetch("/reverse_url_unescaped/")
+        self.assertEqual(response.body, b('/reverse_url_unescaped/foo@example.com'))
 
 
 class ErrorResponseTest(AsyncHTTPTestCase, LogTrapTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -608,7 +608,7 @@ class RequestHandler(object):
             _=self.locale.translate,
             static_url=self.static_url,
             xsrf_form_html=self.xsrf_form_html,
-            reverse_url=self.reverse_url
+            reverse_url=lambda x, *args: escape.url_unescape(self.reverse_url(x, *args))
         )
         args.update(self.ui)
         args.update(kwargs)


### PR DESCRIPTION
Since 28590fce120a42ee5f3f1a960040bd1cb84422cc the URLSpec.reverse method returns an url-escaped string. This is ok, but when rendering an url in html it shouldn't be url-escaped.
