### PR TITLE
Documentation fixes: auto-reloading

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -24,6 +24,11 @@ and static resources.
 This module depends on IOLoop, so it will not work in WSGI applications
 and Google AppEngine.  It also will not work correctly when HTTPServer's
 multi-process mode is used.
+
+Reloading loses any Python interpreter command-line arguments (e.g. ``-u``)
+because it re-executes Python using ``sys.executable`` and ``sys.argv``.
+Additionally, modifying these variables will cause reloading to behave
+incorrectly.
 """
 
 from __future__ import absolute_import, division, with_statement

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1208,9 +1208,15 @@ class Application(object):
 
     .. attribute:: settings
 
-       Additonal keyword arguments passed to the constructor are saved in the
+       Additional keyword arguments passed to the constructor are saved in the
        `settings` dictionary, and are often referred to in documentation as
        "application settings".
+
+    .. attribute:: debug
+
+       If `True` the application runs in debug mode, described in
+       :ref:`debug-mode`. This is an application setting in the `settings`
+       dictionary, so handlers can access it.
     """
     def __init__(self, handlers=None, default_host="", transforms=None,
                  wsgi=False, **settings):

--- a/website/sphinx/overview.rst
+++ b/website/sphinx/overview.rst
@@ -957,6 +957,8 @@ the Google credentials in a cookie for later access:
 
 See the `tornado.auth` module documentation for more details.
 
+.. _debug-mode:
+
 Debug mode and automatic reloading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -975,6 +977,12 @@ are using debug mode.
 The automatic reloading feature of debug mode is available as a
 standalone module in ``tornado.autoreload``, and is optionally used by
 the test runner in ``tornado.testing.main``.
+
+Reloading loses any Python interpreter command-line arguments (e.g. ``-u``)
+because it re-executes Python using ``sys.executable`` and ``sys.argv``.
+Additionally, modifying these variables will cause reloading to behave
+incorrectly.
+
 
 Running Tornado in production
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I just got bitten by a bug where I was running python -u (my app) to avoid print statements from getting buffered into pipes. I was mystified about why the output disappeared after Tornado reloaded my code ... until I saw that it re-execs Python. I worked around this by using the PYTHONUNBUFFERED env var, but some additional documentation would prevent me from running into this.
