### PR TITLE
Enhance the set of configurations tested by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
           env: FULL="true"
         - python: 2.7
           env: FULL="true"
+        - python: 3.2
+          env: LANG="en_US.utf-8"
+        - python: 3.2
+          env: LANG="C"
 # TODO: install pycurl, twisted, etc (depends on python version)
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.5' ]]; then pip install --use-mirrors simplejson; fi


### PR DESCRIPTION
- Add `py26` back to `.travis.yml` but make it an allowable failure
- Add `py25` and `pypy`
- Some testing of `FULL` configs with more installed dependencies
- Test `py32` with both `LANG=C` and `LANG=en_US.utf-8`.

Here's an example set of (10) Travis builds: http://travis-ci.org/#!/msabramo/tornado/builds/1639032
