### PR TITLE
A simple fix for the bug that RequestHandler.add_header() doesn't work for WSGI applications

### DIFF
--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -94,7 +94,7 @@ class WSGIApplication(web.Application):
         assert handler._finished
         status = str(handler._status_code) + " " + \
             httplib.responses[handler._status_code]
-        headers = handler._headers.items()
+        headers = handler._headers.items() + handler._list_headers
         if hasattr(handler, "_new_cookie"):
             for cookie in handler._new_cookie.values():
                 headers.append(("Set-Cookie", cookie.OutputString(None)))


### PR DESCRIPTION
The wsgi.WSGIApplication.__call__() function forgets to include handler._list_headers (which is made by RequestHandler.add_header()) as a part of its response headers.

Thanks
