### PR TITLE
tornado.stack_context.wrap must not to restrict kwargs for function

### DIFF
--- a/tornado/stack_context.py
+++ b/tornado/stack_context.py
@@ -195,7 +195,9 @@ def wrap(fn):
     # functools.wraps doesn't appear to work on functools.partial objects
     #@functools.wraps(fn)
 
-    def wrapped(callback, contexts, *args, **kwargs):
+    def wrapped(*args, **kwargs):
+        callback, contexts, args = args[0], args[1], args[2:]
+        
         if contexts is _state.contexts or not contexts:
             callback(*args, **kwargs)
             return


### PR DESCRIPTION
`tornado.stack_context.wrap` restricts kwargs for function

see this example:

```
import tornado.stack_context

def on_error(t, e, tb):
    pass

with tornado.stack_context.ExceptionStackContext(on_error):
    @tornado.stack_context.wrap
    def test_func_A(my_callback=None):
        print 'SUCCESS (A) !', my_callback

    @tornado.stack_context.wrap
    def test_func_B(callback=None):
        print 'SUCCESS (B) !', callback

    @tornado.stack_context.wrap
    def test_func_C(contexts=None):
        print 'SUCCESS (C) !', contexts

try:
    test_func_A(my_callback='test A') # will be SUCCESS!
except Exception as e:
    print 'ERROR: ', e

try:
    test_func_B(callback='test B') # will be ERROR!
except Exception as e:
    print 'ERROR: ', e

try:
    test_func_C(contexts='test C') # will be ERROR!
except Exception as e:
    print 'ERROR: ', e
```

output of this example is:

```
SUCCESS (A) ! test A
ERROR:  wrapped() got multiple values for keyword argument 'callback'
ERROR:  wrapped() got multiple values for keyword argument 'contexts'
```

this simple patch -- fixes this problem

thanks! :)
