### PR TITLE
Don't set SO_REUSEADDR on Windows

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -252,9 +252,7 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128):
         af, socktype, proto, canonname, sockaddr = res
         sock = socket.socket(af, socktype, proto)
         set_close_exec(sock.fileno())
-        if os.name == 'nt':
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
-        else:
+        if os.name != 'nt':
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if af == socket.AF_INET6:
             # On linux, ipv6 sockets accept ipv4 too by default,


### PR DESCRIPTION
Windows interprets REUSEADDR differently, allowing simultaneous instances.

EDIT: SO_EXCLUSIVEADDR is an alternative, but it seems like doing nothing is actually the best choice.

closes #550
