### PR TITLE
100% CPU with SSL fix

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -654,7 +654,7 @@ class SSLIOStream(IOStream):
                 return self.close()
             raise
         except socket.error, err:
-            if err.args[0] == errno.ECONNABORTED:
+            if err.args[0] in (errno.ECONNABORTED, errno.ECONNRESET):
                 return self.close()
         else:
             self._ssl_accepting = False


### PR DESCRIPTION
When some connection was reset Tornado started to use 100% of CPU. That was caused by not closed socket which constantly generated socket.error with errno.ECONNRESET code instead handled errno.ECONNABORTED.

Platform the error detected: windows. However other platforms probably affected too.
