### PR TITLE
Add ability to get/set HTTP response reason phrase in RequestHandler and HTTPResponse

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -331,11 +331,13 @@ class HTTPResponse(object):
 
     * code: numeric HTTP status code, e.g. 200 or 404
 
+    * reason: human-readable reason phrase describing the status code
+
     * headers: httputil.HTTPHeaders object
 
     * buffer: cStringIO object for response body
 
-    * body: respose body as string (created on demand from self.buffer)
+    * body: response body as string (created on demand from self.buffer)
 
     * error: Exception object, if any
 
@@ -347,11 +349,12 @@ class HTTPResponse(object):
         plus 'queue', which is the delay (if any) introduced by waiting for
         a slot under AsyncHTTPClient's max_clients setting.
     """
-    def __init__(self, request, code, headers=None, buffer=None,
+    def __init__(self, request, code, reason=None, headers=None, buffer=None,
                  effective_url=None, error=None, request_time=None,
                  time_info=None):
         self.request = request
         self.code = code
+        self.reason = reason
         if headers is not None:
             self.headers = headers
         else:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -333,9 +333,10 @@ class _HTTPConnection(object):
     def _on_headers(self, data):
         data = native_str(data.decode("latin1"))
         first_line, _, header_data = data.partition("\n")
-        match = re.match("HTTP/1.[01] ([0-9]+)", first_line)
+        match = re.match("HTTP/1.[01] ([0-9]+) ([^\r]*)", first_line)
         assert match
         self.code = int(match.group(1))
+        self.reason = match.group(2)
         self.headers = HTTPHeaders.parse(header_data)
 
         if "Content-Length" in self.headers:
@@ -426,7 +427,8 @@ class _HTTPConnection(object):
         else:
             buffer = BytesIO(data)  # TODO: don't require one big string?
         response = HTTPResponse(original_request,
-                                self.code, headers=self.headers,
+                                self.code, reason=self.reason,
+                                headers=self.headers,
                                 request_time=time.time() - self.start_time,
                                 buffer=buffer,
                                 effective_url=self.request.url)

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -114,8 +114,10 @@ class WSGIApplication(web.Application):
     def __call__(self, environ, start_response):
         handler = web.Application.__call__(self, HTTPRequest(environ))
         assert handler._finished
-        status = str(handler._status_code) + " " + \
-            httplib.responses[handler._status_code]
+        reason = handler._reason
+        if reason is None:
+            reason = httplib.responses[handler._status_code]
+        status = str(handler._status_code) + " " + reason
         headers = handler._headers.items() + handler._list_headers
         if hasattr(handler, "_new_cookie"):
             for cookie in handler._new_cookie.values():


### PR DESCRIPTION
Loosens the requirement that status codes be RFC2616-standard, if a reason phrase is provided.

Tests added.
