### PR TITLE
return None when a secure-cookie is forged

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2046,6 +2046,7 @@ def decode_signed_value(secret, name, value, max_age_days=31):
         return None
     if parts[1].startswith(b("0")):
         logging.warning("Tampered cookie %r", value)
+        return None
     try:
         return base64.b64decode(parts[0])
     except Exception:


### PR DESCRIPTION
A very simple bug fixing!

It seems one forgot to return None when a secure-cookie is forged -- where the timestamp starts with a "0" -- in the function "decode_signed_value", a mechanism designed to defeat the following forgery:

"TWFu0000|1341271759|02233ed3df447a08059ccb6e4fd0d19797b3e435" forges as 
"TWFu|00001341271759|02233ed3df447a08059ccb6e4fd0d19797b3e435" 

Note that, the fixing does not change the logic of this function but makes the "returns" more consistency.
