### PR TITLE
[trivial] Output a peer name to log message on ssl errors

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -653,7 +653,7 @@ class SSLIOStream(IOStream):
                 try:
                     peer = self.socket.getpeername()
                 except:
-                    peer = 'not connected'
+                    peer = '(not connected)'
                 logging.warning("SSL Error on %d %s: %s",
                                 self.socket.fileno(), peer, err)
                 return self.close()


### PR DESCRIPTION
It is uniformative to have only fd number in log records on such errors.
