### PR TITLE
Fixed and added regression test for an IOStream bug that was introduced in 2.3

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -390,7 +390,7 @@ class IOStream(object):
             self._pending_callbacks -= 1
         if self._read_from_buffer():
             return
-        self._add_io_state(self.io_loop.READ)
+        self._maybe_add_error_listener()
 
     def _read_from_socket(self):
         """Attempts to read from the socket.


### PR DESCRIPTION
where the IOStream._close_callback would never be
called if there were pending reads.
