### PR TITLE
use namespaced loggers instead of the root logger

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -61,6 +61,7 @@ from tornado import escape
 from tornado.httputil import url_concat
 from tornado.util import bytes_type, b
 
+log = logging.getLogger('tornado')
 
 class OpenIdMixin(object):
     """Abstract implementation of OpenID and Attribute Exchange.
@@ -150,7 +151,7 @@ class OpenIdMixin(object):
 
     def _on_authentication_verified(self, callback, response):
         if response.error or b("is_valid:true") not in response.body:
-            logging.warning("Invalid OpenID response: %s", response.error or
+            log.warning("Invalid OpenID response: %s", response.error or
                             response.body)
             callback(None)
             return
@@ -260,14 +261,14 @@ class OAuthMixin(object):
         oauth_verifier = self.get_argument("oauth_verifier", None)
         request_cookie = self.get_cookie("_oauth_request_token")
         if not request_cookie:
-            logging.warning("Missing OAuth request token cookie")
+            log.warning("Missing OAuth request token cookie")
             callback(None)
             return
         self.clear_cookie("_oauth_request_token")
         cookie_key, cookie_secret = [base64.b64decode(escape.utf8(i)) for i in request_cookie.split("|")]
         if cookie_key != request_key:
-            logging.info((cookie_key, request_key, request_cookie))
-            logging.warning("Request token does not match cookie")
+            log.info((cookie_key, request_key, request_cookie))
+            log.warning("Request token does not match cookie")
             callback(None)
             return
         token = dict(key=cookie_key, secret=cookie_secret)
@@ -340,7 +341,7 @@ class OAuthMixin(object):
 
     def _on_access_token(self, callback, response):
         if response.error:
-            logging.warning("Could not fetch access token")
+            log.warning("Could not fetch access token")
             callback(None)
             return
 
@@ -539,7 +540,7 @@ class TwitterMixin(OAuthMixin):
 
     def _on_twitter_request(self, callback, response):
         if response.error:
-            logging.warning("Error response %s fetching %s", response.error,
+            log.warning("Error response %s fetching %s", response.error,
                             response.request.url)
             callback(None)
             return
@@ -661,7 +662,7 @@ class FriendFeedMixin(OAuthMixin):
 
     def _on_friendfeed_request(self, callback, response):
         if response.error:
-            logging.warning("Error response %s fetching %s", response.error,
+            log.warning("Error response %s fetching %s", response.error,
                             response.request.url)
             callback(None)
             return
@@ -922,17 +923,17 @@ class FacebookMixin(object):
 
     def _parse_response(self, callback, response):
         if response.error:
-            logging.warning("HTTP error from Facebook: %s", response.error)
+            log.warning("HTTP error from Facebook: %s", response.error)
             callback(None)
             return
         try:
             json = escape.json_decode(response.body)
         except Exception:
-            logging.warning("Invalid JSON from Facebook: %r", response.body)
+            log.warning("Invalid JSON from Facebook: %r", response.body)
             callback(None)
             return
         if isinstance(json, dict) and json.get("error_code"):
-            logging.warning("Facebook error: %d: %r", json["error_code"],
+            log.warning("Facebook error: %d: %r", json["error_code"],
                             json.get("error_msg"))
             callback(None)
             return
@@ -975,7 +976,7 @@ class FacebookGraphMixin(OAuth2Mixin):
                                           extra_params={"scope": "read_stream,offline_access"})
 
               def _on_login(self, user):
-                logging.error(user)
+                log.error(user)
                 self.finish()
 
         """
@@ -999,7 +1000,7 @@ class FacebookGraphMixin(OAuth2Mixin):
     def _on_access_token(self, redirect_uri, client_id, client_secret,
                         callback, fields, response):
         if response.error:
-            logging.warning('Facebook auth error: %s' % str(response))
+            log.warning('Facebook auth error: %s' % str(response))
             callback(None)
             return
 
@@ -1082,7 +1083,7 @@ class FacebookGraphMixin(OAuth2Mixin):
 
     def _on_facebook_request(self, callback, response):
         if response.error:
-            logging.warning("Error response %s fetching %s", response.error,
+            log.warning("Error response %s fetching %s", response.error,
                             response.request.url)
             callback(None)
             return

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -82,6 +82,7 @@ try:
 except ImportError:
     signal = None
 
+log = logging.getLogger('tornado')
 
 def start(io_loop=None, check_time=500):
     """Restarts the process automatically when a module is modified.
@@ -177,7 +178,7 @@ def _check_file(modify_times, path):
         modify_times[path] = modified
         return
     if modify_times[path] != modified:
-        logging.info("%s modified; restarting server", path)
+        log.info("%s modified; restarting server", path)
         _reload()
 
 
@@ -272,13 +273,13 @@ def main():
                 # module) will see the right things.
                 exec f.read() in globals(), globals()
     except SystemExit, e:
-        logging.info("Script exited with status %s", e.code)
+        log.info("Script exited with status %s", e.code)
     except Exception, e:
-        logging.warning("Script exited with uncaught exception", exc_info=True)
+        log.warning("Script exited with uncaught exception", exc_info=True)
         if isinstance(e, SyntaxError):
             watch(e.filename)
     else:
-        logging.info("Script exited normally")
+        log.info("Script exited normally")
     # restore sys.argv so subsequent executions will include autoreload
     sys.argv = original_argv
 

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -32,6 +32,7 @@ from tornado import stack_context
 from tornado.escape import utf8
 from tornado.httpclient import HTTPRequest, HTTPResponse, HTTPError, AsyncHTTPClient, main
 
+log = logging.getLogger('tornado')
 
 class CurlAsyncHTTPClient(AsyncHTTPClient):
     def initialize(self, io_loop=None, max_clients=10,
@@ -53,7 +54,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             # socket_action is found in pycurl since 7.18.2 (it's been
             # in libcurl longer than that but wasn't accessible to
             # python).
-            logging.warning("socket_action method missing from pycurl; "
+            log.warning("socket_action method missing from pycurl; "
                             "falling back to socket_all. Upgrading "
                             "libcurl and pycurl will improve performance")
             self._socket_action = \
@@ -389,11 +390,11 @@ def _curl_setup_request(curl, request, buffer, headers):
         userpwd = "%s:%s" % (request.auth_username, request.auth_password or '')
         curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_BASIC)
         curl.setopt(pycurl.USERPWD, utf8(userpwd))
-        logging.debug("%s %s (username: %r)", request.method, request.url,
+        log.debug("%s %s (username: %r)", request.method, request.url,
                       request.auth_username)
     else:
         curl.unsetopt(pycurl.USERPWD)
-        logging.debug("%s %s", request.method, request.url)
+        log.debug("%s %s", request.method, request.url)
 
     if request.client_cert is not None:
         curl.setopt(pycurl.SSLCERT, request.client_cert)
@@ -429,12 +430,12 @@ def _curl_header_callback(headers, header_line):
 def _curl_debug(debug_type, debug_msg):
     debug_types = ('I', '<', '>', '<', '>')
     if debug_type == 0:
-        logging.debug('%s', debug_msg.strip())
+        log.debug('%s', debug_msg.strip())
     elif debug_type in (1, 2):
         for line in debug_msg.splitlines():
-            logging.debug('%s %s', debug_types[debug_type], line)
+            log.debug('%s %s', debug_types[debug_type], line)
     elif debug_type == 4:
-        logging.debug('%s %r', debug_types[debug_type], debug_msg)
+        log.debug('%s %r', debug_types[debug_type], debug_msg)
 
 if __name__ == "__main__":
     AsyncHTTPClient.configure(CurlAsyncHTTPClient)

--- a/tornado/database.py
+++ b/tornado/database.py
@@ -33,6 +33,7 @@ except ImportError:
     # which has limitations on third-party modules)
     MySQLdb = None
 
+log = logging.getLogger('tornado')
 
 class Connection(object):
     """A lightweight wrapper around MySQLdb DB-API connections.
@@ -83,7 +84,7 @@ class Connection(object):
         try:
             self.reconnect()
         except Exception:
-            logging.error("Cannot connect to MySQL on %s", self.host,
+            log.error("Cannot connect to MySQL on %s", self.host,
                           exc_info=True)
 
     def __del__(self):
@@ -207,7 +208,7 @@ class Connection(object):
         try:
             return cursor.execute(query, parameters)
         except OperationalError:
-            logging.error("Error connecting to MySQL on %s", self.host)
+            log.error("Error connecting to MySQL on %s", self.host)
             self.close()
             raise
 

--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -43,6 +43,7 @@ try:
 except ImportError:
     ssl = None
 
+log = logging.getLogger('tornado')
 
 class HTTPServer(TCPServer):
     r"""A non-blocking, single-threaded HTTP server.
@@ -261,7 +262,7 @@ class HTTPConnection(object):
 
             self.request_callback(self._request)
         except _BadRequestException, e:
-            logging.info("Malformed HTTP request from %s: %s",
+            log.info("Malformed HTTP request from %s: %s",
                          self.address[0], e)
             self.stream.close()
             return

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -25,6 +25,7 @@ import re
 from tornado.escape import native_str, parse_qs_bytes, utf8
 from tornado.util import b, ObjectDict
 
+log = logging.getLogger('tornado')
 
 class HTTPHeaders(dict):
     """A dictionary that maintains Http-Header-Case for all keys.
@@ -221,7 +222,7 @@ def parse_body_arguments(content_type, body, arguments, files):
                 parse_multipart_form_data(utf8(v), body, arguments, files)
                 break
         else:
-            logging.warning("Invalid multipart/form-data")
+            log.warning("Invalid multipart/form-data")
 
 
 def parse_multipart_form_data(boundary, data, arguments, files):
@@ -240,7 +241,7 @@ def parse_multipart_form_data(boundary, data, arguments, files):
         boundary = boundary[1:-1]
     final_boundary_index = data.rfind(b("--") + boundary + b("--"))
     if final_boundary_index == -1:
-        logging.warning("Invalid multipart/form-data: no final boundary")
+        log.warning("Invalid multipart/form-data: no final boundary")
         return
     parts = data[:final_boundary_index].split(b("--") + boundary + b("\r\n"))
     for part in parts:
@@ -248,17 +249,17 @@ def parse_multipart_form_data(boundary, data, arguments, files):
             continue
         eoh = part.find(b("\r\n\r\n"))
         if eoh == -1:
-            logging.warning("multipart/form-data missing headers")
+            log.warning("multipart/form-data missing headers")
             continue
         headers = HTTPHeaders.parse(part[:eoh].decode("utf-8"))
         disp_header = headers.get("Content-Disposition", "")
         disposition, disp_params = _parse_header(disp_header)
         if disposition != "form-data" or not part.endswith(b("\r\n")):
-            logging.warning("Invalid multipart/form-data")
+            log.warning("Invalid multipart/form-data")
             continue
         value = part[eoh + 4:-2]
         if not disp_params.get("name"):
-            logging.warning("multipart/form-data value missing name")
+            log.warning("multipart/form-data value missing name")
             continue
         name = disp_params["name"]
         if disp_params.get("filename"):

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -48,6 +48,7 @@ except ImportError:
 
 from tornado.platform.auto import set_close_exec, Waker
 
+log = logging.getLogger('tornado')
 
 class IOLoop(object):
     """A level-triggered I/O loop.
@@ -191,7 +192,7 @@ class IOLoop(object):
                 try:
                     os.close(fd)
                 except Exception:
-                    logging.debug("error closing fd %s", fd, exc_info=True)
+                    log.debug("error closing fd %s", fd, exc_info=True)
         self._waker.close()
         self._impl.close()
 
@@ -211,7 +212,7 @@ class IOLoop(object):
         try:
             self._impl.unregister(fd)
         except (OSError, IOError):
-            logging.debug("Error deleting fd from IOLoop", exc_info=True)
+            log.debug("Error deleting fd from IOLoop", exc_info=True)
 
     def set_blocking_signal_threshold(self, seconds, action):
         """Sends a signal if the ioloop is blocked for more than s seconds.
@@ -225,7 +226,7 @@ class IOLoop(object):
         too long.
         """
         if not hasattr(signal, "setitimer"):
-            logging.error("set_blocking_signal_threshold requires a signal module "
+            log.error("set_blocking_signal_threshold requires a signal module "
                        "with the setitimer method")
             return
         self._blocking_signal_threshold = seconds
@@ -244,7 +245,7 @@ class IOLoop(object):
 
         For use with set_blocking_signal_threshold.
         """
-        logging.warning('IOLoop blocked for %f seconds in\n%s',
+        log.warning('IOLoop blocked for %f seconds in\n%s',
                         self._blocking_signal_threshold,
                         ''.join(traceback.format_stack(frame)))
 
@@ -254,6 +255,11 @@ class IOLoop(object):
         The loop will run until one of the I/O handlers calls stop(), which
         will make the loop stop after the current event iteration completes.
         """
+        # don't start without some log handling enabled
+        if len(logging.getLogger().handlers) == 0:
+            logging.basicConfig()
+            # we could also use tornado.options.enable_pretty_logging()
+
         if self._stopped:
             self._stopped = False
             return
@@ -330,10 +336,10 @@ class IOLoop(object):
                         # Happens when the client closes the connection
                         pass
                     else:
-                        logging.error("Exception in I/O handler for fd %s",
+                        log.error("Exception in I/O handler for fd %s",
                                       fd, exc_info=True)
                 except Exception:
-                    logging.error("Exception in I/O handler for fd %s",
+                    log.error("Exception in I/O handler for fd %s",
                                   fd, exc_info=True)
         # reset the stopped flag so another start/stop pair can be issued
         self._stopped = False
@@ -432,7 +438,7 @@ class IOLoop(object):
         The exception itself is not passed explicitly, but is available
         in sys.exc_info.
         """
-        logging.error("Exception in callback %r", callback, exc_info=True)
+        log.error("Exception in callback %r", callback, exc_info=True)
 
 
 class _Timeout(object):
@@ -501,7 +507,7 @@ class PeriodicCallback(object):
         try:
             self.callback()
         except Exception:
-            logging.error("Error in periodic callback", exc_info=True)
+            log.error("Error in periodic callback", exc_info=True)
         self._schedule_next()
 
     def _schedule_next(self):
@@ -668,5 +674,5 @@ else:
         # All other systems
         import sys
         if "linux" in sys.platform:
-            logging.warning("epoll module not found; using select()")
+            log.warning("epoll module not found; using select()")
         _poll = _Select

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -54,6 +54,7 @@ _translations = {}
 _supported_locales = frozenset([_default_locale])
 _use_gettext = False
 
+log = logging.getLogger('tornado')
 
 def get(*locale_codes):
     """Returns the closest match for the given locale codes.
@@ -118,7 +119,7 @@ def load_translations(directory):
             continue
         locale, extension = path.split(".")
         if not re.match("[a-z]+(_[A-Z]+)?$", locale):
-            logging.error("Unrecognized locale %r (path: %s)", locale,
+            log.error("Unrecognized locale %r (path: %s)", locale,
                           os.path.join(directory, path))
             continue
         full_path = os.path.join(directory, path)
@@ -142,13 +143,13 @@ def load_translations(directory):
             else:
                 plural = "unknown"
             if plural not in ("plural", "singular", "unknown"):
-                logging.error("Unrecognized plural indicator %r in %s line %d",
+                log.error("Unrecognized plural indicator %r in %s line %d",
                               plural, path, i + 1)
                 continue
             _translations[locale].setdefault(plural, {})[english] = translation
         f.close()
     _supported_locales = frozenset(_translations.keys() + [_default_locale])
-    logging.debug("Supported locales: %s", sorted(_supported_locales))
+    log.debug("Supported locales: %s", sorted(_supported_locales))
 
 
 def load_gettext_translations(directory, domain):
@@ -184,11 +185,11 @@ def load_gettext_translations(directory, domain):
             _translations[lang] = gettext.translation(domain, directory,
                                                       languages=[lang])
         except Exception, e:
-            logging.error("Cannot load translation for '%s': %s", lang, str(e))
+            log.error("Cannot load translation for '%s': %s", lang, str(e))
             continue
     _supported_locales = frozenset(_translations.keys() + [_default_locale])
     _use_gettext = True
-    logging.debug("Supported locales: %s", sorted(_supported_locales))
+    log.debug("Supported locales: %s", sorted(_supported_locales))
 
 
 def get_supported_locales():

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -34,6 +34,7 @@ try:
 except ImportError:
     ssl = None
 
+log = logging.getLogger('tornado')
 
 class TCPServer(object):
     r"""A non-blocking, single-threaded TCP server.
@@ -234,7 +235,7 @@ class TCPServer(object):
                 stream = IOStream(connection, io_loop=self.io_loop)
             self.handle_stream(stream, address)
         except Exception:
-            logging.error("Error in connection callback", exc_info=True)
+            log.error("Error in connection callback", exc_info=True)
 
 
 def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128):

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -63,6 +63,7 @@ import tornado.ioloop
 from tornado.stack_context import NullContext
 from tornado.ioloop import IOLoop
 
+logger = logging.getLogger(__name__)
 
 class TornadoDelayedCall(object):
     """DelayedCall object for Tornado."""
@@ -80,7 +81,7 @@ class TornadoDelayedCall(object):
         try:
             self._func()
         except:
-            logging.error("_called caught exception", exc_info=True)
+            logger.error("_called caught exception", exc_info=True)
 
     def getTime(self):
         return self._time

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -33,6 +33,7 @@ try:
 except ImportError:
     multiprocessing = None
 
+log = logging.getLogger('tornado')
 
 def cpu_count():
     """Returns the number of processors on this machine."""
@@ -45,7 +46,7 @@ def cpu_count():
         return os.sysconf("SC_NPROCESSORS_CONF")
     except ValueError:
         pass
-    logging.error("Could not detect number of processors; assuming 1")
+    log.error("Could not detect number of processors; assuming 1")
     return 1
 
 
@@ -98,7 +99,7 @@ def fork_processes(num_processes, max_restarts=100):
         raise RuntimeError("Cannot run in multiple processes: IOLoop instance "
                            "has already been initialized. You cannot call "
                            "IOLoop.instance() before calling start_processes()")
-    logging.info("Starting %d processes", num_processes)
+    log.info("Starting %d processes", num_processes)
     children = {}
 
     def start_child(i):
@@ -128,13 +129,13 @@ def fork_processes(num_processes, max_restarts=100):
             continue
         id = children.pop(pid)
         if os.WIFSIGNALED(status):
-            logging.warning("child %d (pid %d) killed by signal %d, restarting",
+            log.warning("child %d (pid %d) killed by signal %d, restarting",
                             id, pid, os.WTERMSIG(status))
         elif os.WEXITSTATUS(status) != 0:
-            logging.warning("child %d (pid %d) exited with status %d, restarting",
+            log.warning("child %d (pid %d) exited with status %d, restarting",
                             id, pid, os.WEXITSTATUS(status))
         else:
-            logging.info("child %d (pid %d) exited normally", id, pid)
+            log.info("child %d (pid %d) exited normally", id, pid)
             continue
         num_restarts += 1
         if num_restarts > max_restarts:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -33,6 +33,7 @@ except ImportError:
 
 _DEFAULT_CA_CERTS = os.path.dirname(__file__) + '/ca-certificates.crt'
 
+log = logging.getLogger('tornado')
 
 class SimpleAsyncHTTPClient(AsyncHTTPClient):
     """Non-blocking HTTP client with no external dependencies.
@@ -101,7 +102,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         self.queue.append((request, callback))
         self._process_queue()
         if self.queue:
-            logging.debug("max_clients limit reached, request queued. "
+            log.debug("max_clients limit reached, request queued. "
                           "%d active, %d queued requests." % (
                     len(self.active), len(self.queue)))
 
@@ -319,7 +320,7 @@ class _HTTPConnection(object):
         try:
             yield
         except Exception, e:
-            logging.warning("uncaught exception", exc_info=True)
+            log.warning("uncaught exception", exc_info=True)
             self._run_callback(HTTPResponse(self.request, 599, error=e,
                                 request_time=time.time() - self.start_time,
                                 ))

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -196,6 +196,7 @@ from tornado.util import bytes_type, ObjectDict
 _DEFAULT_AUTOESCAPE = "xhtml_escape"
 _UNSET = object()
 
+log = logging.getLogger('tornado')
 
 class Template(object):
     """A compiled template.
@@ -229,7 +230,7 @@ class Template(object):
                 "exec")
         except Exception:
             formatted_code = _format_code(self.code).rstrip()
-            logging.error("%s code:\n%s", self.name, formatted_code)
+            log.error("%s code:\n%s", self.name, formatted_code)
             raise
 
     def generate(self, **kwargs):
@@ -261,7 +262,7 @@ class Template(object):
             return execute()
         except Exception:
             formatted_code = _format_code(self.code).rstrip()
-            logging.error("%s code:\n%s", self.name, formatted_code)
+            log.error("%s code:\n%s", self.name, formatted_code)
             raise
 
     def _generate_python(self, loader, compress_whitespace):

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -32,6 +32,7 @@ import tornado.web
 
 from tornado.util import bytes_type, b
 
+log = logging.getLogger('tornado')
 
 class WebSocketHandler(tornado.web.RequestHandler):
     """Subclass this class to create a basic WebSocket handler.
@@ -257,7 +258,7 @@ class WebSocketProtocol(object):
             try:
                 return callback(*args, **kwargs)
             except Exception:
-                logging.error("Uncaught exception in %s",
+                log.error("Uncaught exception in %s",
                               self.request.path, exc_info=True)
                 self._abort()
         return wrapper
@@ -289,7 +290,7 @@ class WebSocketProtocol76(WebSocketProtocol):
         try:
             self._handle_websocket_headers()
         except ValueError:
-            logging.debug("Malformed WebSocket request received")
+            log.debug("Malformed WebSocket request received")
             self._abort()
             return
 
@@ -344,7 +345,7 @@ class WebSocketProtocol76(WebSocketProtocol):
         try:
             challenge_response = self.challenge_response(challenge)
         except ValueError:
-            logging.debug("Malformed key data in WebSocket request")
+            log.debug("Malformed key data in WebSocket request")
             self._abort()
             return
         self._write_response(challenge_response)
@@ -457,7 +458,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             self._handle_websocket_headers()
             self._accept_connection()
         except ValueError:
-            logging.debug("Malformed WebSocket request received")
+            log.debug("Malformed WebSocket request received")
             self._abort()
             return
 

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -50,6 +50,7 @@ try:
 except ImportError:
     from cStringIO import StringIO as BytesIO  # python 2
 
+log = logging.getLogger('tornado')
 
 # PEP 3333 specifies that WSGI on python 3 generally deals with byte strings
 # that are smuggled inside objects of type unicode (via the latin1 encoding).
@@ -302,11 +303,11 @@ class WSGIContainer(object):
 
     def _log(self, status_code, request):
         if status_code < 400:
-            log_method = logging.info
+            log_method = log.info
         elif status_code < 500:
-            log_method = logging.warning
+            log_method = log.warning
         else:
-            log_method = logging.error
+            log_method = log.error
         request_time = 1000.0 * request.request_time()
         summary = request.method + " " + request.uri + " (" + \
             request.remote_ip + ")"


### PR DESCRIPTION
Pull requests are working again for me :-)

This is the patch from #53, specifically the version that logs to `logging.getLogger('tornado')` everywhere.
