### PR TITLE
There's no way to JSON encode/decode custom object types

### DIFF
--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -79,7 +79,7 @@ def xhtml_unescape(value):
     return re.sub(r"&(#?)(\w+?);", _convert_entity, _unicode(value))
 
 
-def json_encode(value):
+def json_encode(value, default):
     """JSON-encodes the given Python object."""
     # JSON permits but does not require forward slashes to be escaped.
     # This is useful when json data is emitted in a <script> tag
@@ -87,7 +87,7 @@ def json_encode(value):
     # the javscript.  Some json libraries do this escaping by default,
     # although python's standard library does not, so we do it here.
     # http://stackoverflow.com/questions/1580647/json-why-are-forward-slashes-escaped
-    return _json_encode(recursive_unicode(value)).replace("</", "<\\/")
+    return _json_encode(recursive_unicode(value), default=default).replace("</", "<\\/")
 
 
 def json_decode(value):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -488,7 +488,9 @@ class RequestHandler(object):
                                "by using async operations without the "
                                "@asynchronous decorator.")
         if isinstance(chunk, dict):
-            chunk = escape.json_encode(chunk)
+            settings = self.application.settings
+            default = settings.get('json_default', None)
+            chunk = escape.json_encode(chunk, default)
             self.set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = utf8(chunk)
         self._write_buffer.append(chunk)


### PR DESCRIPTION
These changes are related to issue #566, and provide the means for providing a "default" method that will be passed on when json-encoding objects.
