### PR TITLE
Adding super(...).__init__ in web.py

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -105,6 +105,8 @@ class RequestHandler(object):
     _template_loader_lock = threading.Lock()
 
     def __init__(self, application, request, **kwargs):
+        super(RequestHandler, self).__init__()
+        
         self.application = application
         self.request = request
         self._headers_written = False


### PR DESCRIPTION
When using multiple class extending, all super classes need to execute super(..).**init**.py as well, otherwise not all **init** methods will be executed.

Example:
from tornado import web

class A(object):
  def **init**(self, _args, *_kwargs):
    super(A, self).**init**(_args, *_kwargs)

class B(object):
  def **init**(self, _args, *_kwargs):
    super(B, self).**init**(_args, *_kwargs)

class BaseHandler(web.RequestHandler, A, B):
  def **init**(self, _args, *_kwargs):
    super(BaseHandler, self).**init**(_args, *_kwargs)

without calling super(...).**init**() in RequestHandler, neither A.**init** nor B.**init** will be executed.
