### PR TITLE
Allow 'oob' as a callback_uri per OAuth spec section 2.1

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -289,7 +289,9 @@ class OAuthMixin(object):
             oauth_version=getattr(self, "_OAUTH_VERSION", "1.0a"),
         )
         if getattr(self, "_OAUTH_VERSION", "1.0a") == "1.0a":
-            if callback_uri:
+            if callback_uri == "oob":
+                args["oauth_callback"] = "oob"
+            elif callback_uri:
                 args["oauth_callback"] = urlparse.urljoin(
                     self.request.full_url(), callback_uri)
             if extra_params:


### PR DESCRIPTION
OAuth spec allows for 'oob' as a value for oauth_callback.

This change allows for this to pass through rather than being concatenated into an actual URL

http://tools.ietf.org/html/draft-hammer-oauth-08#section-2.1
