### PR TITLE
use hostnames and ports in warnings

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1449,9 +1449,10 @@ class Application(object):
         else:
             log_method = logging.error
         request_time = 1000.0 * handler.request.request_time()
-        error_msg = "%d %s %%.2fms" % (handler.get_status(),
+        error_msg = "%d %s" % (handler.get_status(),
                                        handler._request_summary())
-        log_method(error_msg, request_time)
+        error_msg = error_msg.replace('%', '%%')
+        log_method(error_msg + " %.2fms", request_time)
 
 
 class HTTPError(Exception):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1449,8 +1449,9 @@ class Application(object):
         else:
             log_method = logging.error
         request_time = 1000.0 * handler.request.request_time()
-        log_method("%d %s %.2fms", handler.get_status(),
-                   handler._request_summary(), request_time)
+        error_msg = "%d %s %%.2fms" % (handler.get_status(),
+                                       handler._request_summary())
+        log_method(error_msg, request_time)
 
 
 class HTTPError(Exception):


### PR DESCRIPTION
instead of just file descriptor numbers. the address is stored on connect attempt, so even if the connect was unsuccessful we'll have the address of the attempted remote. compatible with at least AF_INET and AF_INET6
