### PR TITLE
Allow 'oob' as a callback_uri per OAuth spec section 2.1

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -289,7 +289,9 @@ class OAuthMixin(object):
             oauth_version=getattr(self, "_OAUTH_VERSION", "1.0a"),
         )
         if getattr(self, "_OAUTH_VERSION", "1.0a") == "1.0a":
-            if callback_uri:
+            if callback_uri == "oob":
+                args["oauth_callback"] = "oob"
+            elif callback_uri:
                 args["oauth_callback"] = urlparse.urljoin(
                     self.request.full_url(), callback_uri)
             if extra_params:
@@ -309,7 +311,10 @@ class OAuthMixin(object):
                 base64.b64encode(request_token["secret"]))
         self.set_cookie("_oauth_request_token", data)
         args = dict(oauth_token=request_token["key"])
-        if callback_uri:
+        if callback_uri == "oob":
+            self.finish(authorize_url + "?" + urllib.urlencode(args)) 
+            return
+        elif callback_uri:
             args["oauth_callback"] = urlparse.urljoin(
                 self.request.full_url(), callback_uri)
         self.redirect(authorize_url + "?" + urllib.urlencode(args))


### PR DESCRIPTION
reopening based on: https://github.com/facebook/tornado/pull/570

changes to allow 'Out of Band' OAuth.

example usage as modified from existing documentation:
## server-side

``` python
class TwitterHandler(tornado.web.RequestHandler,
                     tornado.auth.TwitterMixin):
    @tornado.web.asynchronous
    def get(self):
        if self.get_argument("oauth_token", None):
            self.get_authenticated_user(self.async_callback(self._on_auth))
            return
        if self.get_argument("oob", None):
            self.authorize_redirect(callback_uri="oob")
        else:
            self.authorize_redirect(callback_uri=self.request.full_url())

    def _on_auth(self, user):
        if not user:
            raise tornado.web.HTTPError(500, "Twitter auth failed")
        # Save the user using, e.g., set_secure_cookie()
```
## client

``` python
import urllib
import urllib2
import urlparse
import cookielib

class HTTPConnector:

    def __init__(self):
        self.cj = cookielib.CookieJar()
        self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cj))

    def make_request(self, url, data=None):
        if data:
            encoded_data = urllib.urlencode(data)
            return self.opener.open(url, encoded_data)
        return self.opener.open(url)

conn = HTTPConnector()
resp = conn.make_request("%s/signin?oob=true" % "http://localhost:8887")
oob_url = resp.read()
query_string = urlparse.urlparse(oob_url)[4]
oauth_token = urlparse.parse_qs(query_string)['oauth_token'][0]
print "Navigate to this URL and return with the pin:\n%s" % oob_url
pin = raw_input("pin?: ")
resp = conn.make_request("%s/signin?oauth_token=%s&oauth_verifier=%s" % ("http://localhost:8887", oauth_token, pin))
print resp.read()
```
