### PR TITLE
tornado.platform.twisted shutdown sequence

### DIFF
--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -281,7 +281,8 @@ class TornadoReactor(PosixReactorBase):
     # IOLoop.start() instead of Reactor.run().
     def stop(self):
         PosixReactorBase.stop(self)
-        self.fireSystemEvent("shutdown")
+        fire_shutdown = functools.partial(self.fireSystemEvent,"shutdown")
+        self._io_loop.add_callback(fire_shutdown)
 
     def crash(self):
         PosixReactorBase.crash(self)

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -196,6 +196,9 @@ class Reader(object):
     def fileno(self):
         return self._fd.fileno()
 
+    def readConnectionLost(self, reason):
+        self.close()
+
     def connectionLost(self, reason):
         self.close()
 


### PR DESCRIPTION
Twisted reactor should be stopped only in 'during' phase of shutdown event.
Current behavior causes hang on shutdown if any of event handlers in 'before' phase return Deferred (twisted.application.service.MultiService as an example) and reactor's thread pool is initialized.
This patch fixes it.
