### PR TITLE
Call `self.write` with a list

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -489,7 +489,7 @@ class RequestHandler(object):
             raise RuntimeError("Cannot write() after finish().  May be caused "
                                "by using async operations without the "
                                "@asynchronous decorator.")
-        if isinstance(chunk, dict):
+        if isinstance(chunk, dict) or isinstance(chunk, list):
             chunk = escape.json_encode(chunk)
             self.set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = utf8(chunk)


### PR DESCRIPTION
`self.write` throws AssertionError if you pass it a list. I found this when trying to return data to a jQuery autocomplete from Tornado. It seems like such a simple fix so I can't help but wonder if this was done on purpose? Is there a reason lists couldn't be passed to write?
