### PR TITLE
simple_httpclient: Improved connection error messages

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -328,7 +328,10 @@ class _HTTPConnection(object):
 
     def _on_close(self):
         if self.final_callback is not None:
-            raise HTTPError(599, "Connection closed")
+            message = "Connection closed"
+            if self.stream.error:
+                message = str(self.stream.error)
+            raise HTTPError(599, message)
 
     def _on_headers(self, data):
         data = native_str(data.decode("latin1"))

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -283,6 +283,12 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, LogTrapTestCase):
         response = self.wait()
         self.assertTrue(host_re.match(response.body), response.body)
 
+    def test_connection_refused(self):
+        self.http_client.fetch("http://localhost:1/", self.stop)
+        response = self.wait()
+        self.assertEqual(599, response.code)
+        self.assertIn("Connection refused", str(response.error))
+
 
 class CreateAsyncHTTPClientTestCase(AsyncTestCase, LogTrapTestCase):
     def setUp(self):


### PR DESCRIPTION
Previously, simple_httpclient reported "Connection closed" for everything. This confused me into thinking that my service was closing the connection in the middle of doing something, when in fact I had a dumb configuration error and it was actually getting "connection refused."

This change adds the exception info: HTTP 599: [Errno 61] Connection refused

Feel free to reject this, or maybe I should change it to only have error.strerror, which would look like:

HTTP 599: Connection refused
