### PR TITLE
Added gen.task decorator

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -125,6 +125,27 @@ def engine(func):
     return wrapper
 
 
+def task(func):
+    """Decorator applying Task interface to the function.
+
+    It is shortcut to simplify usage of ``gen.Task``. If function only be used
+    through Task interface, then it can be decorated with ``gen.task`` decorator
+    and then used with yield directly:
+
+        @gen.task
+        def func(name, callback):
+            callback('Hello, %s!' % name)
+
+        result = yield func(*args, **kwargs)
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return Task(func, *args, **kwargs)
+
+    return wrapper
+
+
 class YieldPoint(object):
     """Base class for objects that may be yielded from the generator."""
     def start(self, runner):

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -153,6 +153,14 @@ class GenTest(AsyncTestCase):
             self.stop()
         self.run_gen(f)
 
+    def test_task_decorator(self):
+        @gen.engine
+        def f():
+            w = gen.task(self.io_loop.add_callback)
+            yield w()
+            self.stop()
+        self.run_gen(f)
+
     def test_wait_all(self):
         @gen.engine
         def f():

--- a/website/sphinx/gen.rst
+++ b/website/sphinx/gen.rst
@@ -8,6 +8,8 @@
 
    .. autofunction:: engine
 
+   .. autofunction:: task
+
    Yield points
    ------------
 


### PR DESCRIPTION
It provides more straightforward usage of gen.Task interface.

Example:

``` python
from functools import wraps

from tornado import gen, web 
from tornado.ioloop import IOLoop
from tornado.httpserver import HTTPServer


@gen.task
def worker(name, callback):
    callback('Hello, %s!' % name)


class MainHandler(web.RequestHandler):

    @web.asynchronous
    @gen.engine
    def get(self):
        result = yield worker('world')
        self.finish(result)


application = web.Application([
    (r"/", MainHandler),
])  

if __name__ == "__main__":
    server = HTTPServer(application)
    server.bind(8888)
    server.start(4)
    IOLoop.instance().start()
```
