### PR TITLE
Fix in python3 _oauth_signature get invalid signature problem

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -327,7 +327,7 @@ class OAuthMixin(object):
             oauth_token=request_token["key"],
             oauth_signature_method="HMAC-SHA1",
             oauth_timestamp=str(int(time.time())),
-            oauth_nonce=binascii.b2a_hex(uuid.uuid4().bytes),
+            oauth_nonce=binascii.b2a_hex(uuid.uuid4().bytes).decode('ascii'),
             oauth_version=getattr(self, "_OAUTH_VERSION", "1.0a"),
         )
         if "verifier" in request_token:
@@ -376,7 +376,7 @@ class OAuthMixin(object):
             oauth_token=access_token["key"],
             oauth_signature_method="HMAC-SHA1",
             oauth_timestamp=str(int(time.time())),
-            oauth_nonce=binascii.b2a_hex(uuid.uuid4().bytes),
+            oauth_nonce=binascii.b2a_hex(uuid.uuid4().bytes).decode('ascii'),
             oauth_version=getattr(self, "_OAUTH_VERSION", "1.0a"),
         )
         args = {}


### PR DESCRIPTION
in python3, in the following statement

```
oauth_nonce=binascii.b2a_hex(uuid.uuid4().bytes),
```

oauth_nonce 's type is bytes,
and  in function _oauth_signature and _oauth10a_signature ,the following statement

```
base_elems.append("&".join("%s=%s" % (k, _oauth_escape(str(v)))
                               for k, v in sorted(parameters.items())))
```

use _oauth_escape(str(v)),when v 's type is bytes, str() will  append b to the string

example:

```
>>> print(str(binascii.b2a_hex(uuid.uuid4().bytes)))
b'e72a84e922ac4d43a0186f1caa3c9c94'
```

so function _oauth_signature will return invalid signature

should convert oauth_nonce's type to str in python3(to unicode in python2 for compatibility)
