### PR TITLE
Do not set AI_ADDRCONFIG in netutils.bind_sockets

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -254,7 +254,8 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128, flags
     The ``backlog`` argument has the same meaning as for
     ``socket.listen()``.
 
-    ``flags`` is a bitmask of AI_* flags to ``getaddrinfo``.
+    ``flags`` is a bitmask of AI_* flags to ``getaddrinfo``, like
+    ``socket.AI_PASSIVE | socket.AI_NUMERICHOST``.
     """
     sockets = []
     if address == "":


### PR DESCRIPTION
Currently, `netutils.bind_sockets` will always pass the `AI_ADDRCONFIG` flag to `getaddrinfo`. This is justified by the comment

```
# AI_ADDRCONFIG ensures that we only try to bind on ipv6
# if the system is configured for it (...)
```

In practice, for IPv6, ["configured"](https://bugzilla.redhat.com/show_bug.cgi?id=697149) [means](https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/762512) [that](http://sourceware.org/bugzilla/show_bug.cgi?id=12377) the machine has to have one interface configured to a global address (for IPv4, link-local addresses count as well).

Therefore, `bind_sockets` fails in the common case where a system can communicate via IPv6 in a LAN (or even on the local interface) just fine, but has no global IPv6 address.

Moreover, `AI_ADDRCONFIG` is intended to be used in order to avoid having to wait for the connection timeout when _connecting_ to a dual-stack address from a setup with broken IPv6 connectivity. Here, we are _binding_ to addresses; there is no downside to binding to an IPv6 address (as well as to an IPv4 one) without global IPv6 connectivity. In fact, if the global addresses are not statically configured, this leads to a race condition where IPv6 availability depends on whether the tornado application binds its sockets before or after the global IPv6 address is assigned.

This pull request adds a `flag` parameter for `netutils.bind_sockets` that allows users to pass in flags such as `AI_NUMERICHOST` (or `AI_ADDRCONFIG`, but that's a bad idea as laid out above) should they desire to. Additionally, it removes `AI_ADDRCONFIG` from the default flags.
