### PR TITLE
Allow prepare to be async

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1058,9 +1058,9 @@ class RequestHandler(object):
             if self.request.method not in ("GET", "HEAD", "OPTIONS") and \
                self.application.settings.get("xsrf_cookies"):
                 self.check_xsrf_cookie()
+            self._method_args = ( args, kwargs )
             self.prepare()
             self._prepared = True
-            self._method_args = ( args, kwargs )
             if self._auto_run:
                 self.end_prepare()
         except Exception, e:


### PR DESCRIPTION
Allow prepare to be async using the asynchronous decorator by using a couple flags.

At the end of the async prepare users have to call self._end_prepare()
