### PR TITLE
Ensure apply block in template returns utf8

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -479,7 +479,7 @@ class _ApplyBlock(_Node):
             writer.write_line("_append = _buffer.append", self.line)
             self.body.generate(writer)
             writer.write_line("return _utf8('').join(_buffer)", self.line)
-        writer.write_line("_append(%s(%s()))" % (
+        writer.write_line("_append(_utf8(%s(%s())))" % (
             self.method, method_name), self.line)
 
 


### PR DESCRIPTION
Previously it did not return utf8 which meant built in functions
such as linkify could cause problems as well
