### PR TITLE
correctly handle empty POST parameters

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -215,9 +215,8 @@ def parse_body_arguments(content_type, body, arguments, files):
     that will be updated with the parsed contents.
     """
     if content_type.startswith("application/x-www-form-urlencoded"):
-        uri_arguments = parse_qs_bytes(native_str(body))
+        uri_arguments = parse_qs_bytes(native_str(body), keep_blank_values=True)
         for name, values in uri_arguments.iteritems():
-            values = [v for v in values if v]
             if values:
                 arguments.setdefault(name, []).extend(values)
     elif content_type.startswith("multipart/form-data"):

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -247,6 +247,8 @@ class EchoHandler(RequestHandler):
     def get(self):
         self.write(recursive_unicode(self.request.arguments))
 
+    def post(self):
+        self.write(recursive_unicode(self.request.arguments))
 
 class TypeCheckHandler(RequestHandler):
     def prepare(self):
@@ -299,6 +301,11 @@ class HTTPServerTest(AsyncHTTPTestCase, LogTrapTestCase):
         response = self.fetch("/echo?foo=%C3%A9")
         data = json_decode(response.body)
         self.assertEqual(data, {u"foo": [u"\u00e9"]})
+
+    def test_empty_post_parameters(self):
+        response = self.fetch("/echo", method="POST", body="foo=&bar=")
+        data = json_decode(response.body)
+        self.assertEqual(data, {u"foo": [u""], u"bar": [u""]})
 
     def test_types(self):
         headers = {"Cookie": "foo=bar"}


### PR DESCRIPTION
https://github.com/facebook/tornado/pull/585 only fixed empty GET parameters. This pull adds empty POST parameter support.
