### PR TITLE
Added period check in PeriodicCallback

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -679,8 +679,8 @@ class PeriodicCallback(object):
     """
     def __init__(self, callback, callback_time, io_loop=None):
         self.callback = callback
-        if callback_time == 0:
-            raise ValueError("Periodic callback cannot have a period of 0ms")
+        if callback_time <= 0:
+            raise ValueError("Periodic callback must have a positive callback_time")
         self.callback_time = callback_time
         self.io_loop = io_loop or IOLoop.instance()
         self._running = False


### PR DESCRIPTION
If a user currently passes in 0ms (hopefully by accident) as the callback time for a periodic callback, Tornado consumes a huge amount of CPU and never calls the function. Ideally, this should raise an exception in its constructor to ensure the value makes sense. (Alternatively, a callback time of 0 could mean "call this function on every single IOLoop tick," but I haven't implemented that here.)
