### PR TITLE
redirect throws TypeError in python3

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -480,7 +480,7 @@ class RequestHandler(object):
             assert isinstance(status, int) and 300 <= status <= 399
         self.set_status(status)
         # Remove whitespace
-        url = re.sub(b(r"[\x00-\x20]+"), "", utf8(url))
+        url = re.sub(b(r"[\x00-\x20]+"), b(""), utf8(url))
         self.set_header("Location", urlparse.urljoin(utf8(self.request.uri),
                                                      url))
         self.finish()


### PR DESCRIPTION
``` python3
#!/usr/bin/env python3

import tornado.web, tornado.ioloop

class TestHandler(tornado.web.RequestHandler):
    def get(self):
        self.redirect('a b')

application = tornado.web.Application([
    (r'/', TestHandler),
])
application.listen(8002, 'localhost')
tornado.ioloop.IOLoop.instance().start()
```

```
ERROR:root:Uncaught exception GET / (127.0.0.1)
HTTPRequest(protocol='http', host='localhost:8002', method='GET', uri='/', version='HTTP/1.1', remote_ip='127.0.0.1'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/tornado/web.py", line 1021, in _execute
    getattr(self, self.request.method.lower())(*args, **kwargs)
  File "./test.py", line 7, in get
    self.redirect('a b')
  File "/usr/lib/python3/dist-packages/tornado/web.py", line 466, in redirect
    url = re.sub(b(r"[\x00-\x20]+"), "", utf8(url))
  File "/usr/lib/python3.2/re.py", line 170, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: sequence item 1: expected bytes, str found
ERROR:root:500 GET / (127.0.0.1) 5.71ms
```

I'm not 100% sure this fixes it because I failed to get the most recent code to run under python3 (the traceback is from [python3-tornado](http://packages.debian.org/wheezy/python3-tornado)).
