### PR TITLE
Add support for macros in templates

### DIFF
--- a/tornado/test/template_test.py
+++ b/tornado/test/template_test.py
@@ -109,6 +109,18 @@ class TemplateTest(unittest.TestCase):
         template = Template(utf8(u"{% apply upper %}foo \u00e9{% end %}"))
         self.assertEqual(template.generate(upper=upper), utf8(u"FOO \u00c9"))
 
+    def test_macro(self):
+        template = Template(utf8("{% macro plus(a, b) %}{{ a }} + {{ b }} = {{ a + b }}{% end %}{{ plus(1, 1) }}"))
+        self.assertEqual(template.generate(), b("1 + 1 = 2"))
+
+    def test_unicode_macro(self):
+        template = Template(utf8(u"{% macro plus(a, b) %}{{ a }} + {{ b }} = {{ a + b }}{% end %}{{ plus(1, 1) }} ~ \u00e9"))
+        self.assertEqual(template.generate(), utf8(u"1 + 1 = 2 ~ \u00e9"))
+
+    def test_bytes_macro(self):
+        template = Template(utf8(b"{% macro plus(a, b) %}{{ a }} + {{ b }} = {{ a + b }}{% end %}{{ plus(1, 1) }} ~ \u00e9"))
+        self.assertEqual(template.generate(), utf8(b"1 + 1 = 2 ~ \u00e9"))
+
     def test_if(self):
         template = Template(utf8("{% if x > 4 %}yes{% else %}no{% end %}"))
         self.assertEqual(template.generate(x=5), b("yes"))


### PR DESCRIPTION
Support for simple macros (or functions, just took the name from Jinja2) has been added in the template parser. They can be accessed within the file or block they're defined in.

The current implementation it limited and I was thinking of putting the macros in a dictionary and write the contents when a macro is called. Didn't do that yet, because that'll introduce new syntax for calling macros.

Why macros? I'm currently working on an application with a lot of forms and putting the form controls in separate files did seem a bit too much and confusing. It looks more simple like the code example below.

```
{% autoescape None %}
{% include "../utils.html" %}

<form method="POST" action="{{ action }}">
  {{ hidden_fields(form.xsrf) }}
  {{ field(form.username) }}
  {{ field(form.password) }}
  {{ submit_field(form.submit) }}
</form>
```

What do you think about this?
