### PR TITLE
CachedResolver

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -361,7 +361,7 @@ class CachedResolver(object):
     domain.
     """
 
-    def __init__(self, io_loop=None, executor=None, expire_minutes=60):
+    def __init__(self, io_loop=None, executor=None, expire_minutes=1):
         self.io_loop = io_loop or IOLoop.instance()
         self.executor = executor or dummy_executor
         self.expire_minutes = expire_minutes

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, with_statement
 
 import socket
 
-from tornado.netutil import Resolver
+from tornado.netutil import Resolver, CachedResolver
 from tornado.testing import AsyncTestCase
 from tornado.test.util import unittest
 
@@ -18,15 +18,41 @@ class _ResolverTestMixin(object):
                                   callback=self.stop)
         future = self.wait()
         self.assertIn(
-            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '',
+            (socket.AF_INET, socket.SOCK_STREAM, system_getaddr_proto, '',
              ('127.0.0.1', 80)),
             future.result())
+
+
+class _CachedTestMixin(object):
+    def test_cached_localhost(self):
+        # Fill the cache with a regular lookup
+        self.resolver.getaddrinfo('localhost', 80, socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+            callback=self.stop)
+        future = self.wait()
+        self.assertIn(
+            (socket.AF_INET, socket.SOCK_STREAM, system_getaddr_proto, '',
+             ('127.0.0.1', 80)),
+            future.result())
+
+        # Entry should now be in the cache
+        self.assertIn('localhost', self.resolver.resolve_cache.keys())
+        self.assertIn(
+            (socket.AF_INET, socket.SOCK_STREAM, system_getaddr_proto, '',
+            ('127.0.0.1', 80)), self.resolver.resolve_cache.get('localhost'))
 
 
 class SyncResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(SyncResolverTest, self).setUp()
         self.resolver = Resolver(self.io_loop)
+
+
+class SyncCachedResolvedTest(AsyncTestCase, _CachedTestMixin):
+    def setUp(self):
+        super(SyncCachedResolvedTest, self).setUp()
+        self.resolver = CachedResolver(self.io_loop)
+
 
 class ThreadedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
@@ -38,5 +64,10 @@ class ThreadedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def tearDown(self):
         self.executor.shutdown()
         super(ThreadedResolverTest, self).tearDown()
+
+
+# socket.getaddrinfo returns IPPROTO_IP on Windows and IPPROTO_TCP on linux
+system_getaddr_proto = socket.getaddrinfo('localhost', 80)[0][2]
+
 ThreadedResolverTest = unittest.skipIf(
     futures is None, "futures module not present")(ThreadedResolverTest)


### PR DESCRIPTION
Added a new resolver that avoids to hit socket.getaddrinfo for each request. 

This resolver adds a fair speed increase in Single-Host multi-request code where the dns server is slow or rate-limited. It also gives a noticeable performance increase and network noise decrease when doing 1k+ requests on the same host.

Cache timeout can be controlled with expire_minutes constructor params.

I had to fix the netutil_test.py since socket.getaddrinfo returns IPPROTO_TCP as the protocol on linux and IPPROTO_IP under windows. Tested both platforms.

Supplementary notes: If you are to compare the speed of both resolver, don't forget to add force_instance=True to your constructor since tornado will re-use the previous instance.
