### PR TITLE
kill the child process after the master process be killed when use multiprocess funciton

### DIFF
--- a/tornado/process.py
+++ b/tornado/process.py
@@ -23,6 +23,8 @@ import logging
 import os
 import sys
 import time
+import ctypes
+import signal
 
 from binascii import hexlify
 
@@ -101,10 +103,13 @@ def fork_processes(num_processes, max_restarts=100):
     logging.info("Starting %d processes", num_processes)
     children = {}
 
+    libc = ctypes.CDLL('libc.so.6')
+
     def start_child(i):
         pid = os.fork()
         if pid == 0:
             # child process
+            libc.prctl(1, signal.SIGTERM)
             _reseed_random()
             global _task_id
             _task_id = i


### PR DESCRIPTION
sorry, my english is not good.

when call fork_process(), we need to kill the child process after the master process be killed. 

for example, use Supervisor to control the Tornado process, when we stop the master process, the work process has not be killed.
