### PR TITLE
Changed default Twisted DNS Resolver to be blocking

### DIFF
--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -70,6 +70,7 @@ import functools
 import datetime
 import time
 
+from twisted.internet.base import BlockingResolver
 from twisted.internet.posixbase import PosixReactorBase
 from twisted.internet.interfaces import \
     IReactorFDSet, IDelayedCall, IReactorTime, IReadDescriptor, IWriteDescriptor
@@ -148,6 +149,10 @@ class TornadoReactor(PosixReactorBase):
         self._fds = {}  # a map of fd to a (reader, writer) tuple
         self._delayedCalls = {}
         PosixReactorBase.__init__(self)
+        # The default is a ThreadedResolver which spawns worker threads
+        # from a thread pool which is probably *correct* but was quite
+        # confusing and inconsistent with default Tornado behavior.
+        self.installResolver(BlockingResolver())
         self.addSystemEventTrigger('during', 'shutdown', self.crash)
 
         # IOLoop.start() bypasses some of the reactor initialization.


### PR DESCRIPTION
The default Twisted reactor uses a threaded DNS resolver by default (at least on platforms that support threading).  As a result, if you're using a Twisted library, and you're looking up hostnames, all of the sudden your single threaded Tornado server will spawn additional threads.

This is kind of annoying because
1)  Signals like Ctrl+C no longer work for the main Tornado process because the worker threads will be blocked on their request queues.
2)  It's inconsistent with other Tornado functionality such as AsyncHttpClient which for better or worse, uses blocking dns lookups.
3)  It's confusing - I dug through stuff for hours convinced I wasn't integrating Twisted + Tornado correctly.

So, I changed the default to make my life easier, but I can totally understand if you reject this, given that the Twisted behavior is both correct and more efficient.  But, I figured I'd try to save others a few hours of time in case they suddenly get confused when Ctrl+c stops working in a Twisted+Tornado app.
