### PR TITLE
Use the first IP in the list from X-Forwarded-For

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -382,6 +382,8 @@ class HTTPRequest(object):
             # Squid uses X-Forwarded-For, others use X-Real-Ip
             self.remote_ip = self.headers.get(
                 "X-Real-Ip", self.headers.get("X-Forwarded-For", remote_ip))
+            # use first IP address in comma separated list
+            self.remote_ip = self.remote_ip.split(',')[0]
             if not self._valid_ip(self.remote_ip):
                 self.remote_ip = remote_ip
             # AWS uses X-Forwarded-Proto

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -355,10 +355,25 @@ class XHeaderTest(HandlerBaseTestCase):
             self.fetch_json("/", headers=valid_ipv4)["remote_ip"],
             "4.4.4.4")
 
+        valid_ipv4_list = {"X-Real-IP": "4.4.4.4, 127.0.0.1"}
+        self.assertEqual(
+            self.fetch_json("/", headers=valid_ipv4_list)["remote_ip"],
+            "4.4.4.4")
+
         valid_ipv6 = {"X-Real-IP": "2620:0:1cfe:face:b00c::3"}
         self.assertEqual(
             self.fetch_json("/", headers=valid_ipv6)["remote_ip"],
             "2620:0:1cfe:face:b00c::3")
+
+        valid_ipv6_list = {"X-Real-IP": "2620:0:1cfe:face:b00c::3, ::1"}
+        self.assertEqual(
+            self.fetch_json("/", headers=valid_ipv6_list)["remote_ip"],
+            "2620:0:1cfe:face:b00c::3")
+
+        invalid_chars_list = {"X-Real-IP": "4.4.4.4<script>, 127.0.0.1"}
+        self.assertEqual(
+            self.fetch_json("/", headers=invalid_chars_list)["remote_ip"],
+            "127.0.0.1")
 
         invalid_chars = {"X-Real-IP": "4.4.4.4<script>"}
         self.assertEqual(


### PR DESCRIPTION
fixes #647

This works in the case of only a single IP address and with a list like "99.100.2.45, 10.10.2.5, 10.10.2.4". I have also added tests to reflect this change.

This could still be improved more by using the first public IP address rather than just the first in the list. Ben, if you think that Tornado should handle that case then I can extend this more.
