### PR TITLE
Use TCP_DEFER_ACCEPT when available

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -34,7 +34,7 @@ from tornado.escape import native_str, parse_qs_bytes
 from tornado import httputil
 from tornado import iostream
 from tornado.log import gen_log
-from tornado.netutil import TCPServer
+from tornado.netutil import TCPServer, set_defer_accept
 from tornado import stack_context
 from tornado.util import b, bytes_type
 
@@ -154,6 +154,14 @@ class HTTPServer(TCPServer):
     def handle_stream(self, stream, address):
         HTTPConnection(stream, address, self.request_callback,
                        self.no_keep_alive, self.xheaders, self.protocol)
+
+    def bind(self, port, address=None, family=socket.AF_UNSPEC, backlog=128):
+        super(HTTPServer, self).bind(port, address, family, backlog)
+        if self._started:
+            set_defer_accept(self._sockets.itervalues())
+        else:
+            set_defer_accept(self._pending_sockets)
+
 
 
 class _BadRequestException(Exception):

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -237,6 +237,16 @@ class TCPServer(object):
         except Exception:
             app_log.error("Error in connection callback", exc_info=True)
 
+def set_defer_accept(sockets):
+    """On Linux try to set TCP_DEFER_ACCEPT option for all sockets
+
+    This option helps to evenly distribute connections across processes.
+    """
+    try:
+        for sock in sockets:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_DEFER_ACCEPT, 30)
+    except AttributeError:
+        pass
 
 def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128, flags=None):
     """Creates listening sockets bound to the given port and address.


### PR DESCRIPTION
Without this option the first read() on the newly accepted socket returns EAGAIN and it goes back into the event loop to accept more connections. This can cause connections to be unevenly distributed across forked processes. For example, with 48 worker processes only 4 end up with all the connections. This only really matters when dealing with long-lived persistent connections, for example if you have a load balancing proxy server in front of tornado.
