### PR TITLE
Add the support for GitHub OAuth2 Authentication

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -1215,7 +1215,7 @@ class GitHubMixin(OAuth2Mixin):
 
         http = httpclient.AsyncHTTPClient()
 
-        access_token = None
+        callback_sharing_data = {}
 
         def use_error_callback(response, decoded_body):
             data = {
@@ -1265,10 +1265,10 @@ class GitHubMixin(OAuth2Mixin):
 
                 return
 
-            access_token = body['access_token']
+            callback_sharing_data['access_token'] = body['access_token']
 
             http.fetch(
-                '{}{}'.format(self._OAUTH_USER_URL, access_token),
+                '{}{}'.format(self._OAUTH_USER_URL, callback_sharing_data['access_token']),
                 on_fetching_user_information,
                 headers=self._API_BASE_HEADERS
             )
@@ -1285,7 +1285,7 @@ class GitHubMixin(OAuth2Mixin):
             if not user:
                 return
 
-            success_callback(user, access_token)
+            success_callback(user, callback_sharing_data['access_token'])
 
         # Request the access token.
         http.fetch(


### PR DESCRIPTION
This is a simple implementation to support GitHub OAuth2 Authentication.

For example,

``` python
from tornado.web import asynchronous
from tornado.auth import GitHubMixin

class GitHubAuthentication(Controller, GitHubMixin):
    xsite_token   = 'github'
    client_id     = 'cid'
    client_secret = 'cse'

    @asynchronous
    def get(self):
        params = {
            'redirect_uri': 'http://shiroyuki.com/login',
            'client_id':    self.client_id,
            'state':        self.xsite_token
        }

        if self.session.get('user'):
            return self.redirect('/')

        code = self.get_argument('code', None)

        # Seek the authorization
        if code:
            # For security reason, the state value (cross-site token) will be
            # retrieved from the query string.
            params.update({
                'client_secret': self.client_secret,
                'success_callback': self._on_login,
                'error_callback': self._on_error,
                'code':  code,
                'state': self.get_argument('state', None)
            })

            self.get_authenticated_user(**params)

            return

        # Redirect for user authentication
        self.get_authenticated_user(**params)

    def _on_login(self, user, access_token=None):
        self.session.set('user', user)

        self.redirect('/')

    def _on_error(self, code, body=None, error=None):
        self.write('<h1>HTTP {}</h1>'.format(code))

        if body:
            self.write('<p>Content: {}</p>'.format(body))

        if error:
            self.write('<p>Error: {}</p>'.format(error))

        self.finish()
```

Please note that this PR does not have tests included. I would like some help on updating the tests.
