### PR TITLE
Fix s3server.py to stop truncating downloads of images and other non-text files

### DIFF
--- a/demos/s3server/s3server.py
+++ b/demos/s3server/s3server.py
@@ -221,7 +221,7 @@ class ObjectHandler(BaseRequestHandler):
         self.set_header("Content-Type", "application/unknown")
         self.set_header("Last-Modified", datetime.datetime.utcfromtimestamp(
             info.st_mtime))
-        object_file = open(path, "r")
+        object_file = open(path, "rb")
         try:
             self.finish(object_file.read())
         finally:


### PR DESCRIPTION
I'm using s3server.py to develop a JavaScript app to run from an S3 bucket.  It works fine when serving HTML and CSS files, but my images were getting truncated.  When serving a GET request, the script opens the file with mode "r" which asks Python to interpret the file as text.  Python on Windows will choke on the file data when certain characters are encountered.  Changing the mode to "rb" makes Python read plain bytes, solving the problem.

```
C:\Users\Michael\Desktop\s3blog\s3server-buckets\s3blog>python
Python 2.7.3 (default, Apr 10 2012, 23:31:26) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> len(open('spinner.gif', 'r').read())
965
>>> len(open('spinner.gif', 'rb').read())
17517
>>>
```
