### PR TITLE
Update tornado/netutil.py

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -53,6 +53,8 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128, flags
     sockets = []
     if address == "":
         address = None
+    if not socket.has_ipv6:
+        family = socket.AF_INET
     if flags is None:
         flags = socket.AI_PASSIVE
     for res in set(socket.getaddrinfo(address, port, family, socket.SOCK_STREAM,


### PR DESCRIPTION
`socket.getadrrinfo` yields some strange output if Python is compiled with `--disable-ipv6`, resulting in a `bad family` error.
See http://bugs.python.org/issue16208
