### PR TITLE
Switching from get_unused_port to bind_unused_port in ClientTextMixin class.

### DIFF
--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -24,7 +24,7 @@ from tornado.escape import utf8, to_unicode
 from tornado import gen
 from tornado.iostream import IOStream
 from tornado.tcpserver import TCPServer
-from tornado.testing import AsyncTestCase, LogTrapTestCase, get_unused_port, gen_test
+from tornado.testing import AsyncTestCase, LogTrapTestCase, bind_unused_port, gen_test
 
 
 class ReturnFutureTest(AsyncTestCase):
@@ -206,7 +206,8 @@ class ClientTestMixin(object):
     def setUp(self):
         super(ClientTestMixin, self).setUp()
         self.server = CapServer(io_loop=self.io_loop)
-        port = get_unused_port()
+        # bind_unused_port returns a tuple.  the second entry is the port number.
+        port = bind_unused_port()[1]
         self.server.listen(port, address='127.0.0.1')
         self.client = self.client_class(io_loop=self.io_loop, port=port)
 


### PR DESCRIPTION
bind_unused_port guarantees that it will find an unused port for testing purposes.  get_unused_port was causing tests to fail due to a port already being in use on a development machine (in this case, a mac running osx 10.8).
