### PR TITLE
update the statement of testing if a handler is a list or tuple

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1337,7 +1337,7 @@ class Application(object):
             self.handlers.append((re.compile(host_pattern), handlers))
 
         for spec in host_handlers:
-            if isinstance(spec, type(())):
+            if isinstance(spec, (tuple, list)):
                 assert len(spec) in (2, 3)
                 pattern = spec[0]
                 handler = spec[1]


### PR DESCRIPTION
A small patch.
I think it's not necessary to limit the type of handler definition to tuple, list is OK too.
And why dont' use tuple directly instead of type(())?
