### PR TITLE
Fix chatdemo to work with Python 3.x

### DIFF
--- a/demos/chat/chatdemo.py
+++ b/demos/chat/chatdemo.py
@@ -25,6 +25,12 @@ import uuid
 
 from tornado.options import define, options
 
+try:
+    xrange  # py2
+except NameError:
+    xrange = range  # py3
+
+
 define("port", default=8888, help="run on the given port", type=int)
 
 


### PR DESCRIPTION
Fix a bug in the chat demo, so that it works with python 3.x (xrange is now range).
