### PR TITLE
Do a single accept() per callback

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -131,14 +131,15 @@ def add_accept_handler(sock, callback, io_loop=None):
         io_loop = IOLoop.current()
 
     def accept_handler(fd, events):
-        while True:
-            try:
-                connection, address = sock.accept()
-            except socket.error as e:
-                if e.args[0] in (errno.EWOULDBLOCK, errno.EAGAIN):
-                    return
-                raise
-            callback(connection, address)
+        try:
+            connection, address = sock.accept()
+        except socket.error as e:
+            if e.args[0] in (errno.EWOULDBLOCK, errno.EAGAIN):
+                return
+            raise
+
+        callback(connection, address)
+
     io_loop.add_handler(sock.fileno(), accept_handler, IOLoop.READ)
 
 


### PR DESCRIPTION
Starting with 57f5c57d89be095dc3cb5621364ccedc065f3d47 , accept()ing new connections is done in a loop, accepting everything that's available in a single call.

The problem with this is if you have multiple processes, all bound to the same socket, the first process that is available will accept all the connections. 

To test this out, I did the following:
- Create a simple request handler that sleeps for 2 seconds. 
- Start two processes:
  
  http_server.bind(8080)
  http_server.start(2)
- Then I used ab as follows:
  
  ab -c 4 -n 4 http://localhost:8080

What you would expect, is for this to take exactly 4 seconds. With my patch, that's what you get. Without the patch, it takes between 6 and 8 depending on how lucky you get.
