### PR TITLE
Add check for ssl.CertificateError in netutil.py

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -321,7 +321,7 @@ def ssl_wrap_socket(socket, ssl_options, server_hostname=None, **kwargs):
     else:
         return ssl.wrap_socket(socket, **dict(context, **kwargs))
 
-if hasattr(ssl, 'match_hostname'):  # python 3.2+
+if hasattr(ssl, 'match_hostname') and hasattr(ssl, 'CertificateError'):  # python 3.2+
     ssl_match_hostname = ssl.match_hostname
     SSLCertificateError = ssl.CertificateError
 else:


### PR DESCRIPTION
Rather annoyingly, in the python2.7.x that ships with the soon to be released Ubuntu Raring, they seem to have backported ssl.match_hostname from python3.2+, but they did not backport ssl.CertificateError. This causes a check in netutil.py to not do what it's expected to do. This is just a trivial add to make it work.
