### PR TITLE
try close method to close FDs in IOLoop

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -505,9 +505,10 @@ class PollIOLoop(IOLoop):
         if all_fds:
             for fd in self._handlers.keys():
                 try:
-                    try:
-                        fd.close()
-                    except AttributeError:
+                    close_method = getattr(fd, 'close', None)
+                    if close_method is not None:
+                        close_method()
+                    else:
                         os.close(fd)
                 except Exception:
                     gen_log.debug("error closing fd %s", fd, exc_info=True)


### PR DESCRIPTION
If an object has a `close` method, use that first, then fallback on `os.close`.

This is useful in subclasses that support polling things (zmq sockets, specifically) that are not simple FDs (and Jython, I hear?).
