### PR TITLE
Handle port scan on SSL server gracefully.

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -811,7 +811,7 @@ class SSLIOStream(IOStream):
             return True
 
     def _handle_read(self):
-        if self._ssl_accepting:
+        if self._ssl_accepting and self.socket._connected:
             self._do_ssl_handshake()
             return
         super(SSLIOStream, self)._handle_read()


### PR DESCRIPTION
Port scans and other quickly closing connections will
result in an unwrapped/disconnected socket.  Tornado
needs to check the ssl socket's _connected attribute
prior to attempting a ssl handshake in this case.

This patch makes the SSL server behave similarly to its'
non-ssl counterpart.
