### PR TITLE
Update simple_httpclient.py

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -89,7 +89,11 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
     def _process_queue(self):
         with stack_context.NullContext():
             while self.queue and len(self.active) < self.max_clients:
-                request, callback = self.queue.popleft()
+                try:
+                    request, callback = self.queue.popleft()
+                except IndexError:
+                    # The queue might have been emptied in _release_fetch.
+                    break
                 key = object()
                 self.active[key] = (request, callback)
                 release_callback = functools.partial(self._release_fetch, key)


### PR DESCRIPTION
Fix bug where an async call to _process_queue in _release_fetch might render self.queue empty causing the popleft() call in simple_httpclient.py:93 to fail.
