### PR TITLE
Adding helper function to HTTPResponse for getting charset of response body

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -414,6 +414,14 @@ class HTTPResponse(object):
 
     body = property(_get_body)
 
+    def get_content_charset(self):
+        """Gets the charset of the response body"""
+        content_type = self.headers['Content-Type']
+
+        # Example: 'application/json;charset=utf-8' -> 'utf-8'
+        charset = content_type.split(';')[1].split('=')[1]
+        return charset
+
     def rethrow(self):
         """If there was an error on the request, raise an `HTTPError`."""
         if self.error:


### PR DESCRIPTION
The body of HTTPResponse is `bytes` in Python 3, as a result of which I had to decode it before I could use it with other functions that expect a string object.  However I couldn't find a way to easily get the charset of the response body.  I had to manually inspect the header.  Therefore, I figured that adding a helper function might be helpful.
