### PR TITLE
bind_unused_port raising gaierror: [Errno 8]

### DIFF
--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -77,7 +77,7 @@ def bind_unused_port():
 
     Returns a tuple (socket, port).
     """
-    [sock] = netutil.bind_sockets(0, 'localhost', family=socket.AF_INET)
+    [sock] = netutil.bind_sockets(None, 'localhost', family=socket.AF_INET)
     port = sock.getsockname()[1]
     return sock, port
 


### PR DESCRIPTION
bind_unused_port was passing 0 as port number to the socket module.
This generated some exceptional behaviour on systems where nslookup of
localhost didn't returned the loopback interface.

This commit changes it to pass None instead, this will pass NULL to the underlying C API[1].

[1] http://docs.python.org/2.7/library/socket.html#socket.getaddrinfo
