### PR TITLE
Add note about handler regex capture to StaticFileHandler documentation.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1633,8 +1633,12 @@ class StaticFileHandler(RequestHandler):
             (r"/static/(.*)", web.StaticFileHandler, {"path": "/var/www"}),
         ])
 
-    The local root directory of the content should be passed as the ``path``
-    argument to the handler.
+    The handler constructor requires a ``path`` argument, which specifies the
+    local root directory of the content to be served.
+
+    Note that a capture group in the regex is required to parse the value for
+    the ``path`` argument to the get() method (different than the constructor 
+    argument above); see `URLSpec` for details.
 
     To support aggressive browser caching, if the argument ``v`` is given
     with the path, we set an infinite HTTP expiration header. So, if you


### PR DESCRIPTION
I am a first-time Tornado user and just spent an embarrassing amount of time trying to serve a static home page.

Here is the handler that I added:

```
(r'/index\.html', HomePageHandler, { 'path' : app_html_dir })
```

Here is the error that I got:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/tornado/web.py", line 1077, in _execute
    *self.path_args, **self.path_kwargs)
TypeError: get() missing 1 required positional argument: 'path'
```

The mistake is that I need to add a capture group around the page name in the handler regex. I found the error very confusing, because it seemed that I was passing the 'path' right there in the handler tuple; I see now that this is an argument to initialize(), not get(). The relevant info is in URLSpec, but it took me long time to find it because the example in the StaticFileHandler docs doesn't use URLSpec at all.

This patch adds a bit of commentary to the docstring to clarify for new users.
