### PR TITLE
Don't log EPIPE (broken pipe) errors as warnings

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -547,8 +547,12 @@ class BaseIOStream(object):
                     self._write_buffer_frozen = True
                     break
                 else:
-                    gen_log.warning("Write error on %d: %s",
-                                    self.fileno(), e)
+                    if e.args[0] != errno.EPIPE:
+                        # Broken pipe errors are usually caused by connection
+                        # reset, and its better to not log EPIPE errors to
+                        # minimize log spam
+                        gen_log.warning("Write error on %d: %s",
+                                        self.fileno(), e)
                     self.close(exc_info=True)
                     return
         if not self._write_buffer and self._write_callback:


### PR DESCRIPTION
Broken pipe errors are usually caused by connection reset, and its better to not log `EPIPE` errors to minimize log spam.

We are running a file serve using tornado, there is tens of thousands of broken pipe errors (in `_handle_write` function) every day.

This is much like the behavior to not log `ECONNRESET` errors in `BaseIOStream._read_to_buffer` function.
