### PR TITLE
Make options instance more dict-like.

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -115,11 +115,8 @@ class OptionParser(object):
         """The set of option-groups created by ``define``."""
         return set(opt.group_name for opt in self._options.values())
 
-    def group_dict(self, group=None):
-        """A dict of option names and values.
-
-        If ``group`` is given, get options only from the named group; otherwise
-        all options are included.
+    def group_dict(self, group):
+        """The names and values of options in a group.
 
         Useful for copying options into Application settings::
 
@@ -136,6 +133,11 @@ class OptionParser(object):
         return dict(
             (name, opt.value()) for name, opt in self._options.items()
             if not group or group == opt.group_name)
+
+    def as_dict(self):
+        """The names and values of all options."""
+        return dict(
+            (name, opt.value()) for name, opt in self._options.items())
 
     def define(self, name, default=None, type=None, help=None, metavar=None,
                multiple=False, group=None, callback=None):

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -135,6 +135,11 @@ class OptionsTest(unittest.TestCase):
         actual = sorted(options.items())
         self.assertEqual(expected, actual)
 
+    def test_as_dict(self):
+        options = self._sample_options()
+        expected = {'a': 1, 'b': 2, 'help': options.help}
+        self.assertEqual(expected, options.as_dict())
+
     def test_group_dict(self):
         options = OptionParser()
         options.define('a', default=1)
@@ -143,10 +148,6 @@ class OptionsTest(unittest.TestCase):
         frame = sys._getframe(0)
         this_file = frame.f_code.co_filename
         self.assertEqual(set(['b_group', '', this_file]), options.groups())
-
-        default_group_dict = options.group_dict()
-        expected = {'a': 1, 'b': 2, 'help': options.help}
-        self.assertEqual(expected, default_group_dict)
 
         b_group_dict = options.group_dict('b_group')
         self.assertEqual({'b': 2}, b_group_dict)


### PR DESCRIPTION
In my Motor-Blog application, I find myself copying a lot of options from tornado.options into Application(). I thought this would be nice:

application = Application(handler, **options.options.as_dict())

... so I added as_dict() and some dict-like features to OptionParser.
