### PR TITLE
Send HTTP 200 in response to `Range: bytes=0-`

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -896,7 +896,7 @@ class StaticFileTest(WebTestCase):
         with open(robots_file_path) as f:
             self.assertEqual(response.body, utf8(f.read()))
         self.assertEqual(response.headers.get("Content-Length"), "26")
-        self.assertEqual(response.headers.get("Content-Range"), "0-25/26")
+        self.assertEqual(response.headers.get("Content-Range"), None)
 
     def test_static_with_range_end_edge(self):
         response = self.fetch('/static/robots.txt', headers={

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1816,8 +1816,8 @@ class StaticFileHandler(RequestHandler):
             # ``Range: bytes=0-``.
             if size != (end or size) - (start or 0):
                 self.set_status(206)  # Partial Content
-            self.set_header("Content-Range",
-                            httputil._get_content_range(start, end, size))
+                self.set_header("Content-Range",
+                                httputil._get_content_range(start, end, size))
         else:
             start = end = None
         content = self.get_content(self.absolute_path, start, end)


### PR DESCRIPTION
Ug, well, that's a pain.

It turns out that Chrome refuses to play audio if it gets an HTTP 206 in response to a request for `Range: bytes=0-`.

Chrome is kind of a jerk.

Anyway, since it isn't unreasonable to only return an HTTP 206 when the response is a proper subrange of the file, I've fixed things up so an HTTP 200 is returned if a `Range` is requested and that range is the complete file.
