### PR TITLE
Regression in StaticFileHandler: ignoring {"path": …}

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -21,6 +21,7 @@ import sys
 
 wsgi_safe_tests = []
 
+relpath = lambda *a: os.path.join(os.path.dirname(__file__), *a)
 
 def wsgi_safe(cls):
     wsgi_safe_tests.append(cls)
@@ -792,8 +793,7 @@ class StaticFileTest(WebTestCase):
                 ('/override_static_url/(.*)', OverrideStaticUrlHandler)]
 
     def get_app_kwargs(self):
-        return dict(static_path=os.path.join(os.path.dirname(__file__),
-                                             'static'))
+        return dict(static_path=relpath('static'))
 
     def test_static_files(self):
         response = self.fetch('/robots.txt')
@@ -860,8 +860,7 @@ class StaticFileTest(WebTestCase):
         # chosen just before and after the known modification time
         # of the file to ensure that the right time zone is being used
         # when parsing If-Modified-Since.
-        stat = os.stat(os.path.join(os.path.dirname(__file__),
-                                    'static/robots.txt'))
+        stat = os.stat(relpath('static/robots.txt'))
 
         response = self.fetch('/static/robots.txt', headers={
                 'If-Modified-Since': format_timestamp(stat.st_mtime - 1)})
@@ -943,8 +942,7 @@ class StaticFileTest(WebTestCase):
 @wsgi_safe
 class StaticDefaultFilenameTest(WebTestCase):
     def get_app_kwargs(self):
-        return dict(static_path=os.path.join(os.path.dirname(__file__),
-                                             'static'),
+        return dict(static_path=relpath('static'),
                     static_handler_args=dict(default_filename='index.html'))
 
     def get_handlers(self):
@@ -960,6 +958,21 @@ class StaticDefaultFilenameTest(WebTestCase):
         self.assertEqual(response.code, 301)
         self.assertTrue(response.headers['Location'].endswith('/static/dir/'))
 
+
+@wsgi_safe
+class StaticFileWithPathTest(WebTestCase):
+    def get_app_kwargs(self):
+        return dict(static_path=relpath('static'),
+                    static_handler_args=dict(default_filename='index.html'))
+
+    def get_handlers(self):
+        return [("/foo/(.*)", StaticFileHandler, {
+            "path": relpath("templates/"),
+        })]
+
+    def test_serve(self):
+        response = self.fetch("/foo/utf8.html")
+        self.assertEqual(response.body, b"H\xc3\xa9llo\n")
 
 
 @wsgi_safe


### PR DESCRIPTION
A regression was introduced in 3f04edf5546e388293d8d1d2f015ca74f8a93217 which causes the StaticFileHandler to ignore the `{"path": …}` argument.

This test case passes against the previous revision, 25506060a683d2c0503e8f89c2338e8b710600fe.

I'll be able to work on a fix in the next couple of days, if you'd rather wait for one.
