### PR TITLE
Edge cases of Range header are standards compliant

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -255,6 +255,8 @@ def _parse_request_range(range_header):
     (6, None)
     >>> _parse_request_range("bytes=-6")
     (-6, None)
+    >>> _parse_request_range("bytes=-0")
+    (None, 0)
     >>> _parse_request_range("bytes=")
     (None, None)
     >>> _parse_request_range("foo=42")
@@ -278,8 +280,9 @@ def _parse_request_range(range_header):
         return None
     if end is not None:
         if start is None:
-            start = -end
-            end = None
+            if end != 0:
+                start = -end
+                end = None
         else:
             end += 1
     return (start, end)

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -919,7 +919,21 @@ class StaticFileTest(WebTestCase):
     def test_static_invalid_range(self):
         response = self.fetch('/static/robots.txt', headers={
             'Range': 'asdf'})
+        self.assertEqual(response.code, 200)
+
+    def test_static_unsatisfiable_range_zero_suffix(self):
+        response = self.fetch('/static/robots.txt', headers={
+            'Range': 'bytes=-0'})
+        self.assertEqual(response.headers.get("Content-Range"),
+                         "bytes */26")
         self.assertEqual(response.code, 416)
+
+    def test_static_unsatisfiable_range_invalid_start(self):
+        response = self.fetch('/static/robots.txt', headers={
+            'Range': 'bytes=26'})
+        self.assertEqual(response.code, 416)
+        self.assertEqual(response.headers.get("Content-Range"),
+                         "bytes */26")
 
     def test_static_head(self):
         response = self.fetch('/static/robots.txt', method='HEAD')


### PR DESCRIPTION
Fix a few Range header edge cases to ensure that it is as standards-compliant as possible.

Note: builds on #806
