### PR TITLE
switch to version 1.1 of the Twitter API

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -590,7 +590,7 @@ class TwitterMixin(OAuthMixin):
     _OAUTH_AUTHORIZE_URL = "http://api.twitter.com/oauth/authorize"
     _OAUTH_AUTHENTICATE_URL = "http://api.twitter.com/oauth/authenticate"
     _OAUTH_NO_CALLBACKS = False
-    _TWITTER_BASE_URL = "http://api.twitter.com/1"
+    _TWITTER_BASE_URL = "http://api.twitter.com/1.1"
 
     def authenticate_redirect(self, callback_uri=None):
         """Just like `~OAuthMixin.authorize_redirect`, but


### PR DESCRIPTION
Twitter is turning off version 1.0 on June 11th. We should switch to using 1.1.
