### PR TITLE
Fix bind_sockets if OS does not support IPv6

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -66,7 +66,12 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128, flags
     for res in set(socket.getaddrinfo(address, port, family, socket.SOCK_STREAM,
                                       0, flags)):
         af, socktype, proto, canonname, sockaddr = res
-        sock = socket.socket(af, socktype, proto)
+        try:
+            sock = socket.socket(af, socktype, proto)
+        except socket.error as e:
+            if e.args[0] == errno.EAFNOSUPPORT:
+                continue
+            raise
         set_close_exec(sock.fileno())
         if os.name != 'nt':
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
Python could be compiled with IPv6 support but the host OS does not support IPv6. In this case `socket.getaddrinfo` returns still IPv6 addresses and a call to `socket.socket(socket.AF_INET6)` raises EAFNOSUPPORT.
