### PR TITLE
WSGI specification requires that close() be called on iterable no matter what happens.

### DIFF
--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -242,10 +242,12 @@ class WSGIContainer(object):
             return response.append
         app_response = self.wsgi_application(
             WSGIContainer.environ(request), start_response)
-        response.extend(app_response)
-        body = b"".join(response)
-        if hasattr(app_response, "close"):
-            app_response.close()
+        try:
+            response.extend(app_response)
+            body = b"".join(response)
+        finally:
+            if hasattr(app_response, "close"):
+                app_response.close()
         if not data:
             raise Exception("WSGI app did not call start_response")
 


### PR DESCRIPTION
Tornado does not comply with the WSGI specification (PEP 333/3333).

Specifically the WSGI specification says:

"""If the iterable returned by the application has a close() method, the server or gateway must call that method upon completion of the current request, whether the request was completed normally, or terminated early due to an application error during iteration or an early disconnect of the browser."""

Tornado is not calling close() when an unhandled exception propagates all the way up to the WSGIContainer.

This can cause problems for WSGI applications or middleware which rely on close() being called at the end of the request to cleanup resources or end transactions.

The requirement is something that uWSGI, wsgiref, Sentry and others have got wrong at times and has been blogged about in:

http://blog.dscpl.com.au/2012/10/obligations-for-calling-close-on.html

in order to highlight the problem, yet Tornado still has got it wrong.
