### PR TITLE
ObjectDict support for accessing nested dictionaries like objects.

### DIFF
--- a/tornado/util.py
+++ b/tornado/util.py
@@ -25,6 +25,10 @@ class ObjectDict(dict):
         for name in self:
             if isinstance(self[name], dict):
                 self[name] = ObjectDict(self[name])
+            elif isinstance(self[name], list):
+                for i, elem in enumerate(self[name]):
+                    if isinstance(elem, dict):
+                        self[name][i] = ObjectDict(elem)
 
     def __getattr__(self, name):
         try:


### PR DESCRIPTION
``` pycon
>>> o = ObjectDict({'one': {'two': {'three': 3}}})
>>> o.one
{'two': {'three': 3}}
>>> o.one.two
{'three': 3}
>>> o.one.two.three
3
```
