### PR TITLE
Add a generator iteritems in Optins for python 2.x

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -114,6 +114,11 @@ class OptionParser(object):
         """
         return [(name, opt.value()) for name, opt in self._options.items()]
 
+    def iteritems(self):
+        """Return an iterator of the (name, value) pairs.
+        """
+        return ((name, opt.value()) for name, opt in self._options.iteritems())
+
     def groups(self):
         """The set of option-groups created by ``define``.
 


### PR DESCRIPTION
modified:   tornado/options.py

add a generator method of options for python 2.x