### PR TITLE
Correctly handle EAGAIN when writing to PipeIOStreams

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -562,7 +562,7 @@ class BaseIOStream(object):
                 self._write_buffer_frozen = False
                 _merge_prefix(self._write_buffer, num_bytes)
                 self._write_buffer.popleft()
-            except socket.error as e:
+            except (socket.error, IOError, OSError) as e:
                 if e.args[0] in _ERRNO_WOULDBLOCK:
                     self._write_buffer_frozen = True
                     break

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -543,3 +543,21 @@ class TestPipeIOStream(AsyncTestCase):
         self.assertEqual(data, b"ld")
 
         rs.close()
+
+    def test_pipe_iostream_big_write(self):
+        r, w = os.pipe()
+
+        rs = PipeIOStream(r, io_loop=self.io_loop)
+        ws = PipeIOStream(w, io_loop=self.io_loop)
+
+        NUM_BYTES = 1048576
+
+        # Write 1MB of data, which should fill the buffer
+        ws.write(b"1" * NUM_BYTES)
+
+        rs.read_bytes(NUM_BYTES, self.stop)
+        data = self.wait()
+        self.assertEqual(data, b"1" * NUM_BYTES)
+
+        ws.close()
+        rs.close()


### PR DESCRIPTION
`BaseIOStream._handle_write` needs to catch `IOError` and `OSError` as well as socket.error in order to handle `EAGAIN` when writing to a `PipeIOStream`, which doesn't raise `socket.error` when the buffer is full.

The problem is demonstrated by the added test case, `TestPipeIOStream.test_pipe_iostream_big_write`.

Without the change, `TestPipeIOStream.test_pipe_iostream_big_write` fails with the following error:

```
======================================================================
ERROR: test_pipe_iostream_big_write (tornado.test.iostream_test.TestPipeIOStream)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tornado/test/iostream_test.py", line 556, in test_pipe_iostream_big_write
    ws.write(b"1" * NUM_BYTES)
  File "tornado/iostream.py", line 228, in write
    self._handle_write()
  File "tornado/iostream.py", line 550, in _handle_write
    num_bytes = self.write_to_fd(self._write_buffer[0])
  File "tornado/iostream.py", line 963, in write_to_fd
    return os.write(self.fd, data)
OSError: [Errno 35] Resource temporarily unavailable

----------------------------------------------------------------------
```

This change to the exceptions handled by `BaseIOStream._handle_write` provides consistency with the exceptions caught by `BaseIOStream._read_to_buffer`.
