### PR TITLE
Client request failed if server answered without reason in status line

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -339,7 +339,7 @@ class _HTTPConnection(object):
     def _on_headers(self, data):
         data = native_str(data.decode("latin1"))
         first_line, _, header_data = data.partition("\n")
-        match = re.match("HTTP/1.[01] ([0-9]+) ([^\r]*)", first_line)
+        match = re.match("HTTP/1.[01] ([0-9]+)\s?([^\r]*)", first_line)
         assert match
         code = int(match.group(1))
         self.headers = HTTPHeaders.parse(header_data)


### PR DESCRIPTION
"Reason" in http status line is optional

The reason phrases defined in the HTTP specifications (for example, "Not Found" or "Bad Request") are recommended but optional. The HTTP/1.1 specification says that the reason phrases for each status code may be replaced by local equivalents.
