### PR TITLE
Make poll timeout patchable.

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -59,6 +59,9 @@ except ImportError:
 from tornado.platform.auto import set_close_exec, Waker
 
 
+_POLL_TIMEOUT = 3600.0
+
+
 class TimeoutError(Exception):
     pass
 
@@ -596,7 +599,7 @@ class PollIOLoop(IOLoop):
                 pass
 
         while True:
-            poll_timeout = 3600.0
+            poll_timeout = _POLL_TIMEOUT
 
             # Prevent IO event starvation by delaying new callbacks
             # to the next iteration of the event loop.


### PR DESCRIPTION
`select.select` ignores SIGINT on Windows. This is problematic with some unit tests with Tornado loops in threads. When I abort the execution with Ctrl+C it can happen that a thread is still alive and then I get an hour later (!) a stack trace with a KeyboardInterrupt happened in select. 

This can be easily fixed by patching the poll_timeout with a low value, but right now it is not really possible to do so (yes, you _could_ hack `func_code.co_consts`, but I don't do this...).
