### PR TITLE
Accept header parameters in RFC 2231 format.

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -425,7 +425,7 @@ def _parse_header(line):
     Return the main content-type and a dictionary of options.
 
     >>> d = _parse_header("CD: fd; foo=\"bar\"; file*=utf-8''T%C3%A4st")[1]
-    >>> d['file'] == 'T\u00e4st'
+    >>> d['file'] == r'T\u00e4st'.encode('ascii').decode('unicode_escape')
     True
     >>> d['foo']
     'bar'

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -424,11 +424,12 @@ def _parse_header(line):
 
     Return the main content-type and a dictionary of options.
 
-    >>> d = _parse_header("CD: fd; foo=\"bar\"; file*=utf-8''T%C3%A4st")[1]
+    >>> d = "CD: fd; foo=\"b\\\\a\\\"r\"; file*=utf-8''T%C3%A4st"
+    >>> d = _parse_header(d)[1]
     >>> d['file'] == r'T\u00e4st'.encode('ascii').decode('unicode_escape')
     True
     >>> d['foo']
-    'bar'
+    'b\\a"r'
     """
     parts = _parseparam(';' + line)
     key = next(parts)
@@ -439,9 +440,6 @@ def _parse_header(line):
         if i >= 0:
             name = p[:i].strip().lower()
             value = p[i + 1:].strip()
-            if len(value) >= 2 and value[0] == value[-1] == '"' and False:
-                value = value[1:-1]
-                value = value.replace('\\\\', '\\').replace('\\"', '"')
             params.append((name, value))
     params = email.utils.decode_params(params)
     params.pop(0) # get rid of the dummy again


### PR DESCRIPTION
This should fix facebook/tornado#868. Someone should test whether this works as intended with Python 2, though. In gagern/urllib3@e11e03628f8b82021a74ba7f5b39ce9ad9011382 I had to encode the input from unicode to bytes for this to work. Not sure why, though, and also not sure whether this might be handled in some other location. Python 3 accepts this modification without issues.
