### PR TITLE
Reverse URL produces clean URLs even if path ends in /?

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2525,7 +2525,8 @@ class URLSpec(object):
             if not isinstance(a, (unicode_type, bytes_type)):
                 a = str(a)
             converted_args.append(escape.url_escape(utf8(a), plus=False))
-        return self._path % tuple(converted_args)
+        path = self._path if not url.endswith("/?") else self._path[:-2]
+        return path % tuple(converted_args)
 
 url = URLSpec
 


### PR DESCRIPTION
I often create url paths with /? at the end of them to make it easy for end users in case they type in / at the end of the url, but when I use reverse_url I do not want a /? to show up at the end. One option is to create two tornado.web.urls that both point to the same handler (one ends in /? and the named url doesn't), but I feel like this is a simple and clean addition and good for aesthetics. I usually override it in my projects, but others might benefit from it as well.

This could also be done in application reverse_url if you wish reverse to be "pure."
