### PR TITLE
Handle SimpleAsyncHTTPClient request timeout in heavy-loaded situation 

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -241,7 +241,6 @@ class HTTPRequest(object):
     _DEFAULTS = dict(
         connect_timeout=20.0,
         request_timeout=20.0,
-        async_timeout=20.0,
         follow_redirects=True,
         max_redirects=5,
         use_gzip=True,
@@ -252,7 +251,6 @@ class HTTPRequest(object):
     def __init__(self, url, method="GET", headers=None, body=None,
                  auth_username=None, auth_password=None, auth_mode=None,
                  connect_timeout=None, request_timeout=None,
-                 async_timeout=None,
                  if_modified_since=None, follow_redirects=None,
                  max_redirects=None, user_agent=None, use_gzip=None,
                  network_interface=None, streaming_callback=None,
@@ -342,7 +340,6 @@ class HTTPRequest(object):
         self.auth_mode = auth_mode
         self.connect_timeout = connect_timeout
         self.request_timeout = request_timeout
-        self.async_timeout = async_timeout
         self.follow_redirects = follow_redirects
         self.max_redirects = max_redirects
         self.user_agent = user_agent

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -94,7 +94,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         self.queue.append((key, request, callback))
         if not len(self.active) < self.max_clients:
             timeout_handle = self.io_loop.add_timeout(
-                    request.start_time + request.async_timeout,
+                    request.start_time + min(request.connect_timeout, request.request_timeout),
                     functools.partial(self._on_timeout, key))
             self.waiting[key] = (request, callback, timeout_handle)
         self._process_queue()

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -405,7 +405,7 @@ class HeavyloadAsyncHTTPClientTestCase(SimpleHTTPClientTestMixin, AsyncHTTPTestC
     def test_heavyload_timeout(self):
         with closing(self.create_client(max_clients=1)) as client:
             client.fetch(self.get_url('/trigger?wake=false'), self.stop, request_timeout=10)
-            client.fetch(self.get_url('/hello'), self.stop, async_timeout=3)
+            client.fetch(self.get_url('/hello'), self.stop, connect_timeout=3)
             response = self.wait()
 
             self.assertEqual(response.code, 599)


### PR DESCRIPTION
In a heavy-loaded situation when requests have to be queued, they may have waitted for a long time before pop out and get actual process. These requests become useless and already timeout indeed. The connect_timeout and request_timeout in `HTTPRequest` and their timeout callback only matter when the _HTTPConnection get created. The SimpleAsyncHTTPClient handles requests ignoring their age in queue. As a result old requests get processed and block new request.
I've added a `async_timeout` param to `HTTPRequest` and corresponding timeout logic in the `SimpleAsyncHTTPClient`, hoping this would solve the problem.
