### PR TITLE
Possibility to disable autoreload when debug is on

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -21,6 +21,8 @@ keyword argument ``debug=True`` to the `tornado.web.Application` constructor.
 This will enable autoreload mode as well as checking for changes to templates
 and static resources.  Note that restarting is a destructive operation
 and any requests in progress will be aborted when the process restarts.
+(If you want to disable autoreload while keeping debug on pass in also the
+keyword argument ``autoreload=False``).
 
 This module can also be used as a command-line wrapper around scripts
 such as unit test runners.  See the `main` method for details.

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -92,7 +92,8 @@ def fork_processes(num_processes, max_restarts=100):
     between any server code.
 
     Note that multiple processes are not compatible with the autoreload
-    module (or the debug=True option to `tornado.web.Application`).
+    module (or the ``autoreload=True`` option to `tornado.web.Application`
+    which defaults to True when ``debug=True``).
     When using multiple processes, no IOLoops can be created or
     referenced until after the call to ``fork_processes``.
 

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -180,7 +180,8 @@ class TCPServer(object):
         between any server code.
 
         Note that multiple processes are not compatible with the autoreload
-        module (or the ``debug=True`` option to `tornado.web.Application`).
+        module (or the ``autoreload=True`` option to `tornado.web.Application`
+        which defaults to True when ``debug=True``).
         When using multiple processes, no IOLoops can be created or
         referenced until after the call to ``TCPServer.start(n)``.
         """


### PR DESCRIPTION
Sometimes it might be useful to turn the autoreload off when debug is turned on.
