### PR TITLE
Remove binascii import as UUID has hex property

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -54,7 +54,6 @@ from __future__ import absolute_import, division, print_function, with_statement
 
 
 import base64
-import binascii
 import datetime
 import email.utils
 import functools
@@ -954,7 +953,7 @@ class RequestHandler(object):
         if not hasattr(self, "_xsrf_token"):
             token = self.get_cookie("_xsrf")
             if not token:
-                token = binascii.b2a_hex(uuid.uuid4().bytes)
+                token = uuid.uuid4().hex
                 expires_days = 30 if self.current_user else None
                 self.set_cookie("_xsrf", token, expires_days=expires_days)
             self._xsrf_token = token


### PR DESCRIPTION
UUID has a read only property called hex, so instead of converting it's bytes property to ascii using binascii#b2a_hex you can call hex directly. Furthermore, binascii isn't used anywhere else in this file.

Under the hood in uuid it's just calling:

@property
def hex(self):
  return '%032x' % self.int

The only reason I could think of using bytes to hex conversion with binascii would be because it's actually done in C, but this seems cleaner to me and a uuid isn't a terribly long string.
