### PR TITLE
Fixed WebSocketClient connections not closing on initial connection failure

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -796,6 +796,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
     def _on_close(self):
         self.on_message(None)
         self.resolver.close()
+        super(WebSocketClientConnection, self)._on_close()
 
     def _on_http_response(self, response):
         if not self.connect_future.done():


### PR DESCRIPTION
When I attempted to connect a WebSocketClient to a known closed port, the connect would wait the full connection_timeout before failing instead of immediately failing.  The WebSocketClient class is overriding the base simple_httpclient._HTTPConnection _on_close() without providing the needed functionality.
