### PR TITLE
Don't raise connection reset errors in `set_nodelay`

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -774,7 +774,7 @@ class IOStream(BaseIOStream):
                 # Sometimes setsockopt will fail if the socket is closed
                 # at the wrong time.  This can happen with HTTPServer
                 # resetting the value to false between requests.
-                if e.errno != errno.EINVAL:
+                if e.errno not in (errno.EINVAL, errno.ECONNRESET):
                     raise
 
 


### PR DESCRIPTION
If connection was reset, `request.finish()` wrongly raises socket.error instead of ignoring the error.

The traceback looks like this:

```
  File "our_application.py", line 350, in send_more
    self.finish()
  File "/usr/local/lib/python2.7/site-packages/tornado-3.1.dev2-py2.7.egg/tornado/web.py", line 761, in finish
    self.request.finish()
  File "/usr/local/lib/python2.7/site-packages/tornado-3.1.dev2-py2.7.egg/tornado/httpserver.py", line 485, in finish
    self.connection.finish()
  File "/usr/local/lib/python2.7/site-packages/tornado-3.1.dev2-py2.7.egg/tornado/httpserver.py", line 240, in finish
    self.stream.set_nodelay(True)
  File "/usr/local/lib/python2.7/site-packages/tornado-3.1.dev2-py2.7.egg/tornado/iostream.py", line 753, in set_nodelay
    socket.TCP_NODELAY, 1 if value else 0)
  File "/usr/local/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 54] Connection reset by peer
```
