### PR TITLE
Suppressing LookupError: unknown encoding: latin1 on Mac 

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -289,7 +289,7 @@ class HTTPConnection(object):
 
     def _on_headers(self, data):
         try:
-            data = native_str(data.decode('latin1'))
+            data = native_str(data.decode('latin1', 'ignore'))
             eol = data.find("\r\n")
             start_line = data[:eol]
             try:


### PR DESCRIPTION
There was a strange behavior on mac during many opened connections. So I just made a little change to suppress the error messages:

LookupError: unknown encoding: latin1
ERROR:tornado.application:Exception in callback <functools.partial object at 0x10851a208>

You won't get this error anymore whenever you run any stress-test. 
