### PR TITLE
Pass timeout argument to Future.result

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -124,11 +124,11 @@ class TracebackFuture(Future):
         self.__exc_info = exc_info
         self.set_exception(exc_info[1])
 
-    def result(self):
+    def result(self, timeout=None):
         if self.__exc_info is not None:
             raise_exc_info(self.__exc_info)
         else:
-            return super(TracebackFuture, self).result()
+            return super(TracebackFuture, self).result(timeout=timeout)
 
 
 class DummyExecutor(object):

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -28,6 +28,13 @@ from tornado.iostream import IOStream
 from tornado import stack_context
 from tornado.tcpserver import TCPServer
 from tornado.testing import AsyncTestCase, LogTrapTestCase, bind_unused_port, gen_test
+from tornado.test.util import unittest
+
+
+try:
+    from concurrent import futures
+except ImportError:
+    futures = None
 
 
 class ReturnFutureTest(AsyncTestCase):
@@ -105,6 +112,13 @@ class ReturnFutureTest(AsyncTestCase):
         future2 = self.wait()
         self.assertIs(future, future2)
         self.assertEqual(future.result(), 42)
+
+    @unittest.skipIf(futures is None, "futures module not present")
+    def test_timeout_future(self):
+        with self.assertRaises(futures.TimeoutError):
+            future = self.async_future()
+            # Do not call self.wait()
+            future.result(timeout=.1)
 
     @gen_test
     def test_async_future_gen(self):


### PR DESCRIPTION
Hi,
This pull request add support for timeout parameter of Future.result(timeout=None) method.
