### PR TITLE
Do not redirect to to login_url for XMLHttpRequests

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2367,7 +2367,8 @@ def authenticated(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         if not self.current_user:
-            if self.request.method in ("GET", "HEAD"):
+            if self.request.method in ("GET", "HEAD") and
+                self.request.headers.get("X-Requested-With", "") != "XMLHttpRequest":
                 url = self.get_login_url()
                 if "?" not in url:
                     if urlparse.urlsplit(url).scheme:


### PR DESCRIPTION
When using the web.authenticated decorator, it would be nice to not redirect to the login_url for unauthenticated XMLHttpRequests, but raise a 403 error instead. There is no foolproof way of detecting an XMLHttpRequest, but there seems to be some consensus amongst JS frameworks (mainly jQuery) to add the `X-Requested-With: XMLHttpRequest` header to same-origin requests.