### PR TITLE
Merge websocket_connect into the WebSocketClientConnection class

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -840,7 +840,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
     def read_message(self, callback=None):
         """Reads a message from the WebSocket server.
         
-        If `on_message_callback` was specified at WebSocket
+        If on_message_callback was specified at WebSocket
         initialization, this function will never return messages
 
         Returns a future whose result is the message, or None


### PR DESCRIPTION
It is currently extremely difficult to subclass WebSocketClientConnection without reimplementing websocket_connect due to the fact that WebSocketClientConnection is never really exposed outside the websocket module. In my program, my websocket client is also operating as a HTTP server so needing to loop on the websocket client's read_message is awkward.  I ended up subclassing WebSocketClientConnection and overriding its on_message to act more like an expected callback-type function but it seems like a hack since I also had to reimplement websocket_connect to use my own class.

My idea is to move the call the parent's __init__ to a connect function (which admittedly is also hacky) and change the connect_future's eventual return value to True/False value instead of returning a handle to the websocket client object.

EDIT: I'm happy to submit a merge request if people aren't opposed to the __init__ hackery.