### PR TITLE
Reuse self instead of a dedicated object key for Tasks and YieldFuture

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -374,16 +374,15 @@ class Task(YieldPoint):
 
     def start(self, runner):
         self.runner = runner
-        self.key = object()
-        runner.register_callback(self.key)
-        self.kwargs["callback"] = runner.result_callback(self.key)
+        runner.register_callback(self)
+        self.kwargs["callback"] = runner.result_callback(self)
         self.func(*self.args, **self.kwargs)
 
     def is_ready(self):
-        return self.runner.is_ready(self.key)
+        return self.runner.is_ready(self)
 
     def get_result(self):
-        return self.runner.pop_result(self.key)
+        return self.runner.pop_result(self)
 
 
 class YieldFuture(YieldPoint):
@@ -394,23 +393,21 @@ class YieldFuture(YieldPoint):
     def start(self, runner):
         if not self.future.done():
             self.runner = runner
-            self.key = object()
-            runner.register_callback(self.key)
-            self.io_loop.add_future(self.future,
-                                    runner.result_callback(self.key))
+            runner.register_callback(self)
+            self.io_loop.add_future(self.future, runner.result_callback(self))
         else:
             self.runner = None
             self.result = self.future.result()
 
     def is_ready(self):
         if self.runner is not None:
-            return self.runner.is_ready(self.key)
+            return self.runner.is_ready(self)
         else:
             return True
 
     def get_result(self):
         if self.runner is not None:
-            return self.runner.pop_result(self.key).result()
+            return self.runner.pop_result(self).result()
         else:
             return self.result
 


### PR DESCRIPTION
Just a minor improvement I noticed while playing with the code. And Pep8 fixes in a separate commit.
