### PR TITLE
Prevent a deadlock if ThreadedResolver resolves a unicode hostname at module-import time.

### DIFF
--- a/tornado/test/resolve_test.py
+++ b/tornado/test/resolve_test.py
@@ -1,0 +1,10 @@
+from tornado.ioloop import IOLoop
+from tornado.netutil import ThreadedResolver
+
+# When this module is imported, it runs getaddrinfo on a thread. Since
+# the hostname is unicode, getaddrinfo attempts to import encodings.idna
+# but blocks on the import lock. Verify that ThreadedResolver avoids
+# this deadlock.
+
+resolver = ThreadedResolver()
+IOLoop.current().run_sync(lambda: resolver.resolve(u'tornadoweb.org', 80))


### PR DESCRIPTION
To see the problem this solves, try:

```
PYTHONPATH=. python -c "import tornado.test.resolve_test"
```

Without the patch to ThreadedResolver, that import hangs.

I first discovered this in the process of debugging a [PyMongo issue](https://jira.mongodb.org/browse/PYTHON-607); Gevent had a deadlock and I found that Tornado is susceptible to the same bug.
