### PR TITLE
Define the timeout status code more clearly.

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -187,15 +187,21 @@ class AsyncHTTPClient(Configurable):
 
             def handle_future(future):
                 exc = future.exception()
+
+                status_code = 599
+                if isinstance(exc, HTTPError):
+                    status_code = exc.code
+
                 if isinstance(exc, HTTPError) and exc.response is not None:
                     response = exc.response
                 elif exc is not None:
                     response = HTTPResponse(
-                        request, 599, error=exc,
+                        request, status_code, error=exc,
                         request_time=time.time() - request.start_time)
                 else:
                     response = future.result()
                 self.io_loop.add_callback(callback, response)
+
             future.add_done_callback(handle_future)
 
         def handle_response(response):

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -207,9 +207,9 @@ class SimpleHTTPClientTestMixin(object):
     @skipOnTravis
     def test_request_timeout(self):
         response = self.fetch('/trigger?wake=false', request_timeout=0.1)
-        self.assertEqual(response.code, 599)
+        self.assertEqual(response.code, 524)
         self.assertTrue(0.099 < response.request_time < 0.15, response.request_time)
-        self.assertEqual(str(response.error), "HTTP 599: Timeout")
+        self.assertEqual(str(response.error), "HTTP 524: Timeout")
         # trigger the hanging request to let it clean up after itself
         self.triggers.popleft()()
 
@@ -307,9 +307,9 @@ class SimpleHTTPClientTestMixin(object):
                          connect_timeout=0.1)
             response = self.wait()
 
-            self.assertEqual(response.code, 599)
+            self.assertEqual(response.code, 598)
             self.assertTrue(response.request_time < 1, response.request_time)
-            self.assertEqual(str(response.error), "HTTP 599: Timeout")
+            self.assertEqual(str(response.error), "HTTP 598: Timeout")
             self.triggers.popleft()()
             self.wait()
 
@@ -432,4 +432,4 @@ class ResolveTimeoutTestCase(AsyncHTTPTestCase):
 
     def test_resolve_timeout(self):
         response = self.fetch('/hello', connect_timeout=0.1)
-        self.assertEqual(response.code, 599)
+        self.assertEqual(response.code, 522)


### PR DESCRIPTION
Sometimes we need to know the reasons for the failure of the HTTP Request, and we must distinguish between different timeout status, such as connect timeout and request timeout, so I think that clearly status code defining is necessary.

Status Code Reference from [Wikipedia](http://en.wikipedia.org/wiki/HTTP_status#5xx_Server_Error)
