### PR TITLE
Un-force relative in format_date and more on i18n

### DIFF
--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -310,16 +310,16 @@ class Locale(object):
         if not full_format:
             if relative and days == 0:
                 if seconds < 50:
-                    return _("1 second ago", "%(seconds)d seconds ago",
+                    return _("%(seconds)d second ago", "%(seconds)d seconds ago",
                              seconds) % {"seconds": seconds}
 
                 if seconds < 50 * 60:
                     minutes = round(seconds / 60.0)
-                    return _("1 minute ago", "%(minutes)d minutes ago",
+                    return _("%(minutes)d minute ago", "%(minutes)d minutes ago",
                              minutes) % {"minutes": minutes}
 
                 hours = round(seconds / (60.0 * 60))
-                return _("1 hour ago", "%(hours)d hours ago",
+                return _("%(hours)d hour ago", "%(hours)d hours ago",
                          hours) % {"hours": hours}
 
             if days == 0:


### PR DESCRIPTION
Previously discussed in #961

I've removed the lines in question and tested format_date in en_US and ru locales. It works as intended, however there's one more thing, not strictly related to the #961.

Since there are languages with more interesting pluralization rules than English [1](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html), I also used string formatting markers in singular form of some messages. This way it's less confusing to translators when the first plural form (when inflection is the same for 1 _and_ 21, for instance) requires a formatting marker, but there's none in the original string. Although, in fact, it will work without this change, and it is only "cosmetic", I've never seen a hardcoded `1` in singular form.
