### PR TITLE
Error handling in TwistedResolver

### DIFF
--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -527,8 +527,10 @@ class TwistedResolver(Resolver):
             resolved_family = socket.AF_INET6
         else:
             deferred = self.resolver.getHostByName(utf8(host))
-            resolved = yield gen.Task(deferred.addCallback)
-            if twisted.internet.abstract.isIPAddress(resolved):
+            resolved = yield gen.Task(deferred.addBoth)
+            if isinstance(resolved, failure.Failure):
+                resolved.raiseException()
+            elif twisted.internet.abstract.isIPAddress(resolved):
                 resolved_family = socket.AF_INET
             elif twisted.internet.abstract.isIPv6Address(resolved):
                 resolved_family = socket.AF_INET6


### PR DESCRIPTION
I'm testing Motor with Tornado 3's Resolver, and noticed that TwistedResolver doesn't handle errors. resolve() never executes its callback / resolves its Future, and when the Deferred is deleted it logs:

```
Unhandled error in Deferred:
Unhandled Error
Traceback (most recent call last):
Failure: twisted.names.error.DNSNameError: <twisted.names.dns.Message instance at 0x101958d40>
```
