### PR TITLE
Don't call logging.basicConfig if logging is already configured (#775). Replaces #887

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -549,16 +549,23 @@ class PollIOLoop(IOLoop):
             signal.signal(signal.SIGALRM,
                           action if action is not None else signal.SIG_DFL)
 
-    def start(self):
-        if not logging.getLogger().handlers:
-            # The IOLoop catches and logs exceptions, so it's
-            # important that log output be visible.  However, python's
-            # default behavior for non-root loggers (prior to python
-            # 3.2) is to print an unhelpful "no handlers could be
-            # found" message rather than the actual log entry, so we
-            # must explicitly configure logging if we've made it this
-            # far without anything.
+    def _setup_logging(self):
+        """The IOLoop catches and logs exceptions, so it's
+        important that log output be visible.  However, python's
+        default behavior for non-root loggers (prior to python
+        3.2) is to print an unhelpful "no handlers could be
+        found" message rather than the actual log entry, so we
+        must explicitly configure logging if we've made it this
+        far without anything.
+
+        """
+        if not any([logging.getLogger().handlers,
+                    logging.getLogger('tornado').handlers,
+                    logging.getLogger('tornado.application').handlers]):
             logging.basicConfig()
+
+    def start(self):
+        self._setup_logging()
         if self._stopped:
             self._stopped = False
             return


### PR DESCRIPTION
Will not call logging.basicConfig if there is a root logger,
tornado logger or tornado.application logger.

Updated patch to reflect comments in #887 about tests and method privacy.
