### PR TITLE
removed unnecessary else statements

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -219,11 +219,8 @@ class BaseIOStream(object):
             # write buffer, so we don't have to recopy the entire thing
             # as we slice off pieces to send to the socket.
             WRITE_BUFFER_CHUNK_SIZE = 128 * 1024
-            if len(data) > WRITE_BUFFER_CHUNK_SIZE:
-                for i in range(0, len(data), WRITE_BUFFER_CHUNK_SIZE):
-                    self._write_buffer.append(data[i:i + WRITE_BUFFER_CHUNK_SIZE])
-            else:
-                self._write_buffer.append(data)
+            for i in range(0, len(data), WRITE_BUFFER_CHUNK_SIZE):
+                self._write_buffer.append(data[i:i + WRITE_BUFFER_CHUNK_SIZE])
         self._write_callback = stack_context.wrap(callback)
         if not self._connecting:
             self._handle_write()


### PR DESCRIPTION
I think that `self._write_buffer.append(data)` is unnecessary because when data length is smaller than `WRITE_BUFFER_CHUNK_SIZE`, `self._write_buffer.append(data[i:i + WRITE_BUFFER_CHUNK_SIZE])` in for loop just works as same as `self._write_buffer.append(data)` when i is 0.
