### PR TITLE
 Fix for RequestHandler.write   to check for NoneType in argument [ fixed  code style compliance  regarding spaces]

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -604,6 +604,8 @@ class RequestHandler(object):
             raise RuntimeError("Cannot write() after finish().  May be caused "
                                "by using async operations without the "
                                "@asynchronous decorator.")
+        if not isinstance(chunk, (bytes_type, unicode_type, dict)):
+            raise TypeError("write() only accepts bytes, unicode, and dict objects")
         if isinstance(chunk, dict):
             chunk = escape.json_encode(chunk)
             self.set_header("Content-Type", "application/json; charset=UTF-8")


### PR DESCRIPTION
This is a fix for  https://github.com/facebook/tornado/issues/948,  
it adds a check  to ensure that the  `RequestHandler.write` method raises a
TypeError  if  its called with `None` as an argument.  
