### PR TITLE
make send_error aware of _auto_finish

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -722,8 +722,22 @@ js_embed()
 
 class NonWSGIWebTests(WebTestCase):
     def get_handlers(self):
+        class AutoFinishHandler(RequestHandler):
+            @asynchronous
+            def get(self):
+                1 / 0
+
+            def write_error(self, status_code, **kwargs):
+                from tornado.ioloop import IOLoop
+                IOLoop.current().add_callback(self.finish_callback)
+
+            def finish_callback(self):
+                self.set_header("Content-Type", "text/plain")
+                self.finish("Custom error")
+
         return [("/flow_control", FlowControlHandler),
                 ("/empty_flush", EmptyFlushCallbackHandler),
+                ("/auto_finish", AutoFinishHandler),
                 ]
 
     def test_flow_control(self):
@@ -732,6 +746,12 @@ class NonWSGIWebTests(WebTestCase):
     def test_empty_flush(self):
         response = self.fetch("/empty_flush")
         self.assertEqual(response.body, b"ok")
+
+    def test_write_error_auto_finish(self):
+        with ExpectLog(app_log, "Uncaught exception"):
+            response = self.fetch("/auto_finish")
+            self.assertEqual(response.code, 500)
+            self.assertEqual(b"Custom error", response.body)
 
 
 @wsgi_safe

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -863,8 +863,10 @@ class RequestHandler(object):
             self.write_error(status_code, **kwargs)
         except Exception:
             app_log.error("Uncaught exception in write_error", exc_info=True)
-        if not self._finished:
-            self.finish()
+            if not self._finished:
+                self.finish()
+        else:
+            self._execute_finish()
 
     def write_error(self, status_code, **kwargs):
         """Override to implement custom error pages.


### PR DESCRIPTION
It is impossible to defer self.finish in `write_error` while in `auto_flush=False` mode

Consider the following example:

``` python
def write_error(self, status_code, **kwargs):
    def _finish_callback():
        self.finish('Error')
    IOLoop.add_callback(_finish_callback)
```

This would not work, because `send_error` in the end calls `self.finish()` (https://github.com/facebook/tornado/blob/master/tornado/web.py#L876), even if `auto_flush` is False

I propose to call `_execute_finish` instead, it seems that it shouldn't break compatibility in any way.
