### PR TITLE
Add JSON support to parse_body_arguments

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -25,7 +25,7 @@ import email.utils
 import numbers
 import time
 
-from tornado.escape import native_str, parse_qs_bytes, utf8
+from tornado.escape import native_str, parse_qs_bytes, utf8, json_decode
 from tornado.log import gen_log
 from tornado.util import ObjectDict
 
@@ -313,8 +313,8 @@ def _int_or_none(val):
 def parse_body_arguments(content_type, body, arguments, files):
     """Parses a form request body.
 
-    Supports ``application/x-www-form-urlencoded`` and
-    ``multipart/form-data``.  The ``content_type`` parameter should be
+    Supports ``application/x-www-form-urlencoded``, ``application/json``,
+    and ``multipart/form-data``.  The ``content_type`` parameter should be
     a string and ``body`` should be a byte string.  The ``arguments``
     and ``files`` parameters are dictionaries that will be updated
     with the parsed contents.
@@ -328,6 +328,17 @@ def parse_body_arguments(content_type, body, arguments, files):
         for name, values in uri_arguments.items():
             if values:
                 arguments.setdefault(name, []).extend(values)
+    elif content_type.startswith("application/json"):
+        try:
+            json_arguments = json_decode(native_str(body))
+        except Exception as e:
+            gen_log.warning('Invalid application/json body: %s', e)
+            json_arguments = {}
+        for name, values in json_arguments.items():
+            if isinstance(values, list):
+                arguments.setdefault(name, values)
+            else:
+                arguments.setdefault(name, []).append(values)
     elif content_type.startswith("multipart/form-data"):
         fields = content_type.split(";")
         for field in fields:

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -258,10 +258,10 @@ class FormatTimestampTest(unittest.TestCase):
 class ParseBodyArgumentsTest(unittest.TestCase):
 
     FORM_BODY = b'foo=bar&baz=qux&baz=corgie'
-    FORM_EXPECTED = {b"foo": [b"bar"], b"baz": [b"qux", b"corgie"]}
+    FORM_EXPECTED = {"foo": [b"bar"], "baz": [b"qux", b"corgie"]}
 
     JSON_BODY = b'{"foo": "bar", "baz": ["qux", "corgie"]}'
-    JSON_EXPECTED = {b"foo": [b"bar"], b"baz": [b"qux", b"corgie"]}
+    JSON_EXPECTED = {"foo": ["bar"], "baz": ["qux", "corgie"]}
 
     MULTIPART_BODY = b"""\
 --AaB03x
@@ -278,7 +278,7 @@ Content-Disposition: form-data; name="baz"
 corgie
 --AaB03x--
 """.replace(b"\n", b"\r\n")
-    MULTIPART_EXPECTED = {b"foo": [b"bar"], b"baz": [b"qux", b"corgie"]}
+    MULTIPART_EXPECTED = {"foo": [b"bar"], "baz": [b"qux", b"corgie"]}
 
     def test_form_body(self):
         arguments = {}


### PR DESCRIPTION
This patch adds support for a JSON request body for POST/PATCH/PUT requests. JSON bodies are constructed the same as the other request body arguments to ensure API compatibility with RequestHandler.get_body_argument and RequestHandler.get_body_arguments.

Additionally minimal added test coverage to parse_body_arguments