### PR TITLE
Add write_buffer_size property and max_write_buffer_size limitation to iostream.

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -315,11 +315,6 @@ class BaseIOStream(object):
         """Returns true if we are currently writing to the stream."""
         return bool(self._write_buffer)
 
-    @property
-    def write_buffer_size(self):
-        """Returns how many bytes in write buffer."""
-        return self._write_buffer_size
-
     def closed(self):
         """Returns true if the stream has been closed."""
         return self._closed


### PR DESCRIPTION
In the case of chat application, slow client or TCP timeout may consume very large write buffer.
To write robust application, iostream should support limiting write buffer size.
