### PR TITLE
[httpserver.py] self.get_arguments do NOT work for 'DELETE' and 'OPTIONS' http method

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -334,7 +334,7 @@ class HTTPConnection(object):
 
     def _on_request_body(self, data):
         self._request.body = data
-        if self._request.method in ("POST", "PATCH", "PUT"):
+        if self._request.method in ("POST", "PATCH", "PUT", "DELETE", "OPTIONS"):
             httputil.parse_body_arguments(
                 self._request.headers.get("Content-Type", ""), data,
                 self._request.body_arguments, self._request.files)


### PR DESCRIPTION
There may be some disagreement on the understanding of HTTP Protocol between Tornado and jQuery.
I found sometimes I can not use self.get_argument() to get the data. So I conduct a test:

``` CoffeeScript
for method in ['GET', 'POST', 'HEAD', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']
  $.ajax
    url: '/api/test'
    type: method
    data:
      foo: 'bar'
    success: (evt) ->
        console.log 'foobar'
```

I send each of ''GET', 'POST', 'HEAD', 'PUT', 'PATCH', 'OPTIONS', 'DELETE'' method in $.ajax, examine the HTTP request with Chrome debugger and the results of self.get_argument in RequestHandler, finding that

| method | GET | POST | HEAD | PUT | PATCH | OPTIONS | DELETE |
| --- | --- | --- | --- | --- | --- | --- | --- |
| in Query String paras | Yes | no | Yes | no | no | no | no |
| in Form data | no | Yes | no | Yes | Yes | Yes | Yes |
| in self.request.arguments | Yes | Yes | Yes | Yes | Yes | no | no |
| in self.request.body | no | Yes | no | Yes | Yes | Yes | Yes |
| in self.get_argument | Yes | Yes | Yes | Yes | Yes | no | no |

When the method is OPTIONS or DELETE, I can not use self.get_argument('foo') to get the value I set in ajax request.

Since I'm not familiar with HTTP protocol, I do not understanding the line of code.
Is is a bug? I guess.
