### PR TITLE
remove useless code of BaseIOStream

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -203,7 +203,6 @@ class BaseIOStream(object):
             self._run_read_callback(self._consume(self._read_buffer_size))
             return future
         self._read_until_close = True
-        self._streaming_callback = stack_context.wrap(streaming_callback)
         self._try_inline_read()
         return future
 


### PR DESCRIPTION
Just found a line of duplication in BaseIOStream in iostream.py, [line 206](https://github.com/facebook/tornado/blob/master/tornado/iostream.py#L206).

It  re-assigns value to `self._stream_callback`, which is already done in [line 198](https://github.com/facebook/tornado/blob/master/tornado/iostream.py#L198). 
