### PR TITLE
fix timeouts less than 1 sec when libcurl is compiled without c-ares

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -25,6 +25,11 @@ to switch to ``curl_httpclient`` for reasons such as the following:
 Note that if you are using ``curl_httpclient``, it is highly recommended that
 you use a recent version of ``libcurl`` and ``pycurl``.  Currently the minimum
 supported version is 7.18.2, and the recommended version is 7.21.1 or newer.
+It is highly recommended that your ``libcurl`` installation is built with
+asynchronous DNS resolver (threaded or c-ares), otherwise you may encounter
+various problems with request timeouts (for more information, see
+http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTCONNECTTIMEOUTMS
+and comments in curl_httpclient.py).
 """
 
 from __future__ import absolute_import, division, print_function, with_statement


### PR DESCRIPTION
Consider the following excerpt from libcurl documentation:

```
CURLOPT_CONNECTTIMEOUT_MS

Like CURLOPT_CONNECTTIMEOUT but takes the number of milliseconds instead. If libcurl
is built to use the standard system name resolver, that portion of the connect will still
use full-second resolution for timeouts with a minimum timeout allowed of one second.
(Added in 7.16.2)
```

That means, if the timeout has a value less than a second, it will fail if libcurl is built without c-ares. We should check this and fall back to the minimum value (1 second).

It is also safe (and preferable) to set NOSIGNAL when using libcurl + c-ares. However, without c-ares it leads to ignoring all timeouts.
