### PR TITLE
add IOLoop.clear_instance

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -158,6 +158,12 @@ class IOLoop(Configurable):
         IOLoop._instance = self
 
     @staticmethod
+    def clear_instance():
+        """Clear the global `IOLoop` instance."""
+        if hasattr(IOLoop, "_instance"):
+            del IOLoop._instance
+
+    @staticmethod
     def current():
         """Returns the current thread's `IOLoop`.
 


### PR DESCRIPTION
like clear_current, but for the global IOLoop instance

This came up when helping someone work out an issue dealing with resetting state after a fork.
