### PR TITLE
Correct function that converts object to unicode string or string encoded as utf8

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -262,6 +262,7 @@ class Template(object):
             "datetime": datetime,
             "_tt_utf8": escape.utf8,  # for internal use
             "_tt_string_types": (unicode_type, bytes_type),
+            "_tt_str": unicode_type,
             # __name__ and __loader__ allow the traceback mechanism to find
             # the generated source code.
             "__name__": self.name.replace('.', '_'),
@@ -542,7 +543,7 @@ class _Expression(_Node):
         writer.write_line("_tt_tmp = %s" % self.expression, self.line)
         writer.write_line("if isinstance(_tt_tmp, _tt_string_types):"
                           " _tt_tmp = _tt_utf8(_tt_tmp)", self.line)
-        writer.write_line("else: _tt_tmp = _tt_utf8(str(_tt_tmp))", self.line)
+        writer.write_line("else: _tt_tmp = _tt_utf8(_tt_str(_tt_tmp))", self.line)
         if not self.raw and writer.current_template.autoescape is not None:
             # In python3 functions like xhtml_escape return unicode,
             # so we have to convert to utf8 again.


### PR DESCRIPTION
``` Python
class Foo(object):
    text = u'\u4e2d\u56fd' # they are two chinese characters    

    def __str__(self):
        return self.text
    def __unicode__(self):
        return self.text

foo = Foo()
print str(foo)
```

If object "foo" is an instance of class "Foo", str(foo) will raise the following Exception:

``` Python
Traceback (most recent call last):
  File "/tmp/test.py", line 12, in <module>
    print str(foo)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

unicode(foo) will work. Under Python3.x, we use str(). In case of Python2.x, we use unicode().
