### PR TITLE
fixed broken reference link

### DIFF
--- a/tornado/platform/common.py
+++ b/tornado/platform/common.py
@@ -15,7 +15,8 @@ class Waker(interface.Waker):
     and Jython.
     """
     def __init__(self):
-        # Based on Zope async.py: http://svn.zope.org/zc.ngi/trunk/src/zc/ngi/async.py
+        # Based on Zope select_trigger.py:
+        # https://github.com/zopefoundation/Zope/blob/master/src/ZServer/medusa/thread/select_trigger.py
 
         self.writer = socket.socket()
         # Disable buffering -- pulling the trigger sends 1 byte,


### PR DESCRIPTION
`http://svn.zope.org/zc.ngi/trunk/src/zc/ngi/async.py` was moved to github.
I fixed that link to github repository.
