### PR TITLE
Add SystemError to errors from compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ if sys.platform == 'win32' and sys.version_info > (2, 6):
     build_errors = (CCompilerError, DistutilsExecError,
                     DistutilsPlatformError, IOError)
 else:
-    build_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+    build_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
+                    SystemError)
 
 class custom_build_ext(build_ext):
     """Allow C extension building to fail.


### PR DESCRIPTION
OSX generates a SystemError from a missing compiler; trap with other 
compilation errors.
