### PR TITLE
Delete description for cookie capacity

### DIFF
--- a/demos/twitter/twitterdemo.py
+++ b/demos/twitter/twitterdemo.py
@@ -62,6 +62,7 @@ class LoginHandler(BaseHandler, TwitterMixin):
     def get(self):
         if self.get_argument('oauth_token', None):
             user = yield self.get_authenticated_user()
+            del user["description"]
             self.set_secure_cookie(self.COOKIE_NAME, json_encode(user))
             self.redirect(self.get_argument('next', '/'))
         else:


### PR DESCRIPTION
If a user have long data in twitter, we cannot save any secure_cookie due to cookie limit. 
This may occur to users who use multi-byte characters.
