### PR TITLE
Update overview.rst with typos in nginx conf.

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1095,7 +1095,7 @@ running on ports 8000 - 8003:
             location / {
                 proxy_pass_header Server;
                 proxy_set_header Host $http_host;
-                proxy_redirect false;
+                proxy_redirect off;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Scheme $scheme;
                 proxy_pass http://frontends;


### PR DESCRIPTION
Minor correction in the production nginx server conf with proxy_redirect as off; previously it was false but there is no such option in nginx proxy_redirect.
