### PR TITLE
Changed _on_close method tornado/simple_httpclient.py to raise the error instead of raising an HTTPError

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -371,7 +371,7 @@ class _HTTPConnection(object):
         if self.final_callback is not None:
             message = "Connection closed"
             if self.stream.error:
-                message = str(self.stream.error)
+                raise self.stream.error
             raise HTTPError(599, message)
 
     def _handle_1xx(self, code):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -114,25 +114,23 @@ class WebSocketTest(AsyncHTTPTestCase):
     def test_websocket_network_timeout(self):
         sock, port = bind_unused_port()
         sock.close()
-        with self.assertRaises(HTTPError) as cm:
+        with self.assertRaises(IOError) as cm:
             with ExpectLog(gen_log, ".*"):
                 yield websocket_connect(
                     'ws://localhost:%d/' % port,
                     io_loop=self.io_loop,
                     connect_timeout=0.01)
-        self.assertEqual(cm.exception.code, 599)
 
     @gen_test
     def test_websocket_network_fail(self):
         sock, port = bind_unused_port()
         sock.close()
-        with self.assertRaises(HTTPError) as cm:
+        with self.assertRaises(IOError) as cm:
             with ExpectLog(gen_log, ".*"):
                 yield websocket_connect(
                     'ws://localhost:%d/' % port,
                     io_loop=self.io_loop,
                     connect_timeout=3600)
-        self.assertEqual(cm.exception.code, 599)
 
     @gen_test
     def test_websocket_close_buffered_data(self):


### PR DESCRIPTION
This is a patch for https://github.com/facebook/tornado/issues/1033
1. Changed tornado/simple_httpclient.py to raise the error instead of storing the error message in a string and then raising an HTTPError. 
2. Changed the websocket tests for network_fail and network_timeout to expect an IOError instead of an HTTPError. No error numbers are checked as these are platform independent. It should be sufficient to check the error types.
