### PR TITLE
Fixed tests on Windows.

### DIFF
--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -219,7 +219,7 @@ class TestIOLoop(AsyncTestCase):
             client_sock.connect(('127.0.0.1', port))
             self.wait()
         self.assertIs(fds[0], server_sock)
-        self.assertIs(fds[1], server_sock.fileno())
+        self.assertEqual(fds[1], server_sock.fileno())
         self.io_loop.remove_handler(server_sock.fileno())
         server_sock.close()
 

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -96,6 +96,7 @@ class ThreadedResolverTest(AsyncTestCase, _ResolverTestMixin):
 
 @skipIfNoNetwork
 @unittest.skipIf(futures is None, "futures module not present")
+@unittest.skipIf(sys.platform == 'win32', "preexec_fn not available on win32")
 class ThreadedResolverImportTest(unittest.TestCase):
     def test_import(self):
         TIMEOUT = 5


### PR DESCRIPTION
Errors were

```
======================================================================
FAIL: test_handler_callback_file_object (tornado.test.ioloop_test.TestIOLoop)
The handler callback receives the same fd object it passed in.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\schlaich\Documents\GitHub\typhoon\.tox\py27\lib\site-packages\tornado\testing.py", line 118, in __call__
    result = self.orig_method()
  File "C:\Users\schlaich\Documents\GitHub\typhoon\.tox\py27\lib\site-packages\tornado\test\ioloop_test.py", line 222, in test_handler_callback_file_object
    self.assertIs(fds[1], server_sock.fileno())
AssertionError: 1696 is not 1696

======================================================================
ERROR: test_import (tornado.test.netutil_test.ThreadedResolverImportTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\schlaich\Documents\GitHub\typhoon\.tox\py33\lib\site-packages\tornado\test\netutil_test.py", line 112, in test_import
    popen = Popen(command, preexec_fn=lambda: signal.alarm(TIMEOUT))
  File "c:\python33\Lib\subprocess.py", line 732, in __init__
    raise ValueError("preexec_fn is not supported on Windows "
ValueError: preexec_fn is not supported on Windows platforms
```
