### PR TITLE
Fix for ticket #904 - Addition of get_claimed_ip() to HTTPRequest

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -542,6 +542,10 @@ class HTTPRequest(object):
         except ssl.SSLError:
             return None
 
+    def get_claimed_ip(self):
+        """Returns the first public IP address from the X-Forwarded-For"""
+        return self.remote_ip
+        
     def __repr__(self):
         attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
         args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])


### PR DESCRIPTION
As per ticket description of ticket #904, a method to return the first
public IP address from X-Forwarded-For should be implemented. This
update contains the below changes:
1. In tornado/httpserver.py
   HTTPRequest.get_claimed_ip() is implemented which simply returns
   remote_ip
2. In tornado/test/httpserver_test.py
   The test for verifying ip_headers already existed in XHeaders. I simply
   modified the internal class Handler to retrieve the output of
   get_claimed_ip from the request messge and write it to the dictionary.
   The same tests that were written for verifying ip_headers have been
   re-used except that they now check that remote ip equals claimed_ip
