### PR TITLE
Fixed websocket test.

### DIFF
--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -114,7 +114,7 @@ class WebSocketTest(AsyncHTTPTestCase):
     def test_websocket_network_timeout(self):
         sock, port = bind_unused_port()
         sock.close()
-        with self.assertRaises(IOError) as cm:
+        with self.assertRaises((HTTPError, IOError)) as cm:
             with ExpectLog(gen_log, ".*"):
                 yield websocket_connect(
                     'ws://localhost:%d/' % port,


### PR DESCRIPTION
Previous error:

```
======================================================================
ERROR: test_websocket_network_timeout (tornado.test.websocket_test.WebSocketTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\testing.py", line 118, in __call__
    result = self.orig_method()
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\testing.py", line 488, in post_coroutine
    functools.partial(coro, self), timeout=timeout)
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\ioloop.py", line 418, in run_sync

    return future_cell[0].result()
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\concurrent.py", line 109, in result
    raise_exc_info(self._exc_info)
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\gen.py", line 585, in run
    yielded = self.gen.throw(*sys.exc_info())
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\test\websocket_test.py", line 122, in test_websocket_network_timeout
    connect_timeout=0.01)
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\gen.py", line 582, in run
    value = future.result()
  File "C:\Users\schlaich\Documents\GitHub\tornado\.tox\py27\lib\site-packages\tornado\concurrent.py", line 111, in result
    raise self._exception
HTTPError: HTTP 599: Timeout

----------------------------------------------------------------------
```
