### PR TITLE
Extended gen_test decorator to pass args and kwargs.

### DIFF
--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -198,5 +198,23 @@ class GenTest(AsyncTestCase):
 
         self.finished = True
 
+    def test_with_method_args(self):
+        @gen_test
+        def test_with_args(self, *args):
+            self.assertEqual(args, ('test',))
+            yield gen.Task(self.io_loop.add_callback)
+
+        test_with_args(self, 'test')
+        self.finished = True
+
+    def test_with_method_kwargs(self):
+        @gen_test
+        def test_with_kwargs(self, **kwargs):
+            self.assertDictEqual(kwargs, {'test': 'test'})
+            yield gen.Task(self.io_loop.add_callback)
+
+        test_with_kwargs(self, test='test')
+        self.finished = True
+
 if __name__ == '__main__':
     unittest.main()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -471,8 +471,8 @@ def gen_test(func=None, timeout=None):
         # This is a good case study arguing for either some sort of
         # extensibility in the gen decorators or cancellation support.
         @functools.wraps(f)
-        def pre_coroutine(self):
-            result = f(self)
+        def pre_coroutine(self, *args, **kwargs):
+            result = f(self, *args, **kwargs)
             if isinstance(result, types.GeneratorType):
                 self._test_generator = result
             else:
@@ -482,10 +482,11 @@ def gen_test(func=None, timeout=None):
         coro = gen.coroutine(pre_coroutine)
 
         @functools.wraps(coro)
-        def post_coroutine(self):
+        def post_coroutine(self, *args, **kwargs):
             try:
                 return self.io_loop.run_sync(
-                    functools.partial(coro, self), timeout=timeout)
+                    functools.partial(coro, self, *args, **kwargs),
+                    timeout=timeout)
             except TimeoutError as e:
                 # run_sync raises an error with an unhelpful traceback.
                 # If we throw it back into the generator the stack trace


### PR DESCRIPTION
A use case might be a decorated test class that passes arguments to each class method, like mock.patch for instance.
