### PR TITLE
check for errno.WSA* on 64-bit Windows (fixes #1052)

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -57,12 +57,24 @@ except ImportError:
 # some they differ.
 _ERRNO_WOULDBLOCK = (errno.EWOULDBLOCK, errno.EAGAIN)
 
+if hasattr(errno, "WSAEWOULDBLOCK"):
+    _ERRNO_WOULDBLOCK += (errno.WSAEWOULDBLOCK,)
+
 # These errnos indicate that a connection has been abruptly terminated.
 # They should be caught and handled less noisily than other errors.
 _ERRNO_CONNRESET = (errno.ECONNRESET, errno.ECONNABORTED, errno.EPIPE,
                     errno.ETIMEDOUT)
 
+if hasattr(errno, "WSAECONNRESET"):
+    _ERRNO_CONNRESET += (errno.WSAECONNRESET, errno.WSAECONNABORTED, errno.WSAETIMEDOUT)
 
+# More non-portable errnos:
+_ERRNO_INPROGRESS = (errno.EINPROGRESS,)
+
+if hasattr(errno, "WSAEINPROGRESS"):
+    _ERRNO_INPROGRESS += (errno.WSAEINPROGRESS,)
+
+#######################################################
 class StreamClosedError(IOError):
     """Exception raised by `IOStream` methods when the stream is closed.
 
@@ -990,7 +1002,7 @@ class IOStream(BaseIOStream):
             # returned immediately when attempting to connect to
             # localhost, so handle them the same way as an error
             # reported later in _handle_connect.
-            if (errno_from_exception(e) != errno.EINPROGRESS and
+            if (errno_from_exception(e) not in _ERRNO_INPROGRESS and
                     errno_from_exception(e) not in _ERRNO_WOULDBLOCK):
                 gen_log.warning("Connect error on fd %s: %s",
                                 self.socket.fileno(), e)

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -57,6 +57,9 @@ u('foo').encode('idna')
 # some they differ.
 _ERRNO_WOULDBLOCK = (errno.EWOULDBLOCK, errno.EAGAIN)
 
+if hasattr(errno, "WSAEWOULDBLOCK"):
+    _ERRNO_WOULDBLOCK += (errno.WSAEWOULDBLOCK,)
+
 
 def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128, flags=None):
     """Creates listening sockets bound to the given port and address.

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -232,8 +232,11 @@ class TestIOStreamMixin(object):
         self.assertFalse(self.connect_called)
         self.assertTrue(isinstance(stream.error, socket.error), stream.error)
         if sys.platform != 'cygwin':
+            _ERRNO_CONNREFUSED = (errno.ECONNREFUSED,)
+            if hasattr(errno, "WSAECONNREFUSED"):
+                _ERRNO_CONNREFUSED += (errno.WSAECONNREFUSED,)
             # cygwin's errnos don't match those used on native windows python
-            self.assertEqual(stream.error.args[0], errno.ECONNREFUSED)
+            self.assertTrue(stream.error.args[0] in _ERRNO_CONNREFUSED)
 
     def test_gaierror(self):
         # Test that IOStream sets its exc_info on getaddrinfo error

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -321,8 +321,10 @@ class SimpleHTTPClientTestMixin(object):
 
         if sys.platform != 'cygwin':
             # cygwin returns EPERM instead of ECONNREFUSED here
-            self.assertTrue(str(errno.ECONNREFUSED) in str(response.error),
-                            response.error)
+            contains_errno = str(errno.ECONNREFUSED) in str(response.error)
+            if not contains_errno and hasattr(errno, "WSAECONNREFUSED"):
+                contains_errno = str(errno.WSAECONNREFUSED) in str(response.error)
+            self.assertTrue(contains_errno, response.error)
             # This is usually "Connection refused".
             # On windows, strerror is broken and returns "Unknown error".
             expected_message = os.strerror(errno.ECONNREFUSED)


### PR DESCRIPTION
As suggested by Ben, I added `errno.WSA*` versions of various errors to `_ERRNO_WOULDBLOCK` and `_ERRNO_CONNRESET`. I also introduced a new tuple `_ERRNO_INPROGRESS` for the INPROGRESS check, and changed the test suite accordingly. 

The test suite now runs on 64-bit Windows (Python 2.7, Visual Studio 2012), with two exceptions:

```
======================================================================
ERROR: test_request_timeout (tornado.test.simple_httpclient_test.SimpleHTTPClientTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tornado\testing.py", line 118, in __call__
    result = self.orig_method()
  File "tornado\test\simple_httpclient_test.py", line 243, in test_request_timeout
    self.triggers.popleft()()
IndexError: pop from an empty deque
======================================================================
ERROR: test_request_timeout (tornado.test.simple_httpclient_test.SimpleHTTPSClientTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tornado\testing.py", line 118, in __call__
    result = self.orig_method()
  File "tornado\test\simple_httpclient_test.py", line 243, in test_request_timeout
    self.triggers.popleft()()
IndexError: pop from an empty deque
```

It seems that these errors are unrelated to the present issue.
