### PR TITLE
disable exception raising behavior

### DIFF
--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -362,6 +362,11 @@ Transfer-Encoding: chunked
         self.assertEqual(context.exception.response.code, 404)
 
     @gen_test
+    def test_future_http_error_no_raise(self):
+        response = yield self.http_client.fetch(self.get_url('/notfound'), raise_error=False)
+        self.assertEqual(response.code, 404)
+
+    @gen_test
     def test_reuse_request_from_response(self):
         # The response.request attribute should be an HTTPRequest, not
         # a _RequestProxy.


### PR DESCRIPTION
Pass raise_error=False to the fetch method to disable the raising of
HTTPError on errors.
