### PR TITLE
Write curl_httpclient logs to a separate logger

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -26,7 +26,6 @@ import time
 
 from tornado import httputil
 from tornado import ioloop
-from tornado.log import gen_log
 from tornado import stack_context
 
 from tornado.escape import utf8, native_str
@@ -37,6 +36,8 @@ try:
     from io import BytesIO  # py3
 except ImportError:
     from cStringIO import StringIO as BytesIO  # py2
+
+curl_log = logging.getLogger("tornado.curl_httpclient")
 
 
 class CurlAsyncHTTPClient(AsyncHTTPClient):
@@ -268,7 +269,7 @@ class CurlError(HTTPError):
 
 def _curl_create():
     curl = pycurl.Curl()
-    if gen_log.isEnabledFor(logging.DEBUG):
+    if curl_log.isEnabledFor(logging.DEBUG):
         curl.setopt(pycurl.VERBOSE, 1)
         curl.setopt(pycurl.DEBUGFUNCTION, _curl_debug)
     return curl
@@ -421,11 +422,11 @@ def _curl_setup_request(curl, request, buffer, headers):
             raise ValueError("Unsupported auth_mode %s" % request.auth_mode)
 
         curl.setopt(pycurl.USERPWD, native_str(userpwd))
-        gen_log.debug("%s %s (username: %r)", request.method, request.url,
-                      request.auth_username)
+        curl_log.debug("%s %s (username: %r)", request.method, request.url,
+                       request.auth_username)
     else:
         curl.unsetopt(pycurl.USERPWD)
-        gen_log.debug("%s %s", request.method, request.url)
+        curl_log.debug("%s %s", request.method, request.url)
 
     if request.client_cert is not None:
         curl.setopt(pycurl.SSLCERT, request.client_cert)
@@ -465,12 +466,12 @@ def _curl_header_callback(headers, header_line):
 def _curl_debug(debug_type, debug_msg):
     debug_types = ('I', '<', '>', '<', '>')
     if debug_type == 0:
-        gen_log.debug('%s', debug_msg.strip())
+        curl_log.debug('%s', debug_msg.strip())
     elif debug_type in (1, 2):
         for line in debug_msg.splitlines():
-            gen_log.debug('%s %s', debug_types[debug_type], line)
+            curl_log.debug('%s %s', debug_types[debug_type], line)
     elif debug_type == 4:
-        gen_log.debug('%s %r', debug_types[debug_type], debug_msg)
+        curl_log.debug('%s %r', debug_types[debug_type], debug_msg)
 
 if __name__ == "__main__":
     AsyncHTTPClient.configure(CurlAsyncHTTPClient)


### PR DESCRIPTION
curl_httpclient is too verbose even for debug mode (it logs HTTP headers, connection events, etc)
If it used a separate logger, then we could just turn it off, but unfortunately, it writes to gen_log