### PR TITLE
Fixes bug disallowing custom-made reason phrase

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -919,7 +919,7 @@ class RequestHandler(object):
             return
         self.clear()
 
-        reason = None
+        reason = kwargs.get('reason')
         if 'exc_info' in kwargs:
             exception = kwargs['exc_info'][1]
             if isinstance(exception, HTTPError) and exception.reason:


### PR DESCRIPTION
The send_error method is, I believe, supposed to allow sending an HTTP reason phrase that is not one of the standard ones. This change corrects an apparent bug which made this impossible. With the correction, specifying an 'error' keyword argument to send_error actually sends the specified
reason phrase to the client.
