### PR TITLE
Removed dead "io.BytesIO vs cStringIO.StringIO" code

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -23,6 +23,7 @@ import logging
 import pycurl
 import threading
 import time
+from io import BytesIO
 
 from tornado import httputil
 from tornado import ioloop
@@ -32,11 +33,6 @@ from tornado import stack_context
 from tornado.escape import utf8, native_str
 from tornado.httpclient import HTTPResponse, HTTPError, AsyncHTTPClient, main
 from tornado.util import bytes_type
-
-try:
-    from io import BytesIO  # py3
-except ImportError:
-    from cStringIO import StringIO as BytesIO  # py2
 
 
 class CurlAsyncHTTPClient(AsyncHTTPClient):

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -19,11 +19,8 @@ import functools
 import re
 import socket
 import sys
+from io import BytesIO
 
-try:
-    from io import BytesIO  # python 3
-except ImportError:
-    from cStringIO import StringIO as BytesIO  # python 2
 
 try:
     import urlparse  # py2

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -8,6 +8,7 @@ from contextlib import closing
 import functools
 import sys
 import threading
+from io import BytesIO
 
 from tornado.escape import utf8
 from tornado.httpclient import HTTPRequest, HTTPResponse, _RequestProxy, HTTPError, HTTPClient
@@ -21,11 +22,6 @@ from tornado.testing import AsyncHTTPTestCase, bind_unused_port, gen_test, Expec
 from tornado.test.util import unittest, skipOnTravis
 from tornado.util import u, bytes_type
 from tornado.web import Application, RequestHandler, url
-
-try:
-    from io import BytesIO  # python 3
-except ImportError:
-    from cStringIO import StringIO as BytesIO
 
 
 class HelloWorldHandler(RequestHandler):

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -25,11 +25,7 @@ import socket
 import ssl
 import sys
 import tempfile
-
-try:
-    from io import BytesIO  # python 3
-except ImportError:
-    from cStringIO import StringIO as BytesIO  # python 2
+from io import BytesIO
 
 
 def read_stream_body(stream, callback):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -72,6 +72,7 @@ import time
 import tornado
 import traceback
 import types
+from io import BytesIO
 
 from tornado.concurrent import Future, is_future
 from tornado import escape
@@ -85,10 +86,6 @@ from tornado import template
 from tornado.escape import utf8, _unicode
 from tornado.util import bytes_type, import_object, ObjectDict, raise_exc_info, unicode_type, _websocket_mask
 
-try:
-    from io import BytesIO  # python 3
-except ImportError:
-    from cStringIO import StringIO as BytesIO  # python 2
 
 try:
     import Cookie  # py2

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -32,6 +32,7 @@ provides WSGI support in two ways:
 from __future__ import absolute_import, division, print_function, with_statement
 
 import sys
+from io import BytesIO
 import tornado
 
 from tornado.concurrent import Future
@@ -42,10 +43,6 @@ from tornado import web
 from tornado.escape import native_str
 from tornado.util import bytes_type, unicode_type
 
-try:
-    from io import BytesIO  # python 3
-except ImportError:
-    from cStringIO import StringIO as BytesIO  # python 2
 
 try:
     import urllib.parse as urllib_parse  # py3


### PR DESCRIPTION
io.BytesIO is available since Python 2.6; Tornado doesn't support Python 2.5, so there won't be ImportError.

There is similar code in maint folder; I haven't changed it.

If the intention was to use (persumably) faster cStringIO in Python 2.x then instead of removing the conditional imports they should be changed to 

```
try:
    from cStringIO import StringIO as BytesIO # py2
except ImportError:
    from io import BytesIO # py3
```
