### PR TITLE
make IOCMD_RESTARTREAD available for PUT requests

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -405,12 +405,12 @@ def _curl_setup_request(curl, request, buffer, headers):
     # Handle curl's cryptic options for every individual HTTP method
     if request.method in ("POST", "PUT"):
         request_buffer = BytesIO(utf8(request.body))
+        def ioctl(cmd):
+            if cmd == curl.IOCMD_RESTARTREAD:
+                request_buffer.seek(0)
         curl.setopt(pycurl.READFUNCTION, request_buffer.read)
+        curl.setopt(pycurl.IOCTLFUNCTION, ioctl)
         if request.method == "POST":
-            def ioctl(cmd):
-                if cmd == curl.IOCMD_RESTARTREAD:
-                    request_buffer.seek(0)
-            curl.setopt(pycurl.IOCTLFUNCTION, ioctl)
             curl.setopt(pycurl.POSTFIELDSIZE, len(request.body))
         else:
             curl.setopt(pycurl.INFILESIZE, len(request.body))


### PR DESCRIPTION
I don't know the original reason why `IOCTLFUNCTION` was available for `POST` requests only.
We are receiving 307 redirects from Amazon for `PUT` requests, and without this curl returns:

```
CurlError: HTTP 599: necessary data rewind wasn't possible
```
