### PR TITLE
Cancelable Future from AsyncHTTPClient (for SimpleHTTPClient)

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -96,7 +96,7 @@ class Future(object):
         self._cancelled = self._cancel_callback()
         if self._cancelled:
             self._done = True
-        return self.cancelled
+        return self._cancelled
 
     def cancelled(self):
         """Returns True if the operation has been canceled."""

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -73,7 +73,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         self._multi.close()
         super(CurlAsyncHTTPClient, self).close()
 
-    def fetch_impl(self, request, callback):
+    def fetch_impl(self, request, callback, future=None):
         self._requests.append((request, callback))
         self._process_queue()
         self._set_timeout(0)

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -242,10 +242,10 @@ class AsyncHTTPClient(Configurable):
                 future.set_exception(response.error)
             else:
                 future.set_result(response)
-        self.fetch_impl(request, handle_response)
+        self.fetch_impl(request, handle_response, future)
         return future
 
-    def fetch_impl(self, request, callback):
+    def fetch_impl(self, request, callback, future=None):
         raise NotImplementedError()
 
     @classmethod


### PR DESCRIPTION
This is a draft that will make the Future returned by the `AsyncHTTPClient` cancelable when the underlying implementation makes it possible.  In this particular case, it only makes that connection with `SimpleHTTPClient`.

This should make a solution to tornadoweb/tornado#157.

I'm sure it could use some more love and definitely more eyes, and I'm open to improving it as my use grows and I have some more time with it.
