### PR TITLE
Added support to change the default `Content-Type` for json

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -149,7 +149,8 @@ class RequestHandler(object):
     _template_loaders = {}  # {path: template.BaseLoader}
     _template_loader_lock = threading.Lock()
     _remove_control_chars_regex = re.compile(r"[\x00-\x08\x0e-\x1f]")
-
+    _json_content_type = "application/json; charset=UTF-8"
+    
     def __init__(self, application, request, **kwargs):
         super(RequestHandler, self).__init__()
 
@@ -653,7 +654,7 @@ class RequestHandler(object):
             raise TypeError("write() only accepts bytes, unicode, and dict objects")
         if isinstance(chunk, dict):
             chunk = escape.json_encode(chunk)
-            self.set_header("Content-Type", "application/json; charset=UTF-8")
+            self.set_header("Content-Type", self._json_content_type)
         chunk = utf8(chunk)
         self._write_buffer.append(chunk)
 


### PR DESCRIPTION
APIs, such as [JSON API](http://jsonapi.org/format) which expects `Content-Type: application/vnd.api+json`, would be enhanced by establishing the default `Content-Type` outside the `write()` method.

```
class JSONHandler(RequestHandler):
  _json_content_type = "application/vnd.api+json"
  def get(self):
    # ...
    self.finish(json_api_doc)

```
