### PR TITLE
Addressing race condition in SimpleAsyncHTTPClient's _on_timeout()

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -152,7 +152,10 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
             del self.waiting[key]
 
     def _on_timeout(self, key):
-        request, callback, timeout_handle = self.waiting[key]
+        try:
+            request, callback, timeout_handle = self.waiting[key]
+        except KeyError:
+            return
         self.queue.remove((key, request, callback))
         timeout_response = HTTPResponse(
             request, 599, error=HTTPError(599, "Timeout"),


### PR DESCRIPTION
If you fire off a significant number of fetch requests with SimpleAsyncHTTPClient and some of those requests timeout, you may find yourself with a number of uncaught KeyErrors as a race condition exists.  In this case, it seems that some of the self.waiting[] keys are actually promoted into the self.active[], and deleted from self.waiting[].  Under extreme conditions, _on_timeout() can be called nearly-simultaneous with _remove_timeout() with the del self.waiting[key] winnin the race and causing a KeyError to be thrown by _on_timeout().
