### PR TITLE
Fixed support for test generators

### DIFF
--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -114,8 +114,8 @@ class _TestMethodWrapper(object):
     def __init__(self, orig_method):
         self.orig_method = orig_method
 
-    def __call__(self):
-        result = self.orig_method()
+    def __call__(self, *args, **kwargs):
+        result = self.orig_method(*args, **kwargs)
         if isinstance(result, types.GeneratorType):
             raise TypeError("Generator test methods should be decorated with "
                             "tornado.testing.gen_test")


### PR DESCRIPTION
This fixes the problem that AsyncTestCase no longer seemed to work with test generators (as supported by Nose, http://nose.readthedocs.org/en/latest/writing_tests.html#test-generators).
