### PR TITLE
Support yielding asyncio.Future from gen.coroutine

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -696,6 +696,8 @@ class Runner(object):
                 self.io_loop.add_future(
                     self.future, lambda f: self.run())
                 return False
+        elif self.io_loop.is_yieldable(yielded):
+            self.io_loop.wait_yielded(yielded, lambda f: self.run())
         else:
             self.future = TracebackFuture()
             self.future.set_exception(BadYieldError(

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -625,6 +625,19 @@ class IOLoop(Configurable):
         except OSError:
             pass
 
+    def is_yieldable(self, obj):
+        """Check if `obj` can be yielded from coroutine."""
+        return False
+
+    def wait_yielded(self, obj, callback):
+        """Wait obj yielded from coroutine.
+
+        Raises TypeError when this loop doesn't support waiting it.
+        """
+        if not is_yieldable(obj):
+            raise TypeError
+        raise NotImplementedError()
+
 
 class PollIOLoop(IOLoop):
     """Base class for IOLoops built around a select-like function.

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -129,6 +129,14 @@ class BaseAsyncIOLoop(IOLoop):
 
     add_callback_from_signal = add_callback
 
+    def is_yieldable(self, obj):
+        return isinstance(obj, asyncio.Future)
+
+    def wait_yielded(self, obj, callback):
+        if not isinstance(obj, asyncio.Future):
+            raise TypeError
+        obj.add_done_callback(callback)
+
 
 class AsyncIOMainLoop(BaseAsyncIOLoop):
     def initialize(self):

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, division, print_function, with_statement
+
+try:
+    import asyncio
+except ImportError:
+    pass
+
+import time
+from tornado.testing import AsyncTestCase, gen_test
+from tornado.test.util import unittest
+
+
+class AsyncIoTest(AsyncTestCase):
+    """Test yielding asyncio.Future from gen.coroutine"""
+
+    def setUp(self):
+        if asyncio is None:
+            raise unittest.SkipTest('AsyncIoTest requires asyncio.')
+        super(AsyncIoTest, self).setUp()
+
+    def get_new_ioloop(self):
+        from tornado.platform.asyncio import AsyncIOLoop
+        return AsyncIOLoop()
+
+    @gen_test
+    def test_asyncio_sleep(self):
+        """yield asyncio.sleep(0.01) from gen.coroutine"""
+        t = time.time()
+        yield asyncio.Task(asyncio.sleep(0.01))
+        delta = time.time() - t
+        self.assertLess(delta, 0.1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Request For Comment

This PR is relating to #1041 .
This PR adds `is_yieldable()` and `wait_yielded()` to IOLoop.

`gen.Runner` delegates waiting object to io_loop.
If this changes are OK, `is_future()` and `io_loop.add_future()` may be moved to `IOLoop.wait_yielded` too.
