### PR TITLE
Add missing argument max_buffer_size to TCPClient.connect in SimpleAsyncHTTPClient

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -219,6 +219,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                     stack_context.wrap(self._on_timeout))
             self.tcp_client.connect(host, port, af=af,
                                     ssl_options=ssl_options,
+                                    max_buffer_size=self.max_buffer_size,
                                     callback=self._on_connect)
 
     def _get_ssl_options(self, scheme):


### PR DESCRIPTION
max_buffer_size from SimpleAsyncHTTPClient isn't passed down to the underlying TCPClient
