### PR TITLE
Allow setting query params for HTTPRequest

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -270,7 +270,7 @@ def _curl_create():
 
 
 def _curl_setup_request(curl, request, buffer, headers):
-    curl.setopt(pycurl.URL, native_str(request.url))
+    curl.setopt(pycurl.URL, native_str(request.uri))
 
     # libcurl's magic "Expect: 100-continue" behavior causes delays
     # with servers that don't support it (which include, among others,
@@ -417,11 +417,11 @@ def _curl_setup_request(curl, request, buffer, headers):
             raise ValueError("Unsupported auth_mode %s" % request.auth_mode)
 
         curl.setopt(pycurl.USERPWD, native_str(userpwd))
-        gen_log.debug("%s %s (username: %r)", request.method, request.url,
+        gen_log.debug("%s %s (username: %r)", request.method, request.uri,
                       request.auth_username)
     else:
         curl.unsetopt(pycurl.USERPWD)
-        gen_log.debug("%s %s", request.method, request.url)
+        gen_log.debug("%s %s", request.method, request.uri)
 
     if request.client_cert is not None:
         curl.setopt(pycurl.SSLCERT, request.client_cert)

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -309,7 +309,7 @@ class HTTPRequest(object):
         :type headers: `~tornado.httputil.HTTPHeaders` or `dict`
         :arg body: HTTP request body as a string (byte or unicode; if unicode
            the utf-8 encoding will be used)
-        :arg query_params additional query parameters
+        :arg dict query_params: additional query parameters
         :arg body_producer: Callable used for lazy/asynchronous request bodies.
            It is called with one argument, a ``write`` function, and should
            return a `.Future`.  It should call the write function with new

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -49,6 +49,7 @@ from tornado.escape import utf8, native_str
 from tornado import httputil, stack_context
 from tornado.ioloop import IOLoop
 from tornado.util import Configurable
+from tornado.httputil import url_concat
 
 
 class HTTPClient(object):
@@ -288,8 +289,8 @@ class HTTPRequest(object):
         validate_cert=True)
 
     def __init__(self, url, method="GET", headers=None, body=None,
-                 auth_username=None, auth_password=None, auth_mode=None,
-                 connect_timeout=None, request_timeout=None,
+                 query_params=None, auth_username=None, auth_password=None,
+                 auth_mode=None, connect_timeout=None, request_timeout=None,
                  if_modified_since=None, follow_redirects=None,
                  max_redirects=None, user_agent=None, use_gzip=None,
                  network_interface=None, streaming_callback=None,
@@ -308,6 +309,7 @@ class HTTPRequest(object):
         :type headers: `~tornado.httputil.HTTPHeaders` or `dict`
         :arg body: HTTP request body as a string (byte or unicode; if unicode
            the utf-8 encoding will be used)
+        :arg query_params additional query parameters
         :arg body_producer: Callable used for lazy/asynchronous request bodies.
            It is called with one argument, a ``write`` function, and should
            return a `.Future`.  It should call the write function with new
@@ -411,6 +413,7 @@ class HTTPRequest(object):
         self.url = url
         self.method = method
         self.body = body
+        self.query_params = query_params
         self.body_producer = body_producer
         self.auth_username = auth_username
         self.auth_password = auth_password
@@ -487,6 +490,10 @@ class HTTPRequest(object):
     @prepare_curl_callback.setter
     def prepare_curl_callback(self, value):
         self._prepare_curl_callback = stack_context.wrap(value)
+
+    @property
+    def uri(self):
+        return url_concat(self.url, self.query_params)
 
 
 class HTTPResponse(object):

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -184,7 +184,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         self._timeout = None
         self._sockaddr = None
         with stack_context.ExceptionStackContext(self._handle_exception):
-            self.parsed = urlparse.urlsplit(_unicode(self.request.url))
+            self.parsed = urlparse.urlsplit(_unicode(self.request.uri))
             if self.parsed.scheme not in ("http", "https"):
                 raise ValueError("Unsupported url scheme: %s" %
                                  self.request.url)

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -443,7 +443,8 @@ Transfer-Encoding: chunked
     #    self.assertEqual(response.body, b"Post arg1: foo, arg2: bar")
 
     def test_put_307(self):
-        response = self.fetch("/redirect?status=307&url=/put",
+        response = self.fetch("/redirect",
+                              query_params=dict(status="307", url="/put"),
                               method="PUT", body=b"hello")
         response.rethrow()
         self.assertEqual(response.body, b"Put body: hello")
@@ -563,3 +564,7 @@ class HTTPRequestTestCase(unittest.TestCase):
         request = HTTPRequest('http://example.com')
         request.body = 'foo'
         self.assertEqual(request.body, utf8('foo'))
+
+    def test_queryparams(self):
+        request = HTTPRequest('http://example.com', query_params={'foo': 'bar'})
+        self.assertEqual(request.query_params, {'foo': 'bar'})

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -235,7 +235,7 @@ class SimpleHTTPClientTestMixin(object):
 
     @skipOnTravis
     def test_request_timeout(self):
-        response = self.fetch('/trigger?wake=false', request_timeout=0.1)
+        response = self.fetch('/trigger', query_params={'wake': 'false'}, request_timeout=0.1)
         self.assertEqual(response.code, 599)
         self.assertTrue(0.099 < response.request_time < 0.15, response.request_time)
         self.assertEqual(str(response.error), "HTTP 599: Timeout")
@@ -266,9 +266,9 @@ class SimpleHTTPClientTestMixin(object):
         self.assertEqual(response.body, b"Hello world!")
 
     def xtest_multiple_content_length_accepted(self):
-        response = self.fetch("/content_length?value=2,2")
+        response = self.fetch("/content_length", query_params={"value": "2,2"})
         self.assertEqual(response.body, b"ok")
-        response = self.fetch("/content_length?value=2,%202,2")
+        response = self.fetch("/content_length", query_params={"value": "2, 2,2"})
         self.assertEqual(response.body, b"ok")
 
         response = self.fetch("/content_length?value=2,4")

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -855,9 +855,11 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         self.read_queue = collections.deque()
         self.key = base64.b64encode(os.urandom(16))
 
-        scheme, sep, rest = request.url.partition(':')
+        scheme, sep, rest = request.uri.partition(':')
         scheme = {'ws': 'http', 'wss': 'https'}[scheme]
-        request.url = scheme + sep + rest
+        request.request.url = scheme + sep + rest
+        request.request.query_params = dict()
+
         request.headers.update({
             'Upgrade': 'websocket',
             'Connection': 'Upgrade',


### PR DESCRIPTION
Allow setting queryparams explicitly via `query_params` in HTTPRequest constructor.

This makes things less error prone, as urlencoding is done automatically, via the already existing `httputils.url_concat` method.
