### PR TITLE
Add callback error handling to Future

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -29,6 +29,7 @@ import sys
 
 from tornado.stack_context import ExceptionStackContext, wrap
 from tornado.util import raise_exc_info, ArgReplacer
+from tornado.log import app_log
 
 try:
     from concurrent import futures
@@ -173,8 +174,11 @@ class Future(object):
     def _set_done(self):
         self._done = True
         for cb in self._callbacks:
-            # TODO: error handling
-            cb(self)
+            try:
+                cb(self)
+            except Exception:
+                app_log.exception('exception calling callback %r for %r',
+                                  cb, self)
         self._callbacks = None
 
 TracebackFuture = Future


### PR DESCRIPTION
Catches and logs to the application log exceptions raised by each callback. This
more or less mirrors what concurrent.futures.Future does.

While the diff looks quite innocuous, it seems to break some tests in concurrent_test.py that seem to depend on _set_done() not catching callback exceptions. I am a bit mystified, and would appreciate more input :)
