### PR TITLE
Check handler is class in URLSpec.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -73,6 +73,7 @@ import tornado
 import traceback
 import types
 from io import BytesIO
+from inspect import isclass
 
 from tornado.concurrent import Future, is_future
 from tornado import escape
@@ -2787,6 +2788,10 @@ class URLSpec(object):
             # import the Module and instantiate the class
             # Must be a fully qualified name (module.ClassName)
             handler = import_object(handler)
+
+        if not isclass(handler) or not issubclass(handler, RequestHandler):
+            raise TypeError(
+                'RequestHandler needed for pattern: %s' % pattern)
 
         self.handler_class = handler
         self.kwargs = kwargs or {}


### PR DESCRIPTION
Some simple cases for user error in supplying handlers can end up with
the URLSpec being given bad arguments. If the 'handler' arg isn't a
class, nothing fails right away, but later an obscure error about
an internal attribute not being a class is raised.

This change catches the problem when it happens, and provides context to
help the user hunt it down.
