### PR TITLE
Find real option definer.

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -204,6 +204,13 @@ class OptionParser(object):
                         (name, self._options[name].file_name))
         frame = sys._getframe(0)
         options_file = frame.f_code.co_filename
+
+        # Can be called directly, or through top level define() fn, in which
+        # case, step up above that frame to look for real caller.
+        if (frame.f_back.f_code.co_filename == options_file and
+                frame.f_back.f_code.co_name == 'define'):
+            frame = frame.f_back
+
         file_name = frame.f_back.f_code.co_filename
         if file_name == options_file:
             file_name = ""


### PR DESCRIPTION
When an option is defined through the module level "define" fn, not
directly through the class method, we should look one frame up to
find the real caller.
