### PR TITLE
Subprocess' ioloop can be replaced if it's closed.

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -226,6 +226,10 @@ class IOLoop(Configurable):
     def initialize(self):
         pass
 
+    @property
+    def closed(self):
+        raise NotImplementedError()
+
     def close(self, all_fds=False):
         """Closes the `IOLoop`, freeing any resources used.
 
@@ -658,6 +662,10 @@ class PollIOLoop(IOLoop):
         self.add_handler(self._waker.fileno(),
                          lambda fd, events: self._waker.consume(),
                          self.READ)
+
+    @property
+    def closed(self):
+        return self._callbacks is None
 
     def close(self, all_fds=False):
         with self._callback_lock:

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -38,6 +38,7 @@ class BaseAsyncIOLoop(IOLoop):
         self.readers = set()
         self.writers = set()
         self.closing = False
+        self._closed = False
 
     def close(self, all_fds=False):
         self.closing = True
@@ -48,6 +49,11 @@ class BaseAsyncIOLoop(IOLoop):
                 self.close_fd(fileobj)
         if self.close_loop:
             self.asyncio_loop.close()
+        self._closed = True
+
+    @property
+    def closed(self):
+        return self._closed
 
     def add_handler(self, fd, handler, events):
         fd, fileobj = self.split_fd(fd)

--- a/tornado/platform/kqueue.py
+++ b/tornado/platform/kqueue.py
@@ -28,12 +28,18 @@ class _KQueue(object):
     def __init__(self):
         self._kqueue = select.kqueue()
         self._active = {}
+        self._closed = False
 
     def fileno(self):
         return self._kqueue.fileno()
 
     def close(self):
         self._kqueue.close()
+        self._closed = True
+
+    @property
+    def closed(self):
+        return self._closed
 
     def register(self, fd, events):
         if fd in self._active:

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -413,6 +413,7 @@ class TwistedIOLoop(tornado.ioloop.IOLoop):
         self.reactor = reactor
         self.fds = {}
         self.reactor.callWhenRunning(self.make_current)
+        self._closed = False
 
     def close(self, all_fds=False):
         fds = self.fds
@@ -422,6 +423,11 @@ class TwistedIOLoop(tornado.ioloop.IOLoop):
         if all_fds:
             for fd in fds.values():
                 self.close_fd(fd.fileobj)
+        self._closed = True
+
+    @property
+    def closed(self):
+        return self._closed
 
     def add_handler(self, fd, handler, events):
         if fd in self.fds:


### PR DESCRIPTION
Since Subprocess holds on to a singleton ioloop, and that ioloop can be
closed, if someone tries to re-initialize Subprocess (like during a call
to set_exit_callback), clear out the now-defunct ioloop to make way for
one that can run callbacks.

As part of this, IOLoop implementations now have a property they need to
define, closed, which Subprocess uses to know if its loop is closed. For
minimal impact, it's a property that by default throws a
NotImplementedError, and Subprocess falls back to old behavior.
