### PR TITLE
Support alternate hostname for static_url

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1223,6 +1223,8 @@ class RequestHandler(object):
 
         if include_host:
             base = self.request.protocol + "://" + self.request.host
+		elif include_host and type(include_host).__name__ != 'bool':
+			base = self.request.protocol + "://" + include_host
         else:
             base = ""
 


### PR DESCRIPTION
add RequestHandler set self.include_host can use domain can setting other domain with static_url, 
any better ideas,  please tell me, thanks.
e.g:
class MainHandler(tornado.web.RequestHandler):
    def **init**(....):
        self.include_host = 'apple.com'
will be to get http://apple.com/static/js/jquery.js
