### PR TITLE
Fixed #1218.

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2426,3 +2426,70 @@ class DecoratorTest(WebTestCase):
         response = self.fetch("/addslash?foo=bar", follow_redirects=False)
         self.assertEqual(response.code, 301)
         self.assertEqual(response.headers['Location'], "/addslash/?foo=bar")
+
+
+class CacheTest(WebTestCase):
+    def get_handlers(self):
+        class EtagHandler(RequestHandler):
+            def get(self, computed_etag):
+                self.write(computed_etag)
+
+            def compute_etag(self):
+                return self._write_buffer[0]
+
+        return [
+            ('/etag/(.*)', EtagHandler)
+        ]
+
+    def test_wildcard_etag(self):
+        computed_etag = '"xyzzy"'
+        etags = '*'
+        self._test_etag(computed_etag, etags, 304)
+
+    def test_strong_etag_match(self):
+        computed_etag = '"xyzzy"'
+        etags = '"xyzzy"'
+        self._test_etag(computed_etag, etags, 304)
+
+    def test_multiple_strong_etag_match(self):
+        computed_etag = '"xyzzy1"'
+        etags = '"xyzzy1", "xyzzy2"'
+        self._test_etag(computed_etag, etags, 304)
+
+    def test_strong_etag_not_match(self):
+        computed_etag = '"xyzzy"'
+        etags = '"xyzzy1"'
+        self._test_etag(computed_etag, etags, 200)
+
+    def test_multiple_strong_etag_not_match(self):
+        computed_etag = '"xyzzy"'
+        etags = '"xyzzy1", "xyzzy2"'
+        self._test_etag(computed_etag, etags, 200)
+
+    def test_weak_etag_match(self):
+        computed_etag = '"xyzzy1"'
+        etags = 'W/"xyzzy1"'
+        self._test_etag(computed_etag, etags, 304)
+
+    def test_multiple_weak_etag_match(self):
+        computed_etag = '"xyzzy2"'
+        etags = 'W/"xyzzy1", W/"xyzzy2"'
+        self._test_etag(computed_etag, etags, 304)
+
+    def test_weak_etag_not_match(self):
+        computed_etag = '"xyzzy2"'
+        etags = 'W/"xyzzy1"'
+        self._test_etag(computed_etag, etags, 200)
+
+    def test_multiple_weak_etag_not_match(self):
+        computed_etag = '"xyzzy3"'
+        etags = 'W/"xyzzy1", W/"xyzzy2"'
+        self._test_etag(computed_etag, etags, 200)
+
+    def _test_etag(self, computed_etag, etags, status_code):
+        response = self.fetch(
+            '/etag/' + computed_etag,
+            headers={'If-None-Match': etags}
+
+        )
+        self.assertEqual(response.code, status_code)

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2490,6 +2490,5 @@ class CacheTest(WebTestCase):
         response = self.fetch(
             '/etag/' + computed_etag,
             headers={'If-None-Match': etags}
-
         )
         self.assertEqual(response.code, status_code)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1310,22 +1310,22 @@ class RequestHandler(object):
         before completing the request.  The ``Etag`` header should be set
         (perhaps with `set_etag_header`) before calling this method.
         """
-        computed_etag = self._headers.get("Etag")
+        computed_etag = utf8(self._headers.get("Etag", ""))
         # Find all weak and strong etag values from If-None-Match header
         # because RFC 7232 allows multiple etag values in a single header.
         etags = re.findall(
-            r'\*|(?:W/)?"[^"]*"',
+            br'\*|(?:W/)?"[^"]*"',
             utf8(self.request.headers.get("If-None-Match", ""))
         )
         if not computed_etag or not etags:
             return False
 
         match = False
-        if etags[0] == '*':
+        if etags[0] == b'*':
             match = True
         else:
             # Use a weak comparison when comparing entity-tags.
-            val = lambda x: x[2:] if x.startswith('W/') else x
+            val = lambda x: x[2:] if x.startswith(b'W/') else x
             for etag in etags:
                 if val(etag) == val(computed_etag):
                     match = True

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1314,7 +1314,7 @@ class RequestHandler(object):
         # Split If-None-Match with `,` because RFC 2616 allows multiple etag
         # values in a single header.
         inm = utf8(self.request.headers.get("If-None-Match", "")).split(',')
-        # For the case of weak validator, strip inm entities with `W\"`.
+        # For the case of weak validator, lstrip inm entities with `W/`.
         tags = [x.lstrip('W/') for x in inm]
         match = (inm[0] == '"*"') or (etag in tags)
         return bool(etag and match)


### PR DESCRIPTION
Fixed #1218, please review this.
1. Split `If-None-Match` with `,` to handle multiple etag in a single header.
2. If "*" is given and any current entity exists for that resource, this method should return `True`.
3. Find etag match in tags (maybe including weak validator).