### PR TITLE
Don't depend on backports.ssl-match-hostname with python >=2.7.9, <3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Upgrade notes
 
 As of Tornado 3.2, the `backports.ssl_match_hostname
 <https://pypi.python.org/pypi/backports.ssl_match_hostname>`_ package
-must be installed when running Tornado on Python 2.  This will be
+must be installed when running Tornado on Python 2 (<2.7.9).  This will be
 installed automatically when using ``pip`` or ``easy_install``.
 
 Quick links
@@ -81,8 +81,8 @@ The Tornado source code is `hosted on GitHub
 requires the `certifi <https://pypi.python.org/pypi/certifi>`_ package
 on all Python versions, and the `backports.ssl_match_hostname
 <https://pypi.python.org/pypi/backports.ssl_match_hostname>`_ package
-on Python 2.  These will be installed automatically when using
-``pip`` or ``easy_install``).  Some Tornado features may
+on Python 2 (before 2.7.9).  These will be installed automatically when
+using ``pip`` or ``easy_install``).  Some Tornado features may
 require one of the following optional libraries:
 
 * `unittest2 <https://pypi.python.org/pypi/unittest2>`_ is needed to run

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,8 +81,8 @@ The Tornado source code is `hosted on GitHub
 requires the `certifi <https://pypi.python.org/pypi/certifi>`_ package
 on all Python versions, and the `backports.ssl_match_hostname
 <https://pypi.python.org/pypi/backports.ssl_match_hostname>`_ package
-on Python 2.  These will be installed automatically when using
-``pip`` or ``easy_install``).  Some Tornado features may
+on Python 2 (before 2.7.9).  These will be installed automatically when
+using ``pip`` or ``easy_install``).  Some Tornado features may
 require one of the following optional libraries:
 
 * `unittest2 <https://pypi.python.org/pypi/unittest2>`_ is needed to run

--- a/maint/requirements.txt
+++ b/maint/requirements.txt
@@ -1,6 +1,6 @@
 # Frozen pip requirements for tools used in the development of tornado.
 # This list is for python 3.4; for 2.7 add:
-# - backports.ssl-match-hostname
+# - backports.ssl-match-hostname (<2.7.9 only)
 # - futures
 # - mock
 #

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ if (platform.python_implementation() == 'CPython' and
 if setuptools is not None:
     # If setuptools is not available, you're on your own for dependencies.
     install_requires = ['certifi']
-    if sys.version_info < (3, 2):
+    if sys.version_info < (2, 7, 9) or (3, 0) <= sys.version_info < (3, 2):
         install_requires.append('backports.ssl_match_hostname')
     kwargs['install_requires'] = install_requires
 


### PR DESCRIPTION
Fixes #1275
