### PR TITLE
Ensure that HTTPServerRequest.body is a byte string

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -331,7 +331,7 @@ class HTTPServerRequest(object):
         self.uri = uri
         self.version = version
         self.headers = headers or HTTPHeaders()
-        self.body = body or ""
+        self.body = body or b""
 
         # set remote IP and protocol
         context = getattr(connection, 'context', None)

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -264,6 +264,10 @@ class HTTPServerRequestTest(unittest.TestCase):
         # more required parameters slip in.
         HTTPServerRequest(uri='/')
 
+    def test_body_is_a_byte_string(self):
+        requets = HTTPServerRequest(uri='/')
+        self.assertIsInstance(requets.body, bytes)
+
 
 class ParseRequestStartLineTest(unittest.TestCase):
     METHOD = "GET"

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -207,7 +207,7 @@ class WSGIAdapter(object):
             body = environ["wsgi.input"].read(
                 int(headers["Content-Length"]))
         else:
-            body = ""
+            body = b""
         protocol = environ["wsgi.url_scheme"]
         remote_ip = environ.get("REMOTE_ADDR", "")
         if environ.get("HTTP_HOST"):


### PR DESCRIPTION
HTTPServerRequest.body should be bytes but it is an empty string that
occurs in Python3 when pass no body to HTTPServerRequest.