### PR TITLE
Fix occasional truncation of responses in PipeIOStream.read_from_fd method

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -55,7 +55,7 @@ except ImportError:
 # These errnos indicate that a non-blocking operation must be retried
 # at a later time.  On most platforms they're the same value, but on
 # some they differ.
-_ERRNO_WOULDBLOCK = (errno.EWOULDBLOCK, errno.EAGAIN)
+_ERRNO_WOULDBLOCK = (errno.EWOULDBLOCK, errno.EAGAIN, errno.EINTR)
 
 if hasattr(errno, "WSAEWOULDBLOCK"):
     _ERRNO_WOULDBLOCK += (errno.WSAEWOULDBLOCK,)


### PR DESCRIPTION
The bug occurs on stress testing with ab or siege like:
```
    siege -v -c5 http://localhost:8888/
    ab -c2 -n100 http://localhost:8888/
```
In the tornado log this looks like:
```
    [W 141225 04:07:28 iostream:605] error on read
        Traceback (most recent call last):
          File "/devel/.sflibs/tornado/tornado/iostream.py", line 601, in _handle_read
            pos = self._read_to_buffer_loop()
          File "/devel/.sflibs/tornado/tornado/iostream.py", line 571, in _read_to_buffer_loop
            if self._read_to_buffer() == 0:
          File "/devel/.sflibs/tornado/tornado/iostream.py", line 683, in _read_to_buffer
            chunk = self.read_from_fd()
          File "/devel/.sflibs/tornado/tornado/iostream.py", line 1338, in read_from_fd
            chunk = os.read(self.fd, self.read_chunk_size)
        InterruptedError: [Errno 4] Interrupted system call
```
And in the siege log we see trancated responces:
```
    HTTP/1.1 200   0.12 secs:  761877 bytes ==> GET  /
    HTTP/1.1 200   0.13 secs:  761877 bytes ==> GET  /
    HTTP/1.1 200   0.09 secs:  275252 bytes ==> GET  /
    HTTP/1.1 200   0.15 secs:  761877 bytes ==> GET  /
    HTTP/1.1 200   0.15 secs:  586535 bytes ==> GET  /
    HTTP/1.1 200   0.16 secs:  761877 bytes ==> GET  /
    HTTP/1.1 200   0.07 secs:   11396 bytes ==> GET  /
    HTTP/1.1 200   0.22 secs:  761877 bytes ==> GET  /
```