### PR TITLE
Handle bad xsrf tokens more gracefully

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1124,7 +1124,11 @@ class RequestHandler(object):
         if m:
             version = int(m.group(1))
             if version == 2:
-                _, mask, masked_token, timestamp = cookie.split("|")
+                try:
+                    _, mask, masked_token, timestamp = cookie.split("|")
+                except ValueError:
+                    return None, None, None
+
                 mask = binascii.a2b_hex(utf8(mask))
                 token = _websocket_mask(
                     mask, binascii.a2b_hex(utf8(masked_token)))


### PR DESCRIPTION
Our production logs are currently getting flooded with errors from clients sending bad XSRF tokens, e.g.:

    Traceback (most recent call last): 
      ...
      File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 1190, in xsrf_form_html 
        escape.xhtml_escape(self.xsrf_token) + '"/>' 
      File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 1070, in xsrf_token 
        version, token, timestamp = self._get_raw_xsrf_token() 
      File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 1104, in _get_raw_xsrf_token 
        version, token, timestamp = self._decode_xsrf_token(cookie) 
      File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 1122, in _decode_xsrf_token 
        _, mask, masked_token, timestamp = cookie.split("|") 
    ValueError: too many values to unpack 

These errors coincided with the upgrade to tornado 4 and the new cookies. I thought they'd go away eventually as our cookies would expire, but they still persist from what appear to be crawlers with buggy cookie handling facilities.

We get errors from other parts of `_decode_xsrf_token` as well, e.g. the line `timestamp = int(timestamp)` sometimes raises a `ValueError`. These errors are less frequent, but maybe it would make sense to just wrap `_decode_xsrf_token` in a giant try/catch, and just log warnings on errors?
