### PR TITLE
Changed 'return' to 'raise gen.Return()' to fix Issue #1292

### DIFF
--- a/docs/guide/async.rst
+++ b/docs/guide/async.rst
@@ -108,4 +108,6 @@ the original synchronous version::
     def fetch_coroutine(url):
         http_client = AsyncHTTPClient()
         response = yield http_client.fetch(url)
-        return response.body
+        raise gen.Return(response.body)
+
+The statement ``raise gen.Return(response.body)`` is an artifact of Python 2, in which generators aren't allowed to return values. To overcome this, Tornado coroutines raise a special kind of exception called a ``Return``. The coroutine catches this exception and treats it like a returned value. In Python 3, a ``return response.body`` achieves the same result.


### PR DESCRIPTION
The code example only worked with Python 3 and above, now works with all versions.

Explanation added with the change.