### PR TITLE
With xheaders request.remote_ip should return first ip in X-Forwarded-For chain

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -201,7 +201,7 @@ class _HTTPRequestContext(object):
         """Rewrite the ``remote_ip`` and ``protocol`` fields."""
         # Squid uses X-Forwarded-For, others use X-Real-Ip
         ip = headers.get("X-Forwarded-For", self.remote_ip)
-        ip = ip.split(',')[-1].strip()
+        ip = ip.split(',')[0].strip()
         ip = headers.get("X-Real-Ip", ip)
         if netutil.is_valid_ip(ip):
             self.remote_ip = ip


### PR DESCRIPTION
When request is proxied through several proxies, `X-Forwarded-For` header will have values in format `origin,proxy1,proxy2,...`
This PR will allow client to get first value in forwarded chain, thus getting ip of the origin request.