### PR TITLE
add is_running to get callback state

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -969,6 +969,9 @@ class PeriodicCallback(object):
             self.io_loop.remove_timeout(self._timeout)
             self._timeout = None
 
+    def is_running(self):
+        return self._running
+
     def _run(self):
         if not self._running:
             return


### PR DESCRIPTION
I think that to know if a PeriodicCallback is running or not is important. For example, not to make duplicate PeriodicCallback.