### PR TITLE
gen.coroutine support in Templates

### DIFF
--- a/docs/guide/templates.rst
+++ b/docs/guide/templates.rst
@@ -99,6 +99,9 @@ of these entries are not present).
 - Any keyword arguments passed to `~.RequestHandler.render` or
   `~.RequestHandler.render_string`
 
+Additionally, if you are using `gen.coroutine` support, `gen.coroutine` and
+`gen.Return` are exposed as `coroutine` and `Return`, respectively.
+
 When you are building a real application, you are going to want to use
 all of the features of Tornado templates, especially template
 inheritance. Read all about those features in the `tornado.template`

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -6,7 +6,7 @@
    Class reference
    ---------------
 
-   .. autoclass:: Template(template_string, name="<string>", loader=None, compress_whitespace=None, autoescape="xhtml_escape")
+   .. autoclass:: Template(template_string, name="<string>", loader=None, compress_whitespace=None, autoescape="xhtml_escape", coroutine=False)
       :members:
 
    .. autoclass:: BaseLoader

--- a/tornado/test/template_test.py
+++ b/tornado/test/template_test.py
@@ -4,6 +4,7 @@ import os
 import sys
 import traceback
 
+from tornado import gen
 from tornado.escape import utf8, native_str, to_unicode
 from tornado.template import Template, DictLoader, ParseError, Loader
 from tornado.test.util import unittest
@@ -173,6 +174,23 @@ try{% set y = 1/x %}
         template = Template('{{ 1 / 2 }}')
         self.assertEqual(template.generate(), '0')
 
+    @gen.coroutine
+    def test_coroutine_template(self):
+        @gen.coroutine
+        def value():
+            raise gen.Return('Hello, Ben')
+        template = Template(utf8("{{ yield value() }}"), coroutine=True)
+        result = yield template.generate(value=value)
+        self.assertEqual(result, 'Hello, Ben')
+
+    @gen.coroutine
+    def test_coroutine_template_exception(self):
+        @gen.coroutine
+        def value():
+            raise Exception('Hello, Ben')
+        template = Template(utf8("{{ yield value() }}"), coroutine=True)
+        with self.assertRaises(Exception):
+            result = yield template.generate(value=value)
 
 class StackTraceTest(unittest.TestCase):
     def test_error_line_number_expression(self):

--- a/tornado/test/template_test.py
+++ b/tornado/test/template_test.py
@@ -181,7 +181,7 @@ try{% set y = 1/x %}
             raise gen.Return('Hello, Ben')
         template = Template(utf8("{{ yield value() }}"), coroutine=True)
         result = yield template.generate(value=value)
-        self.assertEqual(result, 'Hello, Ben')
+        self.assertEqual(result, b'Hello, Ben')
 
     @gen.coroutine
     def test_coroutine_template_exception(self):


### PR DESCRIPTION
We're building a semi-lazy-loading asynchronous ORM and have found the `gen.coroutine` decorator to be a great resource. Our objects come out looking something like the below:

Model.attribute = value
Model.reference = `Future`
Model.collection_name = `[Future, Future]`

So it's very efficient for us to start generating content from our templates and only wait for references and collections if we need to. Hence, our templates look like the below:

```html
<html>
<head>
   <title>{{ Model.some_value }} </title>
<body>
<h1>{{ yield Model.some_reference }}</h1>
</body>
```

We love working with the most recent version of Tornado, and aren't willing to break off from the main fork. With that in mind, we're currently using a modified version of the `template.py`, represented in the pull. If this is something that you aren't interested in incorporating into the main repo, we'll happily subclass as necessary to accomplish it without conflict.

Obviously, it's easier for us to modify the code in place, and I'm happy to help incorporate these changes more thoroughly if you think the feature could be useful in, e.g. the UIModules. Those changes could be non-trivial, however, as I believe ultimately everything that uses a coroutine=True argument will need to be decorated with `gen.coroutine`.  Please correct me if I'm wrong. If so, separate methods for .render() and .render_string() are probably necessary.