### PR TITLE
fix `run_sync` no block problem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. image:: https://travis-ci.org/tornadoweb/tornado.svg?branch=master
+    :target: https://travis-ci.org/tornadoweb/tornado
+
+.. image:: https://travis-ci.org/huangwei1024/tornado.svg
+    :target: https://travis-ci.org/huangwei1024/tornado
+    
 Tornado Web Server
 ==================
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -413,7 +413,10 @@ class IOLoop(Configurable):
         self.add_callback(run)
         if timeout is not None:
             timeout_handle = self.add_timeout(self.time() + timeout, self.stop)
-        self.start()
+        while True:
+            self.start()
+            if future_cell[0].done() or (timeout is not None and self.time() >= timeout_handle.deadline):
+                break
         if timeout is not None:
             self.remove_timeout(timeout_handle)
         if not future_cell[0].done():

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -415,7 +415,7 @@ class IOLoop(Configurable):
             timeout_handle = self.add_timeout(self.time() + timeout, self.stop)
         while True:
             self.start()
-            if future_cell[0].done() or (timeout is not None and self.time() >= timeout_handle.deadline):
+            if future_cell[0].done() or (timeout is not None and self.time() >= timeout_handle.getTime()):
                 break
         if timeout is not None:
             self.remove_timeout(timeout_handle)
@@ -944,6 +944,9 @@ class _Timeout(object):
     def __le__(self, other):
         return ((self.deadline, self.tiebreaker) <=
                 (other.deadline, other.tiebreaker))
+                
+    def getTime(self):
+        return self.deadline
 
 
 class PeriodicCallback(object):

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -139,10 +139,6 @@ class TornadoDelayedCall(object):
     def active(self):
         return self._active
             
-    @property
-    def deadline(self):
-        return self._time
-
 @implementer(IReactorTime, IReactorFDSet)
 class TornadoReactor(PosixReactorBase):
     """Twisted reactor built on the Tornado IOLoop.

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -138,7 +138,10 @@ class TornadoDelayedCall(object):
 
     def active(self):
         return self._active
-
+            
+    @property
+    def deadline(self):
+        return self._time
 
 @implementer(IReactorTime, IReactorFDSet)
 class TornadoReactor(PosixReactorBase):


### PR DESCRIPTION
	@coroutine
	def _coroutine():
		ret = yield rpc.call_async(method, *args)
		raise Return(ret)
	return self.ioloop.run_sync(_coroutine)

the example will raise `TimeoutError('Operation timed out after %s seconds' % timeout)`
I modified `run_sync`, it will be run until future was done really or timeout.