### PR TITLE
Better extends blocks

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -137,11 +137,24 @@ with ``{# ... #}``.
     there is no ``{% end %}`` tag; the comment goes from the word ``comment``
     to the closing ``%}`` tag.
 
-``{% extends *filename* %}``
+``{% extends *filename* [with *expr*] %}``
     Inherit from another template.  Templates that use ``extends`` should
     contain one or more ``block`` tags to replace content from the parent
     template.  Anything in the child template not contained in a ``block``
     tag will be ignored.  For an example, see the ``{% block %}`` tag.
+    The ``with`` version allows one to pass values to the inherited template,
+    similiar to calling the constructor of a super class in a OOP language.
+    Semicolons can be used to pass multiple values. The values are only available
+    to ``block`` tags inside the extended template. This implicates that passed
+    values can not be forwarded at the moment. Passed values will shadow any global
+    variables::
+    
+        <!-- base.html -->
+        <body style="width: {{width}}; color: {{color}};">{% block content %}Default{% end %}</body>
+        
+        <!-- mypage.html -->
+        {% extends "base.html" with width = "60%"; color = "red" %}
+        {% block content %}Custom content{% end %}
 
 ``{% for *var* in *expr* %}...{% end %}``
     Same as the python ``for`` statement.  ``{% break %}`` and
@@ -282,11 +295,14 @@ class Template(object):
         try:
             # named_blocks maps from names to _NamedBlock objects
             named_blocks = {}
+            # stores certain preset variables for each template
+            declarations = {}
             ancestors = self._get_ancestors(loader)
             ancestors.reverse()
             for ancestor in ancestors:
                 ancestor.find_named_blocks(loader, named_blocks)
-            writer = _CodeWriter(buffer, named_blocks, loader, ancestors[0].template,
+                ancestor.find_declarations(loader, declarations)
+            writer = _CodeWriter(buffer, named_blocks, declarations, loader, ancestors[0].template,
                                  compress_whitespace)
             ancestors[0].generate(writer)
             return buffer.getvalue()
@@ -401,6 +417,10 @@ class _Node(object):
         for child in self.each_child():
             child.find_named_blocks(loader, named_blocks)
 
+    def find_declarations(self, loader, declarations):
+        for child in self.each_child():
+            child.find_declarations(loader, declarations)
+
 
 class _File(_Node):
     def __init__(self, template, body):
@@ -413,6 +433,9 @@ class _File(_Node):
         with writer.indent():
             writer.write_line("_tt_buffer = []", self.line)
             writer.write_line("_tt_append = _tt_buffer.append", self.line)
+            declaration = writer.declarations.get(self.template.name)
+            if declaration:
+                writer.write_line(declaration, self.line)
             self.body.generate(writer)
             writer.write_line("return _tt_utf8('').join(_tt_buffer)", self.line)
 
@@ -444,8 +467,16 @@ class _NamedBlock(_Node):
 
     def generate(self, writer):
         block = writer.named_blocks[self.name]
-        with writer.include(block.template, self.line):
-            block.body.generate(writer)
+        funcName = "_tt_block_%s()" % self.name
+        writer.write_line("def %s:" % funcName, self.line)
+        with writer.indent():
+            declaration = writer.declarations.get(block.template.name)
+            if declaration:
+                writer.write_line(declaration, self.line)
+            with writer.include(block.template, self.line):
+                block.body.generate(writer)
+            writer.write_line("pass", self.line)
+        writer.write_line(funcName, self.line)
 
     def find_named_blocks(self, loader, named_blocks):
         named_blocks[self.name] = self
@@ -453,8 +484,15 @@ class _NamedBlock(_Node):
 
 
 class _ExtendsBlock(_Node):
-    def __init__(self, name):
+    def __init__(self, reader, name, declaration = None):
+        self.template_name = reader.name
         self.name = name
+        self.declaration = declaration
+        
+    def find_declarations(self, loader, declarations):
+        if self.declaration:
+            print("{} resolves to {}".format(self.name, loader.resolve_path(self.name, self.template_name)))
+            declarations[loader.resolve_path(self.name, self.template_name)] = self.declaration
 
 
 class _IncludeBlock(_Node):
@@ -582,10 +620,11 @@ class ParseError(Exception):
 
 
 class _CodeWriter(object):
-    def __init__(self, file, named_blocks, loader, current_template,
+    def __init__(self, file, named_blocks, declarations, loader, current_template,
                  compress_whitespace):
         self.file = file
         self.named_blocks = named_blocks
+        self.declarations = declarations
         self.loader = loader
         self.current_template = current_template
         self.compress_whitespace = compress_whitespace
@@ -801,10 +840,14 @@ def _parse(reader, template, in_block=None, in_loop=None):
             if operator == "comment":
                 continue
             if operator == "extends":
-                suffix = suffix.strip('"').strip("'")
-                if not suffix:
+                path, separator, declaration = suffix.partition("with")
+                path = path.strip('\"\' ')
+                declaration = declaration.strip('; ')
+                if not path:
                     raise ParseError("extends missing file path on line %d" % line)
-                block = _ExtendsBlock(suffix)
+                if separator and not declaration:
+                    raise ParseError("extends missing variable declarations after with on line %d" % line)
+                block = _ExtendsBlock(reader, path, declaration)
             elif operator in ("import", "from"):
                 if not suffix:
                     raise ParseError("import missing statement on line %d" % line)


### PR DESCRIPTION
This pull request improves the "extends" block and introduces a "default" block which solves #703 and integrates nicely with the improved extends blocks.

### The new default block

The default block allows one to define default values for global variables. Those defaults will only apply to the template where they were defined. Example:

``` html
<!-- base.html -->
{% block main %}
<span style="color: {{color}};">Color will be undefined</span>
{% end %}

<!-- child1.html: -->
{% extend base.html %}
{% default color to "#FF0000" %}

{% block main %}
<span style="color: {{color}}">Color properly defined</span>
{% end %}
```

### The better extends block
In any OOP language one can usually pass values to parent classes in order to modify their behavior. E.g:
``` python
class Base:
    def __init__(self, someParameter):
        pass

class Child(Base):
    def __init__(self):
        Base.__init__(self, 42)
```

The current tags are not enough to emulate this behaviour properly. The closet you can get to the above behaviour at the moment is properly to use extra named blocks like so:

``` html
<!-- base.html -->
<body style="color: {% block color%}red{% end %}">
    {% block main %}Hello from base{% end %}
</body>

<!-- child1.html: -->
{% extend base.html %}
{% block color %}blue{% end %}

{% block main %}Hello from child{% end %}
```

However this approach is not only quite verbose (especially if more than on variable is required) but it also does not provide enough functionality. The problem is, that one does not pass true python variables but rather a (textual) block which is simply not sufficient for more complex templates (e.g if calculations have to be performed) Sure, in conjunction with the "set" block one can also pass variables, but that solution is quite hacky and can quickly become complicated if more than two templates are involved.

It would be nice if we had a syntax similiar to the "module" block which allows to pass parameter directly to the module. This pull request just implements this feature and enable one to write templates just like this:

``` html
<!-- base.html -->
<body style="color: {{color}};">
    {% block main %}Hello from base{% end %}
</body>

<!-- child1.html: -->
{% extend base.html with color = "blue"%}

{% block main %}Hello from child{% end %}
```