### PR TITLE
Skip falsy values for some SimpleCookie flags

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -524,6 +524,12 @@ class RequestHandler(object):
         for k, v in kwargs.items():
             if k == 'max_age':
                 k = 'max-age'
+
+            # skip falsy values for httponly and secure flags because
+            # SimpleCookie sets them regardless
+            if k in ['httponly', 'secure'] and not v:
+                continue
+
             morsel[k] = v
 
     def clear_cookie(self, name, path="/", domain=None):


### PR DESCRIPTION
This makes sure if you pass `httponly=False` or `secure=False` it does not add those flags to the Set-Cookie header.

Fixes #1324 