### PR TITLE
Coroutine exception __context__ leak in python 3

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -824,13 +824,20 @@ class Runner(object):
                 self.future = None
                 try:
                     orig_stack_contexts = stack_context._state.contexts
+                    exc_info = None
+
                     try:
                         value = future.result()
                     except Exception:
                         self.had_exception = True
-                        yielded = self.gen.throw(*sys.exc_info())
+                        exc_info = sys.exc_info()
+
+                    if exc_info is not None:
+                        yielded = self.gen.throw(*exc_info)
+                        exc_info = None
                     else:
                         yielded = self.gen.send(value)
+
                     if stack_context._state.contexts is not orig_stack_contexts:
                         self.gen.throw(
                             stack_context.StackContextInconsistentError(

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -844,6 +844,29 @@ class GenCoroutineTest(AsyncTestCase):
         yield gen.sleep(0.01)
         self.finished = True
 
+    @skipBefore33
+    @gen_test
+    def test_py3_leak_exception_context(self):
+        class LeakedException(Exception):
+            pass
+
+        @gen.coroutine
+        def inner(iteration):
+            raise LeakedException(iteration)
+
+        try:
+            yield inner(1)
+        except LeakedException as e:
+            self.assertEqual(str(e), "1")
+            self.assertIsNone(e.__context__)
+
+        try:
+            yield inner(2)
+        except LeakedException as e:
+            self.assertEqual(str(e), "2")
+            self.assertIsNone(e.__context__)
+
+        self.finished = True
 
 class GenSequenceHandler(RequestHandler):
     @asynchronous


### PR DESCRIPTION
## Background

In Python 3 every exception has an auto-attached `__context__` exception if it was
raised while an existing exception was being handled.  This is often a very
useful property and allows users to see the underlying cause of many problems.

More info about `__context__`: https://www.python.org/dev/peps/pep-3134/

However, when dealing with async code via coroutines this feature can suddenly
become a pretty big issue.  Namely, if you generator.throw back into a coroutine
to raise an exception in the correct scope, and that coroutine raises an
exception at a later time you can have nested exceptions which shouldn't
logically be nested.

This patch resolves this issue in the coroutine code by moving the gen.throw
outside of the exception handler.  By doing this the user-code scope is able to
later raise exceptions without worrying about inheriting prior exception
context.

## Repro

To better understand the problem please play with the following repro.  Without my change, if you run it with python 3 the printed stack will contain a previous iteration's handled exception.  Without inspecting the internals of tornado, this is quite confusing to the end user since their perspective is that they handled the exception.  Once you apply my change the output matches what you expect and we no longer leak exceptions through the `__context__` variable.

```python
#!/usr/bin/env python

import traceback
from tornado import gen
from tornado import ioloop

loop = ioloop.IOLoop.instance()

@gen.coroutine
def test(iteration):
    print("Printing stack inside test for %s" % iteration)
    traceback.print_stack()
    raise Exception(iteration)

@gen.coroutine
def main():
    for i in range(3):
        iteration = "iteration-%d" % i
        print("%s\nStarting %s" % ("-=" * 50, iteration))
        try:
            yield test(iteration)
        except:
            print("Printing exception for %s" % iteration)
            traceback.print_exc()

if __name__ == "__main__":
    loop.run_sync(main)
```

### Notes

 - I could be completely missing something here, and maybe I am just the only person that finds this confusing.  That is fine, just point me in the right direction and I will be on my way
 - I was planning on adding a test to the Tornado test suite, however it seems that it is currently not in a passing state.  At least I couldn't get it to pass on my machine.  I would prefer to understand whether or not my environment is setup correctly for testing Tornado before I build a test that exercises this code.  One thing to note on this: running tests with/without my change are failing for me.  Any tips/tricks on Tornado testing would be appreciated.

Thanks for your time and I hope to get this merged in (or something like it, or just a better understand of the problem) soon.  For now I am going to use my fork of Tornado for the project that crashed due to this "bug" (if it is a bug).