### PR TITLE
Fix memory leak in Semaphore.

### DIFF
--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -181,7 +181,8 @@ class Semaphore(object):
     def release(self):
         """Increment the counter and wake one waiter."""
         self._value += 1
-        for waiter in self._waiters:
+        while self._waiters:
+            waiter = self._waiters.popleft()
             if not waiter.done():
                 self._value -= 1
 

--- a/tornado/test/locks_test.py
+++ b/tornado/test/locks_test.py
@@ -248,6 +248,7 @@ class SemaphoreTest(AsyncTestCase):
         sem.release()
         # Now acquire() is instant.
         self.assertTrue(sem.acquire().done())
+        self.assertEqual(0, len(sem._waiters))
 
     @gen_test
     def test_acquire_timeout(self):


### PR DESCRIPTION
Next I'll propose a reimplementation of Semaphore in terms of Condition in order to reuse its logic for cleaning up timed-out waiters.