### PR TITLE
Reset waker if it errors out.

### DIFF
--- a/tornado/platform/common.py
+++ b/tornado/platform/common.py
@@ -84,8 +84,10 @@ class Waker(interface.Waker):
                 result = self.reader.recv(1024)
                 if not result:
                     break
-        except (IOError, socket.error):
-            pass
+        except (IOError, socket.error) as e:
+            if e.errno = errno.ECONNRESET:
+                # This will leave the waker in a bad state, so raise.
+                raise
 
     def close(self):
         self.reader.close()


### PR DESCRIPTION
This is the diff that fixes the issue discussed in the following thread:
https://groups.google.com/forum/#!topic/python-tornado/oNE8KcdflqQ
If the Waker's reader socket encounters an ECONNRESET error, the ioloop spins, causing 100% CPU usage. We fix this by resetting the waker whenever we encounter this error.