### PR TITLE
Fixed double slash redirect issue

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -597,6 +597,7 @@ class WSGISafeWebTest(WebTestCase):
             url("/redirect", RedirectHandler),
             url("/web_redirect_permanent", WebRedirectHandler, {"url": "/web_redirect_newpath"}),
             url("/web_redirect", WebRedirectHandler, {"url": "/web_redirect_newpath", "permanent": False}),
+            url("//web_redirect_double_slash", WebRedirectHandler, {"url": '/web_redirect_newpath'}),
             url("/header_injection", HeaderInjectionHandler),
             url("/get_argument", GetArgumentHandler),
             url("/get_arguments", GetArgumentsHandler),
@@ -728,6 +729,11 @@ js_embed()
         self.assertEqual(response.headers['Location'], '/web_redirect_newpath')
         response = self.fetch("/web_redirect", follow_redirects=False)
         self.assertEqual(response.code, 302)
+        self.assertEqual(response.headers['Location'], '/web_redirect_newpath')
+
+    def test_web_redirect_double_slash(self):
+        response = self.fetch("//web_redirect_double_slash", follow_redirects=False)
+        self.assertEqual(response.code, 301)
         self.assertEqual(response.headers['Location'], '/web_redirect_newpath')
 
     def test_header_injection(self):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -650,8 +650,7 @@ class RequestHandler(object):
         else:
             assert isinstance(status, int) and 300 <= status <= 399
         self.set_status(status)
-        self.set_header("Location", urlparse.urljoin(utf8(self.request.uri),
-                                                     utf8(url)))
+        self.set_header("Location", utf8(url))
         self.finish()
 
     def write(self, chunk):


### PR DESCRIPTION
Fixed #1123 by removing `urljoin` because joining request uri with redirect url is doing nothing for now.
Although I agree with using `urljoin` with `full_uri()` as its base is more better way to go, this patch temporarily fixes the issue.