### PR TITLE
Cancel timeouts in Condition.wait and Semaphore.acquire.

### DIFF
--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -73,7 +73,10 @@ class Condition(_TimeoutGarbageCollector):
             def on_timeout():
                 waiter.set_result(False)
                 self._garbage_collect()
-            self.io_loop.add_timeout(timeout, on_timeout)
+            io_loop = ioloop.IOLoop.current()
+            timeout_handle = io_loop.add_timeout(timeout, on_timeout)
+            waiter.add_done_callback(
+                lambda _: io_loop.remove_timeout(timeout_handle))
         return waiter
 
     def notify(self, n=1):
@@ -223,7 +226,10 @@ class Semaphore(_TimeoutGarbageCollector):
                 def on_timeout():
                     waiter.set_exception(gen.TimeoutError())
                     self._garbage_collect()
-                ioloop.IOLoop.current().add_timeout(timeout, on_timeout)
+                io_loop = ioloop.IOLoop.current()
+                timeout_handle = io_loop.add_timeout(timeout, on_timeout)
+                waiter.add_done_callback(
+                    lambda _: io_loop.remove_timeout(timeout_handle))
         return waiter
 
     def __enter__(self):


### PR DESCRIPTION
Unfortunately, small differences prevent me from factoring this with _set_timeout in queues.py: Condition.wait wants to set the result to False, rather than throwing TimeoutError, and both timeouts call self._garbage_collect, which is not needed in Queue.