### PR TITLE
replace '%' in invalid arument to "%%"

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -494,7 +494,7 @@ class RequestHandler(object):
             return _unicode(value)
         except UnicodeDecodeError:
             raise HTTPError(400, "Invalid unicode in %s: %r" %
-                            (name or "url", value[:40]))
+                            (name or "url", value[:40].replace('%', "%%")))
 
     @property
     def cookies(self):


### PR DESCRIPTION
Some invalid unicode aruments may contain '%' and an error will occur when trying `str` a `tonado.web.HTTPError()` with message `Invalid unicode in xxx: 'xxxxxxxx'`

for example, an urlencoded url query arg may like this

```
arg=EE%25%BE%0BS%8F%08%A7-%BC%F3%28%82%AC%26%D2%E5%1B%1D1%C5%18%04%3A%D7%8F%23%964%ADd%C8
```

When using `self.get_argument("arg")` ,an `HTTPError` will be raised.If you call `str` to this exception,it will cause an exception:

```
File "/data/server/python/lib/python2.7/site-packages/tornado/web.py", line 1971, in __str__
        return message + " (" + (self.log_message % self.args) + ")"
```
