### PR TITLE
Add WaitIteratorTest.test_no_ref test

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -81,7 +81,6 @@ import functools
 import itertools
 import sys
 import types
-import weakref
 
 from tornado.concurrent import Future, TracebackFuture, is_future, chain_future
 from tornado.ioloop import IOLoop
@@ -335,10 +334,8 @@ class WaitIterator(object):
         self.current_index = self.current_future = None
         self._running_future = None
 
-        self_ref = weakref.ref(self)
         for future in futures:
-            future.add_done_callback(functools.partial(
-                self._done_callback, self_ref))
+            future.add_done_callback(self._done_callback)
 
     def done(self):
         """Returns True if this iterator has no more results."""
@@ -361,14 +358,11 @@ class WaitIterator(object):
 
         return self._running_future
 
-    @staticmethod
-    def _done_callback(self_ref, done):
-        self = self_ref()
-        if self is not None:
-            if self._running_future and not self._running_future.done():
-                self._return_result(done)
-            else:
-                self._finished.append(done)
+    def _done_callback(self, done):
+        if self._running_future and not self._running_future.done():
+            self._return_result(done)
+        else:
+            self._finished.append(done)
 
     def _return_result(self, done):
         """Called set the returned future's state that of the future

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1199,5 +1199,10 @@ class WaitIteratorTest(AsyncTestCase):
                     self.assertEqual(g.current_index, 3, 'wrong index')
             i += 1
 
+    @gen_test
+    def test_no_ref(self):
+        yield gen.with_timeout(datetime.timedelta(seconds=0.1),
+                               gen.WaitIterator(gen.sleep(0)).next())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Using weak reference in `gen.WaitIterator` is problematic, added a test to prove it.

Replacing the test with
```python
    @gen_test
    def test_no_ref(self):
        ref = gen.WaitIterator(gen.sleep(0))
        
        yield gen.with_timeout(datetime.timedelta(seconds=0.1),
                               ref.next())
```

Passes