### PR TITLE
Update KQueue.py

### DIFF
--- a/tornado/platform/kqueue.py
+++ b/tornado/platform/kqueue.py
@@ -46,6 +46,8 @@ class _KQueue(object):
         self.register(fd, events)
 
     def unregister(self, fd):
+        if fd not int self._active.pop(fd):
+            return
         events = self._active.pop(fd)
         self._control(fd, events, select.KQ_EV_DELETE)
 


### PR DESCRIPTION
When have a big load of process attached to ioloop and it is running on Mac Os Yosemite (develop machine) when go to modify(self, fd, events) and it go to unregister(self, fd) it doesn't check if fd exist before pop from self._active.
I understand it should exist but doesn't and make internal issues and not register new fd.
Sometimes to exist and Python3 raise exception. Other time not exist but when go in except block now exist.
I try to find some better fix, but my knowledge on this points (KQueue) is not very good.