### PR TITLE
Allow the same future multiple times in `multi_future`

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -671,8 +671,12 @@ def multi_future(children, quiet_exceptions=()):
                     future.set_result(dict(zip(keys, result_list)))
                 else:
                     future.set_result(result_list)
+
+    listening = set()
     for f in children:
-        f.add_done_callback(callback)
+        if f not in listening:
+            listening.add(f)
+            f.add_done_callback(callback)
     return future
 
 

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -391,6 +391,12 @@ class GenEngineTest(AsyncTestCase):
         self.assertEqual(results, [1, 2])
 
     @gen_test
+    def test_multi_future_duplicate(self):
+        f = self.async_future(2)
+        results = yield [self.async_future(1), f, self.async_future(3), f]
+        self.assertEqual(results, [1, 2, 3, 2])
+
+    @gen_test
     def test_multi_dict_future(self):
         results = yield dict(foo=self.async_future(1), bar=self.async_future(2))
         self.assertEqual(results, dict(foo=1, bar=2))


### PR DESCRIPTION
This prevents failures in cases like the following:

    f = <some future>
    yield [f, f]