### PR TITLE
Add max_body_size parameter to SimpleHTTPClient

### DIFF
--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -631,3 +631,49 @@ class MaxHeaderSizeTest(AsyncHTTPTestCase):
         with ExpectLog(gen_log, "Unsatisfiable read"):
             response = self.fetch('/large')
         self.assertEqual(response.code, 599)
+
+
+class MaxBodySizeTest(AsyncHTTPTestCase):
+    def get_app(self):
+        class SmallBody(RequestHandler):
+            def get(self):
+                self.write("a"*1024*64)
+
+        class LargeBody(RequestHandler):
+            def get(self):
+                self.write("a"*1024*100)
+
+        return Application([('/small', SmallBody),
+                            ('/large', LargeBody)])
+
+    def get_http_client(self):
+        return SimpleAsyncHTTPClient(io_loop=self.io_loop, max_body_size=1024*64)
+
+    def test_small_body(self):
+        response = self.fetch('/small')
+        response.rethrow()
+        self.assertEqual(response.body, "a"*1024*64)
+
+    def test_large_body(self):
+        with ExpectLog(gen_log, "Malformed HTTP message from None: Content-Length too long"):
+            response = self.fetch('/large')
+        self.assertEqual(response.code, 599)
+
+
+class MaxBufferSizeTest(AsyncHTTPTestCase):
+    def get_app(self):
+
+        class LargeBody(RequestHandler):
+            def get(self):
+                self.write("a"*1024*100)
+
+        return Application([('/large', LargeBody)])
+
+    def get_http_client(self):
+        # 100KB body with 64KB buffer
+        return SimpleAsyncHTTPClient(io_loop=self.io_loop, max_body_size=1024*100, max_buffer_size=1024*64)
+
+    def test_large_body(self):
+        response = self.fetch('/large')
+        response.rethrow()
+        self.assertEqual(response.body, "a"*1024*100)

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -652,7 +652,7 @@ class MaxBodySizeTest(AsyncHTTPTestCase):
     def test_small_body(self):
         response = self.fetch('/small')
         response.rethrow()
-        self.assertEqual(response.body, "a"*1024*64)
+        self.assertEqual(response.body, b'a'*1024*64)
 
     def test_large_body(self):
         with ExpectLog(gen_log, "Malformed HTTP message from None: Content-Length too long"):
@@ -676,4 +676,4 @@ class MaxBufferSizeTest(AsyncHTTPTestCase):
     def test_large_body(self):
         response = self.fetch('/large')
         response.rethrow()
-        self.assertEqual(response.body, "a"*1024*100)
+        self.assertEqual(response.body, b'a'*1024*100)

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -908,7 +908,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         self.tcp_client = TCPClient(io_loop=io_loop)
         super(WebSocketClientConnection, self).__init__(
             io_loop, None, request, lambda: None, self._on_http_response,
-            104857600, self.tcp_client, 65536)
+            104857600, self.tcp_client, 65536, 104857600)
 
     def close(self, code=None, reason=None):
         """Closes the websocket connection.


### PR DESCRIPTION
This change allows the SimpleHTTPClient to receive responses larger then `max_buffer_size`. This should allow downloading of very large files without increasing max_buffer_size to unreasonable values.

Intended usage:

```python
#!/usr/bin/env python
import tornado.gen
import tornado.ioloop
import tornado.httpclient

@tornado.gen.coroutine
def main():

    # download 1.1 GB file
    url = 'http://releases.ubuntu.com/14.10/ubuntu-14.10-desktop-amd64.iso'
    http = tornado.httpclient.AsyncHTTPClient(max_body_size=1024*1024*1024*5)

    with open('/dev/null', 'wb') as f:

        response = yield http.fetch(url,
                                    streaming_callback=f.write,
                                    request_timeout=3600)

tornado.ioloop.IOLoop.current().run_sync(main)
```