### PR TITLE
Timeouts not deadlines.

### DIFF
--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -95,12 +95,12 @@ class Condition(_TimeoutGarbageCollector):
         io_loop = ioloop.IOLoop.current()
 
         # Wait up to 1 second for a notification.
-        yield condition.wait(deadline=io_loop.time() + 1)
+        yield condition.wait(timeout=io_loop.time() + 1)
 
-    ...or a `datetime.timedelta` for a deadline relative to the current time::
+    ...or a `datetime.timedelta` for a timeout relative to the current time::
 
         # Wait up to 1 second.
-        yield condition.wait(deadline=datetime.timedelta(seconds=1))
+        yield condition.wait(timeout=datetime.timedelta(seconds=1))
 
     The method raises `tornado.gen.TimeoutError` if there's no notification
     before the deadline.

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -433,13 +433,13 @@ class Lock(object):
             self.__class__.__name__,
             self._block)
 
-    def acquire(self, deadline=None):
+    def acquire(self, timeout=None):
         """Attempt to lock. Returns a Future.
 
         Returns a Future, which raises `tornado.gen.TimeoutError` after a
         timeout.
         """
-        return self._block.acquire(deadline)
+        return self._block.acquire(timeout)
 
     def release(self):
         """Unlock.

--- a/tornado/test/locks_test.py
+++ b/tornado/test/locks_test.py
@@ -448,7 +448,7 @@ class LockTests(AsyncTestCase):
         lock = locks.Lock()
         lock.acquire()
         with self.assertRaises(gen.TimeoutError):
-            yield lock.acquire(deadline=timedelta(seconds=0.01))
+            yield lock.acquire(timeout=timedelta(seconds=0.01))
 
         # Still locked.
         self.assertFalse(lock.acquire().done())


### PR DESCRIPTION
The change to the Condition.wait examples is a bugfix. The change to the argument name for Lock.acquire is a judgment call, neither threading.Lock.acquire nor asyncio.Lock.acquire have any timeout argument at all. I think renaming it "timeout" is consistent within Tornado.