### PR TITLE
add docs recursively to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 recursive-include demos *.py *.yaml *.html *.css *.js *.xml *.sql README
+recursive-include docs *
+prune docs/build
 include tornado/speedups.c
 include tornado/test/README
 include tornado/test/csv_translations/fr_FR.csv


### PR DESCRIPTION
When packaging tornado for Gentoo I found the documentation was not
available in the sdist provided on pypi.  This adds the documentation so
that users can choose to install it locally.