### PR TITLE
Fix GoogleOAuth2Mixin.get_authenticated_user()

### DIFF
--- a/tornado/test/auth_test.py
+++ b/tornado/test/auth_test.py
@@ -417,7 +417,6 @@ class AuthTest(AsyncHTTPTestCase):
 
 
 class GoogleLoginHandler(RequestHandler, GoogleOAuth2Mixin):
-
     def initialize(self, test):
         self._OAUTH_REDIRECT_URI = test.get_url('/client/login')
         self._OAUTH_AUTHORIZE_URL = test.get_url('/google/oauth2/authorize')
@@ -431,8 +430,9 @@ class GoogleLoginHandler(RequestHandler, GoogleOAuth2Mixin):
 
             # retrieve authenticate google user
             user = yield self.get_authenticated_user(self._OAUTH_REDIRECT_URI, code)
-            self.write(user)
 
+            # return the user as json
+            self.write(user)
         else:
             yield self.authorize_redirect(
                 redirect_uri=self._OAUTH_REDIRECT_URI,
@@ -443,9 +443,7 @@ class GoogleLoginHandler(RequestHandler, GoogleOAuth2Mixin):
                 extra_params={'prompt': 'select_account'})
 
 
-
 class GoogleOAuth2AuthorizeHandler(RequestHandler):
-
     def get(self):
         # issue a fake auth code and redirect to redirect_uri
         code = 'fake-authorization-code'
@@ -454,7 +452,6 @@ class GoogleOAuth2AuthorizeHandler(RequestHandler):
 
 
 class GoogleOAuth2TokenHandler(RequestHandler):
-
     def post(self):
         assert self.get_argument('code') == 'fake-authorization-code'
         # issue a fake token
@@ -465,7 +462,6 @@ class GoogleOAuth2TokenHandler(RequestHandler):
 
 
 class GoogleOAuth2ProfileHandler(RequestHandler):
-
     def get(self):
         assert self.get_argument('access_token') == 'fake-access-token'
         # return the user "profile"

--- a/tornado/test/auth_test.py
+++ b/tornado/test/auth_test.py
@@ -5,13 +5,14 @@
 
 
 from __future__ import absolute_import, division, print_function, with_statement
-from tornado.auth import OpenIdMixin, OAuthMixin, OAuth2Mixin, TwitterMixin, AuthError
+from tornado.auth import OpenIdMixin, OAuthMixin, OAuth2Mixin, TwitterMixin, AuthError, GoogleOAuth2Mixin
 from tornado.concurrent import Future
 from tornado.escape import json_decode
 from tornado import gen
 from tornado.log import gen_log
 from tornado.testing import AsyncHTTPTestCase, ExpectLog
 from tornado.util import u
+from tornado.httputil import url_concat
 from tornado.web import RequestHandler, Application, asynchronous, HTTPError
 
 
@@ -413,3 +414,91 @@ class AuthTest(AsyncHTTPTestCase):
         response = self.fetch('/twitter/client/show_user_future?name=error')
         self.assertEqual(response.code, 500)
         self.assertIn(b'Error response HTTP 500', response.body)
+
+
+class GoogleLoginHandler(RequestHandler, GoogleOAuth2Mixin):
+
+    def initialize(self, test):
+        self._OAUTH_REDIRECT_URI = test.get_url('/client/login')
+        self._OAUTH_AUTHORIZE_URL = test.get_url('/google/oauth2/authorize')
+        self._OAUTH_ACCESS_TOKEN_URL = test.get_url('/google/oauth2/token')
+        self._OAUTH_BASE_URL = test.get_url('/google/api')
+
+    @gen.coroutine
+    def get(self):
+        code = self.get_argument('code', None)
+        if code is not None:
+
+            # retrieve authenticate google user
+            user = yield self.get_authenticated_user(self._OAUTH_REDIRECT_URI, code)
+            self.write(user)
+
+        else:
+            yield self.authorize_redirect(
+                redirect_uri=self._OAUTH_REDIRECT_URI,
+                client_id=self.settings['google_oauth']['key'],
+                client_secret=self.settings['google_oauth']['secret'],
+                scope=['profile', 'email'],
+                response_type='code',
+                extra_params={'prompt': 'select_account'})
+
+
+
+class GoogleOAuth2AuthorizeHandler(RequestHandler):
+
+    def get(self):
+        # issue a fake auth code and redirect to redirect_uri
+        code = 'fake-authorization-code'
+        self.redirect(url_concat(self.get_argument('redirect_uri'),
+                                 dict(code=code)))
+
+
+class GoogleOAuth2TokenHandler(RequestHandler):
+
+    def post(self):
+        assert self.get_argument('code') == 'fake-authorization-code'
+        # issue a fake token
+        self.finish({
+            'access_token': 'fake-access-token',
+            'expires_in': 'never-expires'
+        })
+
+
+class GoogleOAuth2ProfileHandler(RequestHandler):
+
+    def get(self):
+        assert self.get_argument('access_token') == 'fake-access-token'
+        # return the user "profile"
+        self.finish({
+            'name': 'foo',
+            'id': 4567
+        })
+
+
+class GoogleOAuth2Test(AsyncHTTPTestCase):
+    def get_app(self):
+        return Application(
+            [
+                # test endpoints
+                ('/client/login', GoogleLoginHandler, dict(test=self)),
+
+                # simulated google authorization server endpoints
+                ('/google/oauth2/authorize', GoogleOAuth2AuthorizeHandler),
+                ('/google/oauth2/token', GoogleOAuth2TokenHandler),
+
+                # simulated google api endpoints
+                ('/google/api/userinfo', GoogleOAuth2ProfileHandler)
+            ],
+            google_oauth={
+                "key": 'fake_google_client_id',
+                "secret": 'fake_google_client_secret'
+            })
+
+    def test_google_login(self):
+        response = self.fetch('/client/login')
+        self.assertDictEqual({
+            u'name': u'foo',
+            u'id': 4567,
+            u'access_token': u'fake-access-token',
+            u'session_expires': u'never-expires',
+        }, json_decode(response.body))


### PR DESCRIPTION
The method `GoogleOAuth2Mixin.get_authenticated_user` says its supposed to return the authenticated user, but it currently returns the access_ token. My fix is pretty much the same as #1212: After the access_token is retrieved, an API call is made to get the current user from the Google API. This was accomplished by adding a method `GoogleOAuth2Mixin.google_request`, using an extracted version of `FacebookGraphMixin.facebook_request` into OAuth2Mixin as `_auth_request`.

Additionally, I've added a basic test for the GoogleOAuth2Mixin authorization code grant flow.