### PR TITLE
Initial work on Keep-Alive

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -46,6 +46,10 @@ def _default_ca_certs():
     return certifi.where()
 
 
+_ConnectionBase = collections.namedtuple('_ConnectionBase', ('scheme', 'host',
+                                                             'port', 'parsed'))
+
+
 class SimpleAsyncHTTPClient(AsyncHTTPClient):
     """Non-blocking HTTP client with no external dependencies.
 
@@ -58,7 +62,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
     def initialize(self, io_loop, max_clients=10,
                    hostname_mapping=None, max_buffer_size=104857600,
                    resolver=None, defaults=None, max_header_size=None,
-                   max_body_size=None):
+                   max_body_size=None, reuse_connections=False):
         """Creates a AsyncHTTPClient.
 
         Only a single AsyncHTTPClient instance exists per IOLoop
@@ -88,6 +92,12 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         applies; with a ``streaming_callback`` only ``max_body_size``
         does.
 
+        ``reuse_connections`` will pool clients processing requests with the
+        "Connection: Keep-Alive" header. Future requests matching host, port,
+        and scheme with an idle connection in the pool will be first dispatched
+        from an available connection. If no connection is available, typical
+        procedure is followed.  Defaults to False.
+
         .. versionchanged:: 4.2
            Added the ``max_body_size`` argument.
         """
@@ -97,9 +107,11 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         self.queue = collections.deque()
         self.active = {}
         self.waiting = {}
+        self.idle = {}
         self.max_buffer_size = max_buffer_size
         self.max_header_size = max_header_size
         self.max_body_size = max_body_size
+        self.reuse_connections = reuse_connections
         # TCPClient could create a Resolver for us, but we have to do it
         # ourselves to support hostname_mapping.
         if resolver:
@@ -151,14 +163,40 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         return _HTTPConnection
 
     def _handle_request(self, request, release_callback, final_callback):
-        self._connection_class()(
-            self.io_loop, self, request, release_callback,
-            final_callback, self.max_buffer_size, self.tcp_client,
-            self.max_header_size, self.max_body_size)
+        cls = self._connection_class()
+        base = cls.parse_connection_base(request)
+        if self.reuse_connections and base in self.idle and self.idle[base]:
+            conn = self.idle[base].popleft()
+            conn.release_callback = release_callback
+            conn.final_callback = final_callback
+            conn.send(request)
+            return
+        cls(self.io_loop, self, request, release_callback, final_callback,
+            self.max_buffer_size, self.tcp_client, self.max_header_size,
+            self.max_body_size, self.reuse_connections, base)
 
-    def _release_fetch(self, key):
+    def _release_fetch(self, key, conn):
         del self.active[key]
+        if self.reuse_connections:
+            if not conn.stream._closed:
+                self._add_idle(conn)
+            else:
+                self._remove_idle(conn)
+        elif conn.keepalive:
+            conn.close()
         self._process_queue()
+
+    def _add_idle(self, conn):
+        if not conn.base in self.idle:
+            self.idle[conn.base] = collections.deque()
+        self.idle[conn.base].append(conn)
+
+    def _remove_idle(self, conn):
+        if not conn.base in self.idle:
+            return
+        self.idle[conn.base].remove(conn)
+        if not self.idle[conn.base]:
+            del self.idle[conn.base]
 
     def _remove_timeout(self, key):
         if key in self.waiting:
@@ -182,7 +220,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
 
     def __init__(self, io_loop, client, request, release_callback,
                  final_callback, max_buffer_size, tcp_client,
-                 max_header_size, max_body_size):
+                 max_header_size, max_body_size, keepalive=False, base=None):
         self.start_time = io_loop.time()
         self.io_loop = io_loop
         self.client = client
@@ -193,6 +231,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         self.tcp_client = tcp_client
         self.max_header_size = max_header_size
         self.max_body_size = max_body_size
+        self.keepalive = keepalive
+        self.base = base
         self.code = None
         self.headers = None
         self.chunks = []
@@ -201,65 +241,78 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         self._timeout = None
         self._sockaddr = None
         with stack_context.ExceptionStackContext(self._handle_exception):
-            self.parsed = urlparse.urlsplit(_unicode(self.request.url))
-            if self.parsed.scheme not in ("http", "https"):
-                raise ValueError("Unsupported url scheme: %s" %
-                                 self.request.url)
-            # urlsplit results have hostname and port results, but they
-            # didn't support ipv6 literals until python 2.7.
-            netloc = self.parsed.netloc
-            if "@" in netloc:
-                userpass, _, netloc = netloc.rpartition("@")
-            host, port = httputil.split_host_and_port(netloc)
-            if port is None:
-                port = 443 if self.parsed.scheme == "https" else 80
-            if re.match(r'^\[.*\]$', host):
-                # raw ipv6 addresses in urls are enclosed in brackets
-                host = host[1:-1]
-            self.parsed_hostname = host  # save final host for _on_connect
+            if not self.base:
+                self.base = self.parse_connection_base(self.request)
 
-            if request.allow_ipv6 is False:
+            # Store .parsed values for backward compatibility
+            self.parsed = self.base.parsed
+            self.parsed_hostname = self.base.host
+
+            if self.request.allow_ipv6 is False:
                 af = socket.AF_INET
             else:
                 af = socket.AF_UNSPEC
 
-            ssl_options = self._get_ssl_options(self.parsed.scheme)
+            ssl_options = self._get_ssl_options(self.base.scheme,
+                                                self.request)
 
-            timeout = min(self.request.connect_timeout, self.request.request_timeout)
+            timeout = min(self.request.connect_timeout,
+                          self.request.request_timeout)
             if timeout:
                 self._timeout = self.io_loop.add_timeout(
                     self.start_time + timeout,
                     stack_context.wrap(self._on_timeout))
-            self.tcp_client.connect(host, port, af=af,
+
+            self.tcp_client.connect(self.base.host, self.base.port, af=af,
                                     ssl_options=ssl_options,
                                     max_buffer_size=self.max_buffer_size,
                                     callback=self._on_connect)
 
-    def _get_ssl_options(self, scheme):
+
+    @classmethod
+    def parse_connection_base(cls, request):
+        parsed = urlparse.urlsplit(_unicode(request.url))
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("Unsupported url scheme: %s" % request.url)
+        # urlsplit results have hostname and port results, but they
+        # didn't support ipv6 literals until python 2.7.
+        netloc = parsed.netloc
+        if "@" in netloc:
+            userpass, _, netloc = parsed.netloc.rpartition("@")
+        host, port = httputil.split_host_and_port(netloc)
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        if re.match(r'^\[.*\]$', host):
+            # raw ipv6 addresses in urls are enclosed in brackets
+            host = host[1:-1]
+        return _ConnectionBase(parsed.scheme, host, port, parsed)
+
+    @classmethod
+    def _get_ssl_options(cls, scheme, request):
         if scheme == "https":
-            if self.request.ssl_options is not None:
-                return self.request.ssl_options
+            if request.ssl_options is not None:
+                return request.ssl_options
             # If we are using the defaults, don't construct a
             # new SSLContext.
-            if (self.request.validate_cert and
-                    self.request.ca_certs is None and
-                    self.request.client_cert is None and
-                    self.request.client_key is None):
+            if (request.validate_cert and
+                request.ca_certs is None and
+                request.client_cert is None and
+                request.client_key is None):
                 return _client_ssl_defaults
             ssl_options = {}
-            if self.request.validate_cert:
+            if request.validate_cert:
                 ssl_options["cert_reqs"] = ssl.CERT_REQUIRED
-            if self.request.ca_certs is not None:
+            if request.ca_certs is not None:
                 ssl_options["ca_certs"] = self.request.ca_certs
             elif not hasattr(ssl, 'create_default_context'):
                 # When create_default_context is present,
                 # we can omit the "ca_certs" parameter entirely,
                 # which avoids the dependency on "certifi" for py34.
                 ssl_options["ca_certs"] = _default_ca_certs()
-            if self.request.client_key is not None:
-                ssl_options["keyfile"] = self.request.client_key
-            if self.request.client_cert is not None:
-                ssl_options["certfile"] = self.request.client_cert
+            if request.client_key is not None:
+                ssl_options["keyfile"] = request.client_key
+            if request.client_cert is not None:
+                ssl_options["certfile"] = request.client_cert
 
             # SSL interoperability is tricky.  We want to disable
             # SSLv2 for security reasons; it wasn't disabled by default
@@ -304,6 +357,10 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         self._remove_timeout()
         if self.final_callback is None:
             return
+        self.send()
+
+    def send(self, request=None):
+        self.request = request or self.request
         if self.request.request_timeout:
             self._timeout = self.io_loop.add_timeout(
                 self.start_time + self.request.request_timeout,
@@ -317,7 +374,11 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             if getattr(self.request, key, None):
                 raise NotImplementedError('%s not supported' % key)
         if "Connection" not in self.request.headers:
-            self.request.headers["Connection"] = "close"
+            if not self.keepalive:
+                self.request.headers["Connection"] = "close"
+            else:
+                self.request.headers["Connection"] = "Keep-Alive"  # for 1.0
+
         if "Host" not in self.request.headers:
             if '@' in self.parsed.netloc:
                 self.request.headers["Host"] = self.parsed.netloc.rpartition('@')[-1]
@@ -365,7 +426,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             self.request.headers["Accept-Encoding"] = "gzip"
         req_path = ((self.parsed.path or '/') +
                     (('?' + self.parsed.query) if self.parsed.query else ''))
-        self.connection = self._create_connection(stream)
+        if not hasattr(self, 'connection') or not self.connection:
+            self.connection = self._create_connection(self.stream)
         start_line = httputil.RequestStartLine(self.request.method,
                                                req_path, '')
         self.connection.write_headers(start_line, self.request.headers)
@@ -379,7 +441,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         connection = HTTP1Connection(
             stream, True,
             HTTP1ConnectionParameters(
-                no_keep_alive=True,
+                no_keep_alive=not self.keepalive,
                 max_header_size=self.max_header_size,
                 max_body_size=self.max_body_size,
                 decompress=self.request.decompress_response),
@@ -414,7 +476,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         if self.release_callback is not None:
             release_callback = self.release_callback
             self.release_callback = None
-            release_callback()
+            release_callback(self)
 
     def _run_callback(self, response):
         self._release()
@@ -454,6 +516,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                 raise HTTPError(599, message)
             except HTTPError:
                 self._handle_exception(*sys.exc_info())
+        if self.keepalive:
+            self._release()
 
     def headers_received(self, first_line, headers):
         if self.request.expect_100_continue and first_line.code == 100:
@@ -521,7 +585,10 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         self._on_end_request()
 
     def _on_end_request(self):
-        self.stream.close()
+        if not self.keepalive:
+            self.stream.close()
+        else:
+            self.chunks = collections.deque()
 
     def data_received(self, chunk):
         if self.request.streaming_callback is not None:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -201,7 +201,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         except KeyError:
             return
         if not self.idle[conn.base]:
-	    del self.idle[conn.base]
+            del self.idle[conn.base]
 
     def _remove_timeout(self, key):
         try:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -348,8 +348,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
     def _on_timeout(self):
         self._timeout = None
         if self.keepalive:
-	    self.stream.close()
-	    self._release()
+            self.stream.close()
+            self._release()
         if self.final_callback is not None:
             raise HTTPError(599, "Timeout")
 

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -702,7 +702,8 @@ class KeepAliveTest(AsyncHTTPTestCase):
 
     _state_app = KeepAliveApplication([
         ('/keepalive', EchoPostHandler),
-        ('/keepalive-closed', CloseHandler)
+        ('/keepalive-closed', CloseHandler),
+        ('/hang', HangHandler)
     ], gzip=True)
 
     def get_app(self):
@@ -735,3 +736,8 @@ class KeepAliveTest(AsyncHTTPTestCase):
         self.assertEquals(self.http_client.idle, {})
         response = self.fetch('/keepalive', method='POST', body="foo")
         self.assertEqual(response.body, b"foo")
+
+    def test_keep_alive_timeout(self):
+        response = self.fetch('/hang', request_timeout=.1)
+        self.assertEquals(response.error.code, 599)
+        self.assertEquals(self.http_client.idle, {})

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -123,7 +123,6 @@ class RespondInPrepareHandler(RequestHandler):
         self.set_status(403)
         self.finish("forbidden")
 
-
 class SimpleHTTPClientTestMixin(object):
     def get_app(self):
         # callable objects to finish pending /trigger requests
@@ -677,3 +676,62 @@ class MaxBufferSizeTest(AsyncHTTPTestCase):
         response = self.fetch('/large')
         response.rethrow()
         self.assertEqual(response.body, b'a'*1024*100)
+
+
+class KeepAliveTest(AsyncHTTPTestCase):
+
+    class KeepAliveApplication(Application):
+
+        def __init__(self, *args, **kwargs):
+            self.request_streams = []
+            self.server_streams = []
+            Application.__init__(self, *args, **kwargs)
+
+        def start_request(self, serv_conn, req_conn):
+            self.request_streams.append(req_conn.stream)
+            self.server_streams.append(serv_conn.stream)
+            return Application.start_request(self, serv_conn, req_conn)
+
+    class CloseHandler(RequestHandler):
+
+        @asynchronous
+        def post(self):
+            self.write(b'')
+            self.flush()
+            self.request.connection.close()
+
+    _state_app = KeepAliveApplication([
+        ('/keepalive', EchoPostHandler),
+        ('/keepalive-closed', CloseHandler)
+    ], gzip=True)
+
+    def get_app(self):
+        return self._state_app
+
+    def get_http_client(self):
+        # 100KB body with 64KB buffer
+        client = SimpleAsyncHTTPClient(io_loop=self.io_loop,
+                                       force_instance=True)
+        client.initialize(self.io_loop, max_clients=1, reuse_connections=True)
+        return client
+
+    def test_keep_alive(self):
+        response1 = self.fetch('/keepalive', method='POST', body=u"foo")
+        self.assertEqual(response1.body, u'foo')
+        response2 = self.fetch('/keepalive', method='POST', body=u"bar")
+        self.assertEqual(response2.body, u'bar')
+
+        # Confirm only a single stream was opened.
+        app = self.get_app()
+        base = app.request_streams[0]
+        for stream in app.request_streams:
+            self.assertIs(base, stream)
+
+        for stream in app.server_streams:
+            self.assertIs(base, stream)
+
+    def test_keep_alive_closed(self):
+        response = self.fetch('/keepalive-closed', method='POST', body=u"foo")
+        self.assertEquals(self.http_client.idle, {})
+        response = self.fetch('/keepalive', method='POST', body=u"foo")
+        self.assertEqual(response.body, u"foo")

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -716,10 +716,10 @@ class KeepAliveTest(AsyncHTTPTestCase):
         return client
 
     def test_keep_alive(self):
-        response1 = self.fetch('/keepalive', method='POST', body=u"foo")
-        self.assertEqual(response1.body, u'foo')
-        response2 = self.fetch('/keepalive', method='POST', body=u"bar")
-        self.assertEqual(response2.body, u'bar')
+        response1 = self.fetch('/keepalive', method='POST', body="foo")
+        self.assertEqual(response1.body, b'foo')
+        response2 = self.fetch('/keepalive', method='POST', body="bar")
+        self.assertEqual(response2.body, b'bar')
 
         # Confirm only a single stream was opened.
         app = self.get_app()
@@ -731,7 +731,7 @@ class KeepAliveTest(AsyncHTTPTestCase):
             self.assertIs(base, stream)
 
     def test_keep_alive_closed(self):
-        response = self.fetch('/keepalive-closed', method='POST', body=u"foo")
+        response = self.fetch('/keepalive-closed', method='POST', body="foo")
         self.assertEquals(self.http_client.idle, {})
-        response = self.fetch('/keepalive', method='POST', body=u"foo")
-        self.assertEqual(response.body, u"foo")
+        response = self.fetch('/keepalive', method='POST', body="foo")
+        self.assertEqual(response.body, b"foo")

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -909,7 +909,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
 
         self.tcp_client = TCPClient(io_loop=io_loop)
         super(WebSocketClientConnection, self).__init__(
-            io_loop, None, request, lambda: None, self._on_http_response,
+            io_loop, None, request, lambda x: None, self._on_http_response,
             104857600, self.tcp_client, 65536, 104857600)
 
     def close(self, code=None, reason=None):


### PR DESCRIPTION
An initial attempt at adding Connection: Keep-Alive pooling to SimpleAsyncHTTPClient per #324.

In order to prevent duplication of the url-parsing step, I converted the current process to a class method that is called and compared against idle connections if the reuse_connections attribute is set. If a new connection is required, the "_ConnectionBase" namedtuple is passed as a parameter to the private _HTTPConnection class so that re-parsing is not necessary.

Please let me know what we can do to improve the testing here.
