### PR TITLE
Add Google OAuth2 user info request.

### DIFF
--- a/tornado/test/auth_test.py
+++ b/tornado/test/auth_test.py
@@ -467,8 +467,8 @@ class GoogleOAuth2UserinfoHandler(RequestHandler):
         assert self.get_argument('access_token') == 'fake-access-token'
         # return a fake user
         self.finish({
-                u'name': u'Foo',
-                u'email': u'foo@example.com'
+                'name': 'Foo',
+                'email': 'foo@example.com'
                 })
 
 


### PR DESCRIPTION
-   Added a Google user info API URL to `GoogleOAuth2Mixin`
-   Added code to get user object to the `GoogleOAuth2Mixin.get_authenticated_user` docstring example
-   Added user object process to the auth tests
-   Changed what looks like the wrong function in `oauth2_request`
