### PR TITLE
StaticFileHandler sets Content-Encoding for gzip

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2313,6 +2313,10 @@ class StaticFileHandler(RequestHandler):
         if content_type:
             self.set_header("Content-Type", content_type)
 
+        encoding = mimetypes.guess_type(self.absolute_path)[1]
+        if encoding == "gzip":
+            self.set_header("Content-Encoding", "x-gzip")
+
         cache_time = self.get_cache_time(self.path, self.modified,
                                          content_type)
         if cache_time > 0:


### PR DESCRIPTION
Without this, the staticFileHandler would fail to serve files with an
.xml.gz extension, giving binary files with no encoding specified and a
Content-Type of 'application/xml'.