### PR TITLE
Remove an useless line

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -182,7 +182,6 @@ class HTTPServer(TCPServer, httputil.HTTPServerConnectionDelegate):
 class _HTTPRequestContext(object):
     def __init__(self, stream, address, protocol):
         self.address = address
-        self.protocol = protocol
         # Save the socket's address family now so we know how to
         # interpret self.address even after the stream is closed
         # and its socket attribute replaced with None.


### PR DESCRIPTION
This [line](https://github.com/tornadoweb/tornado/blob/master/tornado/httpserver.py#L191) seems useless.
We handle ```self.protocol``` [here](https://github.com/tornadoweb/tornado/blob/master/tornado/httpserver.py#L206-L211)