### PR TITLE
allow overriding RequestHandler json_encode

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -299,6 +299,10 @@ class RequestHandler(object):
         """
         pass
 
+    def json_encode(self, value):
+        """Override this to change the default json encoder"""
+        return escape.json_encode(value)
+
     def set_status(self, status_code, reason=None):
         """Sets the status code for our response.
 
@@ -692,7 +696,7 @@ class RequestHandler(object):
                 message += ". Lists not accepted for security reasons; see http://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write"
             raise TypeError(message)
         if isinstance(chunk, dict):
-            chunk = escape.json_encode(chunk)
+            chunk = self.json_encode(chunk)
             self.set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = utf8(chunk)
         self._write_buffer.append(chunk)

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -212,7 +212,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
         if self.ws_connection is None:
             raise WebSocketClosedError()
         if isinstance(message, dict):
-            message = tornado.escape.json_encode(message)
+            message = self.json_encode(message)
         self.ws_connection.write_message(message, binary=binary)
 
     def select_subprotocol(self, subprotocols):


### PR DESCRIPTION
It is very convenient to be able to use self.write(result_dict) in Tornado and automatically have it serve JSON with the appropriate header. However, it forces you to use the json_encode function, which isn't really that flexible (for example, it can't handle types like Decimal, and can't be overloaded).

This can lead to boilerplate code everywhere that looks like this:

```python
class MyRequestHandler(RequestHandler):
    def get():
        ...
        result_str = simplejson.dumps(result_dict)
        self.write(result_str)
        self.set_header('Content-type', 'application/json; charset=utf-8')
        self.finish()
```

I've seen lots of discussion about replacing/not replacing json_encode (#1202, #706, #566, #414, #646, #54, #16, #129, #116, #914, #705 to name the ones I found).

Would allowing users to override the json_encode function used by RequestHandler be a best-of-both-worlds solution to this? This would allow any other json encoding mechanism to be used simply by
defining a new function in an inherited class of RequestHandler.

For example
```python
class JSONRequestHandler(RequestHandler):
    def json_encode(self, value):
        return simplejson.dumps(value)

class MyRequestHandler(JSONRequestHandler):
    def get():
        ...
        self.write(result_dict)
        self.finish()
```