### PR TITLE
Support Python 3.5 `async` statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ script:
     # We use "python -m coverage" instead of the "bin/coverage" script
     # so we can pass additional arguments to python.  However, this doesn't
     # work on 2.6, so skip coverage on that version.
-    - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then export TARGET="-m coverage run $TARGET"; fi
+    # coverage needs a function that was removed in python 3.6 so we can't
+    # run it with nightly cpython.
+    - if [[ $TRAVIS_PYTHON_VERSION != 2.6 && $TRAVIS_PYTHON_VERSION != nightly ]]; then export TARGET="-m coverage run $TARGET"; fi
     - python $TARGET
     - python $TARGET --ioloop=tornado.platform.select.SelectIOLoop
     - python -O $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - 3.2
     - 3.3
     - 3.4
+    - nightly
     - pypy3
 
 env:

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -346,6 +346,9 @@ class WaitIterator(object):
 
     .. versionadded:: 4.1
 
+    .. versionchanged:: 4.3
+       Added ``async for`` support in Python 3.5.
+
     """
     def __init__(self, *args, **kwargs):
         if args and kwargs:

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -624,11 +624,12 @@ class Multi(YieldPoint):
 def multi_future(children, quiet_exceptions=()):
     """Wait for multiple asynchronous futures in parallel.
 
-    Takes a list of ``Futures`` (but *not* other ``YieldPoints``) and returns
-    a new Future that resolves when all the other Futures are done.
-    If all the ``Futures`` succeeded, the returned Future's result is a list
-    of their results.  If any failed, the returned Future raises the exception
-    of the first one to fail.
+    Takes a list of ``Futures`` or other yieldable objects (with the
+    exception of the legacy `.YieldPoint` interfaces) and returns a
+    new Future that resolves when all the other Futures are done. If
+    all the ``Futures`` succeeded, the returned Future's result is a
+    list of their results. If any failed, the returned Future raises
+    the exception of the first one to fail.
 
     Instead of a list, the argument may also be a dictionary whose values are
     Futures, in which case a parallel dictionary is returned mapping the same
@@ -649,12 +650,16 @@ def multi_future(children, quiet_exceptions=()):
        If multiple ``Futures`` fail, any exceptions after the first (which is
        raised) will be logged. Added the ``quiet_exceptions``
        argument to suppress this logging for selected exception types.
+
+    .. versionchanged:: 4.3
+       Added support for other yieldable objects.
     """
     if isinstance(children, dict):
         keys = list(children.keys())
         children = children.values()
     else:
         keys = None
+    children = list(map(convert_yielded, children))
     assert all(is_future(i) for i in children)
     unfinished_children = set(children)
 

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -108,6 +108,11 @@ try:
 except ImportError:
     def isawaitable(x): return False
 
+try:
+    import builtins  # py3
+except ImportError:
+    import __builtin__ as builtins
+
 
 class KeyReuseError(Exception):
     pass
@@ -412,7 +417,7 @@ class WaitIterator(object):
     def __anext__(self):
         if self.done():
             # Lookup by name to silence pyflakes on older versions.
-            raise globals()['StopAsyncIteration']()
+            raise getattr(builtins, 'StopAsyncIteration')()
         return self.next()
 
 

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -338,6 +338,9 @@ class Semaphore(_TimeoutGarbageCollector):
 
             # Now the semaphore has been released.
             print("Worker %d is done" % worker_id)
+
+    .. versionchanged:: 4.3
+       Added ``async with`` support in Python 3.5.
     """
     def __init__(self, value=1):
         super(Semaphore, self).__init__()
@@ -459,6 +462,9 @@ class Lock(object):
     ...        pass
     ...
     ...    # Now the lock is released.
+
+    .. versionchanged:: 3.5
+       Added ``async with`` support in Python 3.5.
     """
     def __init__(self):
         self._block = BoundedSemaphore(value=1)

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -453,8 +453,10 @@ class Lock(object):
     ...
     ...    # Now the lock is released.
 
-    In Python 3.5, `Lock` also supports the async context manager protocol.
-    Note that in this case there is no `acquire`:
+    In Python 3.5, `Lock` also supports the async context manager
+    protocol. Note that in this case there is no `acquire`, because
+    ``async with`` includes both the ``yield`` and the ``acquire``
+    (just as it does with `threading.Lock`):
 
     >>> async def f():  # doctest: +SKIP
     ...    async with lock:
@@ -465,6 +467,7 @@ class Lock(object):
 
     .. versionchanged:: 3.5
        Added ``async with`` support in Python 3.5.
+
     """
     def __init__(self):
         self._block = BoundedSemaphore(value=1)

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -116,6 +116,9 @@ class Queue(object):
                 finally:
                     q.task_done()
 
+    .. versionchanged:: 4.3
+       Added ``async for`` support in Python 3.5.
+
     """
     def __init__(self, maxsize=0):
         if maxsize is None:

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -6,7 +6,6 @@ import functools
 import sys
 import textwrap
 import time
-import platform
 import weakref
 
 from tornado.concurrent import return_future, Future
@@ -16,7 +15,7 @@ from tornado.ioloop import IOLoop
 from tornado.log import app_log
 from tornado import stack_context
 from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
-from tornado.test.util import unittest, skipOnTravis
+from tornado.test.util import unittest, skipOnTravis, skipBefore33, skipBefore35, skipNotCPython, exec_test
 from tornado.web import Application, RequestHandler, asynchronous, HTTPError
 
 from tornado import gen
@@ -25,11 +24,6 @@ try:
     from concurrent import futures
 except ImportError:
     futures = None
-
-skipBefore33 = unittest.skipIf(sys.version_info < (3, 3), 'PEP 380 (yield from) not available')
-skipBefore35 = unittest.skipIf(sys.version_info < (3, 5), 'PEP 492 (async/await) not available')
-skipNotCPython = unittest.skipIf(platform.python_implementation() != 'CPython',
-                                 'Not CPython implementation')
 
 
 class GenEngineTest(AsyncTestCase):
@@ -694,19 +688,13 @@ class GenCoroutineTest(AsyncTestCase):
     @skipBefore33
     @gen_test
     def test_async_return(self):
-        # It is a compile-time error to return a value in a generator
-        # before Python 3.3, so we must test this with exec.
-        # Flatten the real global and local namespace into our fake globals:
-        # it's all global from the perspective of f().
-        global_namespace = dict(globals(), **locals())
-        local_namespace = {}
-        exec(textwrap.dedent("""
+        namespace = exec_test(globals(), locals(), """
         @gen.coroutine
         def f():
             yield gen.Task(self.io_loop.add_callback)
             return 42
-        """), global_namespace, local_namespace)
-        result = yield local_namespace['f']()
+        """)
+        result = yield namespace['f']()
         self.assertEqual(result, 42)
         self.finished = True
 
@@ -716,16 +704,14 @@ class GenCoroutineTest(AsyncTestCase):
         # A yield statement exists but is not executed, which means
         # this function "returns" via an exception.  This exception
         # doesn't happen before the exception handling is set up.
-        global_namespace = dict(globals(), **locals())
-        local_namespace = {}
-        exec(textwrap.dedent("""
+        namespace = exec_test(globals(), locals(), """
         @gen.coroutine
         def f():
             if True:
                 return 42
             yield gen.Task(self.io_loop.add_callback)
-        """), global_namespace, local_namespace)
-        result = yield local_namespace['f']()
+        """)
+        result = yield namespace['f']()
         self.assertEqual(result, 42)
         self.finished = True
 
@@ -735,34 +721,30 @@ class GenCoroutineTest(AsyncTestCase):
         # This test verifies that an async function can await a
         # yield-based gen.coroutine, and that a gen.coroutine
         # (the test method itself) can yield an async function.
-        global_namespace = dict(globals(), **locals())
-        local_namespace = {}
-        exec(textwrap.dedent("""
+        namespace = exec_test(globals(), locals(), """
         async def f():
             await gen.Task(self.io_loop.add_callback)
             return 42
-        """), global_namespace, local_namespace)
-        result = yield local_namespace['f']()
+        """)
+        result = yield namespace['f']()
         self.assertEqual(result, 42)
         self.finished = True
 
     @skipBefore35
     @gen_test
     def test_async_await_mixed_multi(self):
-        global_namespace = dict(globals(), **locals())
-        local_namespace = {}
-        exec(textwrap.dedent("""
+        namespace = exec_test(globals(), locals(), """
         async def f1():
             await gen.Task(self.io_loop.add_callback)
             return 42
-        """), global_namespace, local_namespace)
+        """)
 
         @gen.coroutine
         def f2():
             yield gen.Task(self.io_loop.add_callback)
             raise gen.Return(43)
 
-        results = yield [local_namespace['f1'](), f2()]
+        results = yield [namespace['f1'](), f2()]
         self.assertEqual(results, [42, 43])
         self.finished = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ envlist =
         # Basic configurations: Run the tests in both minimal installations
         # and with all optional dependencies.
         # (pypy3 doesn't have any optional deps yet)
-        {py26,py27,pypy,py32,py33,py34,pypy3},
-        {py26,py27,pypy,py32,py33,py34}-full,
+        {py26,py27,pypy,py32,py33,py34,py35,pypy3},
+        {py26,py27,pypy,py32,py33,py34,py35}-full,
 
         # Also run the tests with each possible replacement of a default
         # component.  Run each test on both python 2 and 3 where possible.
@@ -58,6 +58,7 @@ basepython =
            py32: python3.2
            py33: python3.3
            py34: python3.4
+           py35: python3.5
            pypy: pypy
            pypy3: pypy3
            py2: python2.7
@@ -72,10 +73,10 @@ deps =
      py3-unittest2: unittest2py3k
      # cpython-only deps: pycurl installs but curl_httpclient doesn't work;
      # twisted mostly works but is a bit flaky under pypy.
-     {py26,py27,py32,py33,py34}-full: pycurl
+     {py26,py27,py32,py33,py34,py35}-full: pycurl
      {py2,py3}: pycurl==7.19.3.1
      # twisted is cpython only and doesn't support py32.
-     {py26,py27,py33,py34}-full: twisted
+     {py26,py27,py33,py34,py35}-full: twisted
      {py2,py3}: twisted
      # pycares installation currently fails on py33
      # (https://github.com/pypa/pip/pull/816)
@@ -95,7 +96,7 @@ deps =
 
 setenv =
        # The extension is mandatory on cpython.
-       {py2,py26,py27,py3,py32,py33,py34}: TORNADO_EXTENSION=1
+       {py2,py26,py27,py3,py32,py33,py34,py35}: TORNADO_EXTENSION=1
        # In python 3, opening files in text mode uses a
        # system-dependent encoding by default.  Run the tests with "C"
        # (ascii) and "utf-8" locales to ensure we don't have hidden
@@ -104,7 +105,7 @@ setenv =
        lang_utf8: LANG=en_US.utf-8
        # tox's parser chokes if all the setenv entries are conditional.
        DUMMY=dummy
-       {py2,py26,py27,py3,py32,py33,py34}-no-ext: TORNADO_EXTENSION=0
+       {py2,py26,py27,py3,py32,py33,py34,py35}-no-ext: TORNADO_EXTENSION=0
 
 # All non-comment lines but the last must end in a backslash.
 # Tox filters line-by-line based on the environment name.
@@ -112,7 +113,7 @@ commands =
          python \
          # py3*: -b turns on an extra warning when calling
          # str(bytes), and -bb makes it an error.
-         {py3,py32,py33,py34,pypy3}: -bb \
+         {py3,py32,py33,py34,py35,pypy3}: -bb \
          # Python's optimized mode disables the assert statement, so
          # run the tests in this mode to ensure we haven't fallen into
          # the trap of relying on an assertion's side effects or using


### PR DESCRIPTION
`Lock` and `Semaphore` support `async with`. All of the `queues` and `WaitIterator` support `async for`. It is now possible to yield a list of awaitables, not just `Futures`.

@ajdavis 