### PR TITLE
add timed rotating mode for logging into separated files in tornado.log

### DIFF
--- a/tornado/log.py
+++ b/tornado/log.py
@@ -190,16 +190,16 @@ def enable_pretty_logging(options=None, logger=None):
         logger = logging.getLogger()
     logger.setLevel(getattr(logging, options.logging.upper()))
     if options.log_file_prefix:
-        if options.rotating_mode == 'sized':
+        if options.log_rotate_mode == 'size':
             channel = logging.handlers.RotatingFileHandler(
                 filename=options.log_file_prefix,
                 maxBytes=options.log_file_max_size,
                 backupCount=options.log_file_num_backups)
-        elif options.rotating_mode == 'timed':
+        elif options.log_rotate_mode == 'time':
             channel = logging.handlers.TimedRotatingFileHandler(
                 filename=options.log_file_prefix,
-                when=options.log_file_rotating_when,
-                interval=options.log_file_rotating_interval,
+                when=options.log_rotate_when,
+                interval=options.log_rotate_interval,
                 backupCount=options.log_file_num_backups)
         else:
             channel = logging.NullHandler()
@@ -244,13 +244,13 @@ def define_logging_options(options=None):
     options.define("log_file_num_backups", type=int, default=10,
                    help="number of log files to keep")
 
-    options.define("log_file_rotating_when", type=str, default='midnight',
+    options.define("log_rotate_when", type=str, default='midnight',
                    help=("specify the type of TimedRotatingFileHandler interval "
                          "other options:('S', 'M', 'H', 'D', 'W0'-'W6')"))
-    options.define("log_file_rotating_interval", type=int, default=1,
+    options.define("log_rotate_interval", type=int, default=1,
                    help="The interval value of timed rotating")
 
-    options.define("rotating_mode", type=str, default='sized',
-                   help="The mode of rotating files(timed or sized)")
+    options.define("log_rotate_mode", type=str, default='size',
+                   help="The mode of rotating files(time or size)")
 
     options.add_parse_callback(lambda: enable_pretty_logging(options))

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -190,19 +190,27 @@ def enable_pretty_logging(options=None, logger=None):
         logger = logging.getLogger()
     logger.setLevel(getattr(logging, options.logging.upper()))
     if options.log_file_prefix:
-        if options.log_rotate_mode == 'size':
+        rotate_mode = options.log_rotate_mode
+        if rotate_mode == 'size':
             channel = logging.handlers.RotatingFileHandler(
                 filename=options.log_file_prefix,
                 maxBytes=options.log_file_max_size,
                 backupCount=options.log_file_num_backups)
-        elif options.log_rotate_mode == 'time':
+        elif rotate_mode == 'time':
             channel = logging.handlers.TimedRotatingFileHandler(
                 filename=options.log_file_prefix,
                 when=options.log_rotate_when,
                 interval=options.log_rotate_interval,
                 backupCount=options.log_file_num_backups)
         else:
-            channel = logging.NullHandler()
+            if not isinstance(rotate_mode, str):
+                error_message = 'The type of log_rotate_mode option should be ' +\
+                                'str, not {}.'.format(str(type(rotate_mode)))
+                raise TypeError(error_message)
+            else:
+                error_message = 'The value of log_rotate_mode option should be ' +\
+                                '"size" or "time", not "{}".'.format(rotate_mode)
+                raise ValueError(error_message)
         channel.setFormatter(LogFormatter(color=False))
         logger.addHandler(channel)
 

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -203,14 +203,9 @@ def enable_pretty_logging(options=None, logger=None):
                 interval=options.log_rotate_interval,
                 backupCount=options.log_file_num_backups)
         else:
-            if not isinstance(rotate_mode, str):
-                error_message = 'The type of log_rotate_mode option should be ' +\
-                                'str, not {}.'.format(str(type(rotate_mode)))
-                raise TypeError(error_message)
-            else:
-                error_message = 'The value of log_rotate_mode option should be ' +\
-                                '"size" or "time", not "{}".'.format(rotate_mode)
-                raise ValueError(error_message)
+            error_message = 'The value of log_rotate_mode option should be ' +\
+                            '"size" or "time", not "%s".' % rotate_mode
+            raise ValueError(error_message)
         channel.setFormatter(LogFormatter(color=False))
         logger.addHandler(channel)
 

--- a/tornado/test/log_test.py
+++ b/tornado/test/log_test.py
@@ -165,25 +165,16 @@ class EnablePrettyLoggingTest(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         try:
             self.options.log_file_prefix = tmpdir + '/test_log'
-            self.options.rotating_mode = 'timed'
-            self.options.log_file_rotating_when = 'S'
-            self.options.log_file_rotating_interval = 1
+            self.options.log_rotate_mode = 'time'
             enable_pretty_logging(options=self.options, logger=self.logger)
-            self.logger.error('hello1 from TimedRotatingFileHandler')
-            time.sleep(1.01)
-            self.logger.error('hello2 from TimedRotatingFileHandler')
+            self.logger.error('hello')
+            self.logger.handlers[0].flush()
             filenames = glob.glob(tmpdir + '/test_log*')
-            self.assertEqual(2, len(filenames))
-            new_file = tmpdir + '/test_log'
-            old_file = glob.glob(tmpdir + '/test_log.*')[0]
-            with open(old_file) as f:
+            self.assertEqual(1, len(filenames))
+            with open(filenames[0]) as f:
                 self.assertRegexpMatches(
                     f.read(),
-                    r'^\[E [^]]*\] hello1 from TimedRotatingFileHandler$')
-            with open(new_file) as f:
-                self.assertRegexpMatches(
-                    f.read(),
-                    r'^\[E [^]]*\] hello2 from TimedRotatingFileHandler$')
+                    r'^\[E [^]]*\] hello$')
         finally:
             for handler in self.logger.handlers:
                 handler.flush()

--- a/tornado/test/log_test.py
+++ b/tornado/test/log_test.py
@@ -194,17 +194,6 @@ class EnablePrettyLoggingTest(unittest.TestCase):
                 handler.flush()
                 handler.close()
 
-    def test_wrong_rotate_mode_type(self):
-        try:
-            self.options.log_file_prefix = 'some_path'
-            self.options.log_rotate_mode = None
-            self.assertRaises(TypeError, enable_pretty_logging,
-                              options=self.options, logger=self.logger)
-        finally:
-            for handler in self.logger.handlers:
-                handler.flush()
-                handler.close()
-
 
 class LoggingOptionTest(unittest.TestCase):
     """Test the ability to enable and disable Tornado's logging hooks."""

--- a/tornado/test/log_test.py
+++ b/tornado/test/log_test.py
@@ -183,6 +183,28 @@ class EnablePrettyLoggingTest(unittest.TestCase):
                 os.unlink(filename)
             os.rmdir(tmpdir)
 
+    def test_wrong_rotate_mode_value(self):
+        try:
+            self.options.log_file_prefix = 'some_path'
+            self.options.log_rotate_mode = 'wrong_mode'
+            self.assertRaises(ValueError, enable_pretty_logging,
+                              options=self.options, logger=self.logger)
+        finally:
+            for handler in self.logger.handlers:
+                handler.flush()
+                handler.close()
+
+    def test_wrong_rotate_mode_type(self):
+        try:
+            self.options.log_file_prefix = 'some_path'
+            self.options.log_rotate_mode = None
+            self.assertRaises(TypeError, enable_pretty_logging,
+                              options=self.options, logger=self.logger)
+        finally:
+            for handler in self.logger.handlers:
+                handler.flush()
+                handler.close()
+
 
 class LoggingOptionTest(unittest.TestCase):
     """Test the ability to enable and disable Tornado's logging hooks."""


### PR DESCRIPTION
Sometimes we want to log messages into files that separated by times(e.g. by days) rather than by file-size.

For that, define `rotating_mode='timed'` for tornado options