### PR TITLE
Backport of custom method with payloads fix

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -408,7 +408,10 @@ def _curl_setup_request(curl, request, buffer, headers):
         raise KeyError('unknown method ' + request.method)
 
     # Handle curl's cryptic options for every individual HTTP method
-    if request.method in ("POST", "PUT"):
+    if request.method == "GET":
+        if request.body is not None:
+            raise AssertionError('Body must be empty for GET request')
+    elif request.method in ("POST", "PUT") or request.body:
         if request.body is None:
             raise AssertionError(
                 'Body must not be empty for "%s" request'
@@ -423,10 +426,8 @@ def _curl_setup_request(curl, request, buffer, headers):
             curl.setopt(pycurl.IOCTLFUNCTION, ioctl)
             curl.setopt(pycurl.POSTFIELDSIZE, len(request.body))
         else:
+            curl.setopt(pycurl.UPLOAD, True)
             curl.setopt(pycurl.INFILESIZE, len(request.body))
-    elif request.method == "GET":
-        if request.body is not None:
-            raise AssertionError('Body must be empty for GET request')
 
     if request.auth_username is not None:
         userpwd = "%s:%s" % (request.auth_username, request.auth_password or '')

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, with_statement
 
+import json
 from hashlib import md5
 
 from tornado.escape import utf8
@@ -9,6 +10,7 @@ from tornado.testing import AsyncHTTPTestCase
 from tornado.test import httpclient_test
 from tornado.test.util import unittest
 from tornado.web import Application, RequestHandler
+
 
 try:
     import pycurl

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -84,6 +84,12 @@ class ContentLength304Handler(RequestHandler):
         pass
 
 
+class PatchHandler(RequestHandler):
+    def patch(self):
+        "Return the request payload - so we can check it is being kept"
+        self.write(self.request.body)
+
+
 class AllMethodsHandler(RequestHandler):
     SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ('OTHER',)
 
@@ -109,6 +115,7 @@ class HTTPClientCommonTestCase(AsyncHTTPTestCase):
             url("/user_agent", UserAgentHandler),
             url("/304_with_content_length", ContentLength304Handler),
             url("/all_methods", AllMethodsHandler),
+            url('/patch', PatchHandler),
         ], gzip=True)
 
     def test_hello_world(self):
@@ -129,6 +136,12 @@ class HTTPClientCommonTestCase(AsyncHTTPTestCase):
         # with streaming_callback, data goes to the callback and not response.body
         self.assertEqual(chunks, [b"Hello world!"])
         self.assertFalse(response.body)
+
+    def test_patch_with_payload(self):
+        body = b"some patch data"
+        response = self.fetch("/patch", method='PATCH', body=body)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, body)
 
     def test_post(self):
         response = self.fetch("/post", method="POST",


### PR DESCRIPTION
This fixes `PATCH` method with a payload using the CURL HTTP client.
