### PR TITLE
Allow multi-line headers in CurlAsyncHTTPClient

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -454,7 +454,8 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         if header_callback is not None:
             self.io_loop.add_callback(header_callback, header_line)
         # header_line as returned by curl includes the end-of-line characters.
-        header_line = header_line.strip()
+        # whitespace at the start should be preserved to allow multi-line headers
+        header_line = header_line.rstrip()
         if header_line.startswith("HTTP/"):
             headers.clear()
             try:

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -371,6 +371,30 @@ Transfer-Encoding: chunked
                     "response=%r, value=%r, container=%r" %
                     (resp.body, value, container))
 
+    def test_multi_line_headers(self):
+        # Multi-line http headers are rare but rfc-allowed
+        # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+        sock, port = bind_unused_port()
+        with closing(sock):
+            def write_response(stream, request_data):
+                stream.write(b"""\
+HTTP/1.1 200 OK
+X-XSS-Protection: 1;
+\tmode=block
+
+""".replace(b"\n", b"\r\n"), callback=stream.close)
+
+            def accept_callback(conn, address):
+                stream = IOStream(conn, io_loop=self.io_loop)
+                stream.read_until(b"\r\n\r\n",
+                                  functools.partial(write_response, stream))
+            netutil.add_accept_handler(sock, accept_callback, self.io_loop)
+            self.http_client.fetch("http://127.0.0.1:%d/" % port, self.stop)
+            resp = self.wait()
+            resp.rethrow()
+            self.assertEqual(resp.headers['X-XSS-Protection'], b"1; mode=block")
+            self.io_loop.remove_handler(sock.fileno())
+
     def test_304_with_content_length(self):
         # According to the spec 304 responses SHOULD NOT include
         # Content-Length or other entity headers, but some servers do it

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -392,7 +392,7 @@ X-XSS-Protection: 1;
             self.http_client.fetch("http://127.0.0.1:%d/" % port, self.stop)
             resp = self.wait()
             resp.rethrow()
-            self.assertEqual(resp.headers['X-XSS-Protection'], b"1; mode=block")
+            self.assertEqual(resp.headers['X-XSS-Protection'], "1; mode=block")
             self.io_loop.remove_handler(sock.fileno())
 
     def test_304_with_content_length(self):


### PR DESCRIPTION
Hi and thanks for maintaining Tornado!

The Tornado curl client currently chokes on multi-line headers without a colon:
```
Traceback (most recent call last):
  File "tornado/curl_httpclient.py", line 468, in _curl_header_callback
    headers.parse_line(header_line)
  File "tornado/httputil.py", line 190, in parse_line
    name, value = line.split(":", 1)
ValueError: need more than 1 value to unpack
```

A sample case (apparently X-XSS-Protection is notorious for multi-line headers):
```
curl --trace /tmp/curl http://www.88gala.com/js/mage/adminhtml/sales.js
[...]
<= Recv header, 22 bytes (0x16)
0000: 58 2d 58 53 53 2d 50 72 6f 74 65 63 74 69 6f 6e X-XSS-Protection
0010: 3a 20 31 3b 20 0a                               : 1; .
<= Recv header, 13 bytes (0xd)
0000: 09 6d 6f 64 65 3d 62 6c 6f 63 6b 0d 0a          .mode=block..
```
Tornado [supports multi-line headers](https://github.com/tornadoweb/tornado/blob/1b6157dd03dbb393de5d1066a31f4810bf609686/tornado/httputil.py#L182) but the code is never run due to a `.strip()` earlier.
