### PR TITLE
use Codecov as coverage provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,10 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
 
 after_success:
-    codecov -e DEPS
+    - echo $PWD
+    - ls -al
+    - coverage xml
+    - codecov -e DEPS
 
 # This reportedly works around an issue downloading packages from pypi on
 # travis.  Consider removing this after the underlying issue is fixed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then python $TARGET --ioloop_time_monotonic; fi
     # make coverage reports for Codecov to find
-    - coverage xml
+    - if [[ $TRAVIS_PYTHON_VERSION != 2.6 && $TRAVIS_PYTHON_VERSION != nightly ]]; then coverage xml; fi
     - export TORNADO_EXTENSION=0
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
@@ -76,7 +76,7 @@ script:
 
 after_success:
     # call codecov from project root
-    - cd ../ && codecov -e DEPS
+    - if [[ $TRAVIS_PYTHON_VERSION != 2.6 && $TRAVIS_PYTHON_VERSION != nightly ]]; then cd ../ && codecov -e DEPS; fi
 
 # This reportedly works around an issue downloading packages from pypi on
 # travis.  Consider removing this after the underlying issue is fixed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ install:
     # On travis the extension should always be built
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
     - travis_retry python setup.py install
-    - travis_retry pip install coveralls
+    - travis_retry pip install codecov
 
 script:
     # Get out of the source directory before running tests to avoid PYTHONPATH
     # confusion.  This is necessary to ensure that the speedups module can
     # be found in the installation directory.
     - cd maint
-    # Copy the coveragerc down so coveralls can find it.
+    # Copy the coveragerc down so codecov can find it.
     - cp ../.coveragerc .
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
     - export TARGET="-m tornado.test.runtests"
@@ -73,7 +73,7 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
 
 after_success:
-    coveralls
+    codecov -e DEPS
 
 # This reportedly works around an issue downloading packages from pypi on
 # travis.  Consider removing this after the underlying issue is fixed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
     # confusion.  This is necessary to ensure that the speedups module can
     # be found in the installation directory.
     - cd maint
-    # Copy the coveragerc down so codecov can find it.
+    # Copy the coveragerc down so coverage.py can find it.
     - cp ../.coveragerc .
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
     - export TARGET="-m tornado.test.runtests"
@@ -67,16 +67,16 @@ script:
     #- if [[ $TRAVIS_PYTHON_VERSION != pypy* && $DEPS == true ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then python $TARGET --ioloop_time_monotonic; fi
+    # make coverage reports for Codecov to find
+    - coverage xml
     - export TORNADO_EXTENSION=0
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' && $DEPS == true ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
 
 after_success:
-    - echo $PWD
-    - ls -al
-    - coverage xml
-    - codecov -e DEPS
+    # call codecov from project root
+    - cd ../ && codecov -e DEPS
 
 # This reportedly works around an issue downloading packages from pypi on
 # travis.  Consider removing this after the underlying issue is fixed.


### PR DESCRIPTION
> Full disclosure I work for Codecov

I've been waiting to make this pull request for some time now :) Codecov's entire product is using Tornado as its http web server. I adore this project and would be proud to have it use Codecov as its coverage product.

Some of our core features include:
- Seamless overlay of coverage reports in Github with our browser extensions. [Video](https://www.youtube.com/watch?v=d6wJKODB8_g)
- Awesome pull request comments. [Example](https://gist.github.com/codecov-io/ba612976215481e7f27c)
- Github commit status integration to ensure coverage meets minimum standards
- Automatic unified builds. See [pyca/cryptography](https://codecov.io/github/pyca/cryptography) for example
- Storing build environment variables.

I look forward to your feedback! You can find the [reports for this build here](https://codecov.io/github/tornadoweb/tornado?ref=a55a17579ff887ca2ab29c47fe37151b88d122fe).

Cheers,
Steve

> **Note** Codecov coverage will be lower then `coveragepy`. We consider "partials" as a miss (coveragepy counts them as hits). We do this because when a partial becomes a hit the coverage should increase.