### PR TITLE
Fix incorrect inspection of WebSocket RSV1 bit.

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -708,7 +708,7 @@ class WebSocketProtocol13(WebSocketProtocol):
         reserved_bits = header & self.RSV_MASK
         self._frame_opcode = header & self.OPCODE_MASK
         self._frame_opcode_is_control = self._frame_opcode & 0x8
-        if self._decompressor is not None:
+        if self._decompressor is not None and self._frame_opcode != 0:
             self._frame_compressed = bool(reserved_bits & self.RSV1)
             reserved_bits &= ~self.RSV1
         if reserved_bits:


### PR DESCRIPTION
`_frame_compressed` should not be overwrite in continuation frames. According to the Protocol:
https://tools.ietf.org/html/draft-ietf-hybi-permessage-compression-13#section-8.2.3.1
"the RSV1 bit is set only on the first frame"