### PR TITLE
修复: 在python 2.7中，当使用了"from __future__ import unicode_literals "，传入中文字…

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -629,7 +629,7 @@ class _CodeWriter(object):
             ancestors = ["%s:%d" % (tmpl.name, lineno)
                          for (tmpl, lineno) in self.include_stack]
             line_comment += ' (via %s)' % ', '.join(reversed(ancestors))
-        print("    " * indent + line + line_comment, file=self.file)
+        print("    " * indent + line + escape.utf8(line_comment), file=self.file)
 
 
 class _TemplateReader(object):


### PR DESCRIPTION
…符会引发UnicodeDecodeError的问题