### PR TITLE
Add timeouts to TCPClient

### DIFF
--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -142,6 +142,8 @@ class TCPClient(object):
     """
     def __init__(self, resolver=None, io_loop=None):
         self.io_loop = io_loop or IOLoop.current()
+        self._connector_future = None
+        self._connector_streams = []
         if resolver is not None:
             self.resolver = resolver
             self._own_resolver = False
@@ -155,17 +157,22 @@ class TCPClient(object):
 
     @gen.coroutine
     def connect(self, host, port, af=socket.AF_UNSPEC, ssl_options=None,
-                max_buffer_size=None):
+                max_buffer_size=None, timeout=None):
         """Connect to the given host and port.
 
         Asynchronously returns an `.IOStream` (or `.SSLIOStream` if
         ``ssl_options`` is not None).
         """
+        self._connector_future = None
+        self._connector_streams = []
+        if timeout:
+            self.io_loop.add_timeout(timeout, self.connect_timeout)
         addrinfo = yield self.resolver.resolve(host, port, af)
         connector = _Connector(
             addrinfo, self.io_loop,
             functools.partial(self._create_stream, max_buffer_size))
-        af, addr, stream = yield connector.start()
+        self._connector_future = connector.start()
+        af, addr, stream = yield self._connector_future
         # TODO: For better performance we could cache the (af, addr)
         # information here and re-use it on subsequent connections to
         # the same host. (http://tools.ietf.org/html/rfc6555#section-4.2)
@@ -174,10 +181,22 @@ class TCPClient(object):
                                             server_hostname=host)
         raise gen.Return(stream)
 
+    def connect_timeout(self):
+        def timeout_callback(_):
+            # Close all the _Connector's streams.
+            for s in self._connector_streams:
+                s.close()
+            self._future = None
+            self._connector_streams = []
+        if self._connector_future and not self._connector_future.done():
+            self._connector_future.add_done_callback(timeout_callback)
+            self._connector_future.set_exception(IOError('connection timeout'))
+
     def _create_stream(self, max_buffer_size, af, addr):
         # Always connect in plaintext; we'll convert to ssl if necessary
         # after one connection has completed.
         stream = IOStream(socket.socket(af),
                           io_loop=self.io_loop,
                           max_buffer_size=max_buffer_size)
+        self._connector_streams.append(stream)
         return stream.connect(addr)

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -142,8 +142,8 @@ class TCPClient(object):
     """
     def __init__(self, resolver=None, io_loop=None):
         self.io_loop = io_loop or IOLoop.current()
-        self._connector_future = None
-        self._connector_streams = []
+        self._future = None
+        self._streams = []
         if resolver is not None:
             self.resolver = resolver
             self._own_resolver = False
@@ -163,34 +163,36 @@ class TCPClient(object):
         Asynchronously returns an `.IOStream` (or `.SSLIOStream` if
         ``ssl_options`` is not None).
         """
-        self._connector_future = None
-        self._connector_streams = []
+        self._future = None
+        self._streams = []
         if timeout:
             self.io_loop.add_timeout(timeout, self.connect_timeout)
-        addrinfo = yield self.resolver.resolve(host, port, af)
+        self._future = self.resolver.resolve(host, port, af)
+        addrinfo = yield self._future
         connector = _Connector(
             addrinfo, self.io_loop,
             functools.partial(self._create_stream, max_buffer_size))
-        self._connector_future = connector.start()
-        af, addr, stream = yield self._connector_future
+        self._future = connector.start()
+        af, addr, stream = yield self._future
         # TODO: For better performance we could cache the (af, addr)
         # information here and re-use it on subsequent connections to
         # the same host. (http://tools.ietf.org/html/rfc6555#section-4.2)
         if ssl_options is not None:
-            stream = yield stream.start_tls(False, ssl_options=ssl_options,
+            self._future = stream.start_tls(False, ssl_options=ssl_options,
                                             server_hostname=host)
+            stream = yield self._future
         raise gen.Return(stream)
 
     def connect_timeout(self):
         def timeout_callback(_):
             # Close all the _Connector's streams.
-            for s in self._connector_streams:
+            for s in self._streams:
                 s.close()
             self._future = None
-            self._connector_streams = []
-        if self._connector_future and not self._connector_future.done():
-            self._connector_future.add_done_callback(timeout_callback)
-            self._connector_future.set_exception(IOError('connection timeout'))
+            self._streams = []
+        if self._future and not self._future.done():
+            self._future.add_done_callback(timeout_callback)
+            self._future.set_exception(IOError('connection timeout'))
 
     def _create_stream(self, max_buffer_size, af, addr):
         # Always connect in plaintext; we'll convert to ssl if necessary
@@ -198,5 +200,5 @@ class TCPClient(object):
         stream = IOStream(socket.socket(af),
                           io_loop=self.io_loop,
                           max_buffer_size=max_buffer_size)
-        self._connector_streams.append(stream)
+        self._streams.append(stream)
         return stream.connect(addr)

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -19,12 +19,13 @@ from __future__ import absolute_import, division, print_function, with_statement
 from contextlib import closing
 import os
 import socket
+import time
 
 from tornado.concurrent import Future
 from tornado.netutil import bind_sockets, Resolver
 from tornado.tcpclient import TCPClient, _Connector
 from tornado.tcpserver import TCPServer
-from tornado.testing import AsyncTestCase, gen_test
+from tornado.testing import AsyncTestCase, gen_test, get_unused_port
 from tornado.test.util import skipIfNoIPv6, unittest, refusing_port
 
 # Fake address families for testing.  Used in place of AF_INET
@@ -124,6 +125,12 @@ class TCPClientTest(AsyncTestCase):
         self.addCleanup(cleanup_func)
         with self.assertRaises(IOError):
             yield self.client.connect('127.0.0.1', port)
+
+    @gen_test
+    def test_timeout_ipv4(self):
+        # connect to non-routable IP
+        with self.assertRaises(IOError):
+            yield self.client.connect('10.255.255', get_unused_port(), timeout=time.time() + 0.1)
 
 
 class TestConnectorSplit(unittest.TestCase):


### PR DESCRIPTION
I tried to solve the issue [Add timeouts to TCPClient](https://github.com/tornadoweb/tornado/issues/1219). 
When the timeout is trigged, it will close all the `_Connector`'s stream on each `TCPClient.connect` and raise a IOError .  