### PR TITLE
Remove synchronization in add_callback from the ioloop thread

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -909,9 +909,6 @@ class PollIOLoop(IOLoop):
         self._cancellations += 1
 
     def add_callback(self, callback, *args, **kwargs):
-        # The check doesn't need to be guarded by the callback lock,
-        # since the GIL makes all access to it atomic, and it can
-        # only ever transition to True
         if thread.get_ident() != self._thread_ident:
             # If we're not on the IOLoop's thread, we need to synchronize
             # with other threads, or waking logic will induce a race.

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -909,20 +909,32 @@ class PollIOLoop(IOLoop):
         self._cancellations += 1
 
     def add_callback(self, callback, *args, **kwargs):
-        with self._callback_lock:
-            if self._closing:
-                raise RuntimeError("IOLoop is closing")
-            list_empty = not self._callbacks
+        if thread.get_ident() != self._thread_ident:
+            with self._callback_lock:
+                if self._closing:
+                    raise RuntimeError("IOLoop is closing")
+                list_empty = not self._callbacks
+                self._callbacks.append(functools.partial(
+                    stack_context.wrap(callback), *args, **kwargs))
+                if list_empty:
+                    # If we're in the IOLoop's thread, we know it's not currently
+                    # polling.  If we're not, and we added the first callback to an
+                    # empty list, we may need to wake it up (it may wake up on its
+                    # own, but an occasional extra wake is harmless).  Waking
+                    # up a polling IOLoop is relatively expensive, so we try to
+                    # avoid it when we can.
+                    self._waker.wake()
+        else:
+            # If we're on the IOLoop's thread, we don't need the lock,
+            # since we don't need to wake anyone, just add the callback.
+            # Blindly insert into self._callbacks.
+            # This is safe because the GIL makes list.append atomic.
+            # One subtlety is that if the thread is interrupting another
+            # thread holding the _callback_lock block in IOLoop.start, 
+            # we may modify either the old or new version of self._callbacks,
+            # but either way will work.
             self._callbacks.append(functools.partial(
                 stack_context.wrap(callback), *args, **kwargs))
-            if list_empty and thread.get_ident() != self._thread_ident:
-                # If we're in the IOLoop's thread, we know it's not currently
-                # polling.  If we're not, and we added the first callback to an
-                # empty list, we may need to wake it up (it may wake up on its
-                # own, but an occasional extra wake is harmless).  Waking
-                # up a polling IOLoop is relatively expensive, so we try to
-                # avoid it when we can.
-                self._waker.wake()
 
     def add_callback_from_signal(self, callback, *args, **kwargs):
         with stack_context.NullContext():


### PR DESCRIPTION
Locking the callback_lock is unnecessary when adding callbacks from the ioloop's thread.

As it's been noted in add_callback_from_signal, the ioloop won't need to be woken up in those cases, and in fact the logic excludes calling wake from the ioloop's thread. Without such a need, the operation of adding the callback is atomic. If it interrupts a thread that is also adding a callback it cannot harmfully interfere: either exactly one unnecessary wake will be induced, which is harmless, or the wake won't happen at all, which would be correct since it's already polling.

The lock has a big performance impact on add_callback. With it, profiling shows add_callback taking around 160us per call on average from the main thread. Without the lock, that time drops to about 30us.

To implement this, thread.get_ident() is now called every time add_callback is called. It is however faster than acquiring the lock, as can be confirmed by profiling.

At least on our app, add_callback used to dominate the profiles before the change. Even though it was only 160us, it was the top function on the profile, with 16s of accumulated time on the profiling run. That dropped to considerably, to 3s, after the patch.
