### PR TITLE
netutil.bind_sockets: add `reuse_port` option to set SO_REUSEPORT

### DIFF
--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -85,12 +85,13 @@ def get_unused_port():
     return port
 
 
-def bind_unused_port():
+def bind_unused_port(reuse_port=False):
     """Binds a server socket to an available port on localhost.
 
     Returns a tuple (socket, port).
     """
-    [sock] = netutil.bind_sockets(None, 'localhost', family=socket.AF_INET)
+    [sock] = netutil.bind_sockets(None, 'localhost', family=socket.AF_INET,
+                                  reuse_port=reuse_port)
     port = sock.getsockname()[1]
     return sock, port
 


### PR DESCRIPTION
This option is `False` by default, because not all platforms support it. Also there's a workaround for old versions of Python which don't export `SO_REUSEPORT` constant even if it supports by a kernel.

Related to #1513 