### PR TITLE
Improve tornado.web.Application documentation

### DIFF
--- a/docs/guide/structure.rst
+++ b/docs/guide/structure.rst
@@ -73,8 +73,8 @@ are mapped to ``StoryHandler``.  That number is passed (as a string) to
             self.write("this is story %s" % story_id)
 
     app = Application([
-        url(r"/", MainHandler),
-        url(r"/story/([0-9]+)", StoryHandler, dict(db=db), name="story")
+        (r"/", MainHandler),
+        (r"/story/([0-9]+)", StoryHandler, dict(db=db), name="story")
         ])
 
 The `.Application` constructor takes many keyword arguments that
@@ -267,7 +267,7 @@ manner.
 static redirect::
 
     app = tornado.web.Application([
-        url(r"/app", tornado.web.RedirectHandler,
+        (r"/app", tornado.web.RedirectHandler,
             dict(url="http://itunes.apple.com/my-app-id")),
         ])
 
@@ -276,8 +276,8 @@ The following rule redirects all requests beginning with ``/pictures/``
 to the prefix ``/photos/`` instead::
 
     app = tornado.web.Application([
-        url(r"/photos/(.*)", MyPhotoHandler),
-        url(r"/pictures/(.*)", tornado.web.RedirectHandler,
+        (r"/photos/(.*)", MyPhotoHandler),
+        (r"/pictures/(.*)", tornado.web.RedirectHandler,
             dict(url=r"/photos/\1")),
         ])
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1687,7 +1687,7 @@ class Application(httputil.HTTPServerConnectionDelegate):
     (fully-qualified) name.
 
     Each tuple can contain additional elements, which correspond to the
-    arguments to the `URLSpec` constructor.  (Prior to Tornado 3.2, this
+    arguments to the `URLSpec` constructor.  (Prior to Tornado 3.2,
     only tuples of two or three elements were allowed).
 
     A dictionary may be passed as the third element of the tuple,


### PR DESCRIPTION
This removes the use of the undocumented alias `url` for `URLSpec` from the guide's `Application` examples and fixes a typo in the docstring of `tornado.web.Application`.