### PR TITLE
simple_httpclient: Don't call streaming_callback for redirects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
     # codecov tries to install the latest.
     - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'coverage<4.0'; fi
     - travis_retry pip install codecov
+    - curl-config --version; pip freeze
 
 script:
     # Get out of the source directory before running tests to avoid PYTHONPATH

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -11,7 +11,7 @@ import threading
 import datetime
 from io import BytesIO
 
-from tornado.escape import utf8, to_unicode
+from tornado.escape import utf8
 from tornado import gen
 from tornado.httpclient import HTTPRequest, HTTPResponse, _RequestProxy, HTTPError, HTTPClient
 from tornado.httpserver import HTTPServer
@@ -479,21 +479,6 @@ Transfer-Encoding: chunked
                               method="PUT", body=b"hello")
         response.rethrow()
         self.assertEqual(response.body, b"Put body: hello")
-
-    def test_streaming_follow_redirects(self):
-        # When following redirects, header and streaming callbacks
-        # should only be called for the final result.
-        headers = []
-        chunks = []
-        self.fetch("/redirect?url=/hello",
-                   header_callback=headers.append,
-                   streaming_callback=chunks.append)
-        chunks = list(map(to_unicode, chunks))
-        self.assertEqual(chunks, ['Hello world!'])
-        # Make sure we only got one set of headers.
-        num_start_lines = len([h for h in headers if h.startswith("HTTP/")])
-        self.assertEqual(num_start_lines, 1)
-
 
 
 class RequestProxyTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #1518.

cc @terminalmage