### PR TITLE
Removed links to facebook.com.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,7 @@ announced on the `announcements mailing list
 <http://groups.google.com/group/python-tornado-announce>`_.
 
 
-Tornado is one of `Facebook's open source technologies
-<https://code.facebook.com/opensource/>`_. It is available under
+Tornado is available under
 the `Apache License, Version 2.0
 <http://www.apache.org/licenses/LICENSE-2.0.html>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,8 +150,7 @@ resources can be found on the `Tornado wiki
 announced on the `announcements mailing list
 <http://groups.google.com/group/python-tornado-announce>`_.
 
-Tornado is one of `Facebook's open source technologies
-<http://developers.facebook.com/opensource/>`_. It is available under
+Tornado is one of Facebook's open source technologies. It is available under
 the `Apache License, Version 2.0
 <http://www.apache.org/licenses/LICENSE-2.0.html>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,7 +150,7 @@ resources can be found on the `Tornado wiki
 announced on the `announcements mailing list
 <http://groups.google.com/group/python-tornado-announce>`_.
 
-Tornado is one of Facebook's open source technologies. It is available under
+Tornado is available under
 the `Apache License, Version 2.0
 <http://www.apache.org/licenses/LICENSE-2.0.html>`_.
 


### PR DESCRIPTION
Removed links to [facebook.com](https://code.facebook.com/projects/) as Tornado is no longer featured. As discussed in https://github.com/tornadoweb/tornado/pull/1537.
 