### PR TITLE
Add void to empty function parameter

### DIFF
--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -41,12 +41,12 @@ static struct PyModuleDef speedupsmodule = {
 };
 
 PyMODINIT_FUNC
-PyInit_speedups() {
+PyInit_speedups(void) {
     return PyModule_Create(&speedupsmodule);
 }
 #else  // Python 2.x
 PyMODINIT_FUNC
-initspeedups() {
+initspeedups(void) {
     Py_InitModule("tornado.speedups", methods);
 }
 #endif


### PR DESCRIPTION
This fixes the gcc warning:

tornado/speedups.c:49:1: warning: function declaration isn’t a prototype
[-Wstrict-prototypes]
 initspeedups() {
 ^