### PR TITLE
Make singledispatch and backports_abc mandatory dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,11 @@ install:
     # always install unittest2 on py26 even if $DEPS is unset
     - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* && $DEPS == true ]]; then travis_retry pip install futures mock Monotime trollius; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then travis_retry pip install singledispatch; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' && $DEPS == true ]]; then travis_retry pip install futures mock singledispatch; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' && $DEPS == true ]]; then travis_retry pip install futures mock; fi
     # TODO(bdarnell): pycares tests are currently disabled on travis due to ipv6 issues.
     #- if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && $DEPS == true ]]; then travis_retry pip install pycares; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && $DEPS == true ]]; then travis_retry pip install pycurl; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' && $DEPS == true ]]; then travis_retry pip install mock singledispatch; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' && $DEPS == true ]]; then travis_retry pip install mock; fi
     # Twisted runs on 2.x and 3.3+, but is flaky on pypy.
     - if [[ $TRAVIS_PYTHON_VERSION != '3.2' && $TRAVIS_PYTHON_VERSION != 'pypy'* && $DEPS == true ]]; then travis_retry pip install Twisted; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $DEPS == true ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,9 @@ if (platform.python_implementation() == 'CPython' and
 if setuptools is not None:
     # If setuptools is not available, you're on your own for dependencies.
     install_requires = []
+    if sys.version_info < (2, 7):
+        # Only needed indirectly, for singledispatch.
+        install_requires.append('ordereddict')
     if sys.version_info < (3, 2):
         install_requires.append('backports.ssl_match_hostname')
     if sys.version_info < (3, 4):

--- a/setup.py
+++ b/setup.py
@@ -125,10 +125,13 @@ if setuptools is not None:
     if sys.version_info < (3, 2):
         install_requires.append('backports.ssl_match_hostname')
     if sys.version_info < (3, 4):
+        install_requires.append('singledispatch')
         # Certifi is also optional on 2.7.9+, although making our dependencies
         # conditional on micro version numbers seems like a bad idea
         # until we have more declarative metadata.
         install_requires.append('certifi')
+    if sys.version_info < (3, 5):
+        install_requires.append('backports_abc>=0.4')
     kwargs['install_requires'] = install_requires
 
 setup(

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -25,9 +25,6 @@ else:
     # This is used in dynamically-evaluated code, so silence pyflakes.
     to_asyncio_future
 
-skipIfNoSingleDispatch = unittest.skipIf(
-    gen.singledispatch is None, "singledispatch module not present")
-
 
 @unittest.skipIf(asyncio is None, "asyncio module not present")
 class AsyncIOLoopTest(AsyncTestCase):
@@ -41,7 +38,6 @@ class AsyncIOLoopTest(AsyncTestCase):
         asyncio.get_event_loop().call_soon(self.stop)
         self.wait()
 
-    @skipIfNoSingleDispatch
     @gen_test
     def test_asyncio_future(self):
         # Test that we can yield an asyncio future from a tornado coroutine.
@@ -51,7 +47,6 @@ class AsyncIOLoopTest(AsyncTestCase):
         self.assertEqual(x, 42)
 
     @skipBefore33
-    @skipIfNoSingleDispatch
     @gen_test
     def test_asyncio_yield_from(self):
         # Test that we can use asyncio coroutines with 'yield from'

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -72,9 +72,6 @@ from tornado.web import RequestHandler, Application
 skipIfNoTwisted = unittest.skipUnless(have_twisted,
                                       "twisted module not present")
 
-skipIfNoSingleDispatch = unittest.skipIf(
-    gen.singledispatch is None, "singledispatch module not present")
-
 
 def save_signal_handlers():
     saved = {}
@@ -495,7 +492,6 @@ class CompatibilityTests(unittest.TestCase):
             'http://127.0.0.1:%d' % self.tornado_port, self.run_reactor)
         self.assertEqual(response, 'Hello from tornado!')
 
-    @skipIfNoSingleDispatch
     def testTornadoServerTwistedCoroutineClientIOLoop(self):
         self.start_tornado_server()
         response = self.twisted_coroutine_fetch(
@@ -504,7 +500,6 @@ class CompatibilityTests(unittest.TestCase):
 
 
 @skipIfNoTwisted
-@skipIfNoSingleDispatch
 class ConvertDeferredTest(unittest.TestCase):
     def test_success(self):
         @inlineCallbacks

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -72,6 +72,9 @@ from tornado.web import RequestHandler, Application
 skipIfNoTwisted = unittest.skipUnless(have_twisted,
                                       "twisted module not present")
 
+skipIfPy26 = unittest.skipIf(sys.version_info < (2, 7),
+                             "twisted incompatible with singledispatch in py26")
+
 
 def save_signal_handlers():
     saved = {}
@@ -492,6 +495,7 @@ class CompatibilityTests(unittest.TestCase):
             'http://127.0.0.1:%d' % self.tornado_port, self.run_reactor)
         self.assertEqual(response, 'Hello from tornado!')
 
+    @skipIfPy26
     def testTornadoServerTwistedCoroutineClientIOLoop(self):
         self.start_tornado_server()
         response = self.twisted_coroutine_fetch(
@@ -500,6 +504,7 @@ class CompatibilityTests(unittest.TestCase):
 
 
 @skipIfNoTwisted
+@skipIfPy26
 class ConvertDeferredTest(unittest.TestCase):
     def test_success(self):
         @inlineCallbacks


### PR DESCRIPTION
I anticipate confusion around the differing behavior based on whether or
not these packages are installed, so it's better to just make them
mandatory (except on app engine).