### PR TITLE
Return HTTPServer in Application.listen

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1810,6 +1810,7 @@ class Application(httputil.HTTPServerConnectionDelegate):
         from tornado.httpserver import HTTPServer
         server = HTTPServer(self, **kwargs)
         server.listen(port, address)
+        return server
 
     def add_handlers(self, host_pattern, host_handlers):
         """Appends the given handlers to our handler list.


### PR DESCRIPTION
For unittesting I start and stop the server in setUp and tearDown. If I use Application.listen I don't have a reference to the HTTPServer and cannot close the socket. Binding it to the same address the next time will result in a address in use error. If the server is returned, calling close on it will allow the address/port to be reused.