### PR TITLE
Check for Content-Length and Transfer-Encoding

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -515,6 +515,12 @@ class HTTP1Connection(httputil.HTTPConnection):
 
     def _read_body(self, code, headers, delegate):
         if "Content-Length" in headers:
+            if "Transfer-Encoding" in headers:
+                # Response cannot contain both Content-Length and
+                # Transfer-Encoding headers.
+                # http://tools.ietf.org/html/rfc7230#section-3.3.3
+                raise httputil.HTTPInputError(
+                    "Response with both Transfer-Encoding and Content-Length")
             if "," in headers["Content-Length"]:
                 # Proxies sometimes cause Content-Length headers to get
                 # duplicated.  If all the values are identical then we can

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -748,6 +748,9 @@ class ChunkedWithContentLengthTest(AsyncHTTPTestCase):
 
         return Application([('/chunkwithcl', ChunkedWithContentLength)])
 
+    def get_http_client(self):
+        return SimpleAsyncHTTPClient()
+
     def test_chunked_with_content_length(self):
         # Make sure the invalid headers are detected
         with ExpectLog(gen_log, ("Malformed HTTP message from None: Response "


### PR DESCRIPTION
If an HTTP response contains both Content-Length and
Transfer-Encoding headers, flag this as an error as
per RFC 7230, Section 3.3.3#3. Also added a unit test
to validate the code.