### PR TITLE
Disable emitting server info header

### DIFF
--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import absolute_import, division, print_function, with_statement
+import tornado
 from tornado import netutil
 from tornado.escape import json_decode, json_encode, utf8, _unicode, recursive_unicode, native_str
 from tornado import gen
@@ -1089,3 +1090,19 @@ class LegacyInterfaceTest(AsyncHTTPTestCase):
         if not self.http1:
             self.skipTest("requires HTTP/1.x")
         self.assertEqual(response.body, b"Hello world")
+
+
+class ServerTokensTest(AsyncHTTPTestCase):
+
+    def get_app(self):
+        return Application([('/', HelloWorldRequestHandler)])
+
+    def test_server_tokens_enabled(self):
+        response = self.fetch('/', method='HEAD')
+        self.assertEqual(response.headers.get('Server'),
+                         'TornadoServer/%s' % tornado.version)
+
+    def test_server_tokens_disabled(self):
+        self._app.settings.update({'server_tokens': False})
+        response = self.fetch('/', method='HEAD')
+        self.assertIsNone(response.headers.get('Server'))

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -280,10 +280,11 @@ class RequestHandler(object):
     def clear(self):
         """Resets all headers and content for this response."""
         self._headers = httputil.HTTPHeaders({
-            "Server": "TornadoServer/%s" % tornado.version,
             "Content-Type": "text/html; charset=UTF-8",
             "Date": httputil.format_timestamp(time.time()),
         })
+        if self.settings.get('server_tokens', True):
+            self.add_header("Server", "TornadoServer/%s" % tornado.version)
         self.set_default_headers()
         self._write_buffer = []
         self._status_code = 200


### PR DESCRIPTION
For security measures we are required to disable all server info headers. Should come handy for others.