### PR TITLE
Fixes #1573: Grab first localhost socket when more than one localhost interface registered

### DIFF
--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -97,8 +97,8 @@ def bind_unused_port(reuse_port=False):
 
     Returns a tuple (socket, port).
     """
-    [sock] = netutil.bind_sockets(None, 'localhost', family=socket.AF_INET,
-                                  reuse_port=reuse_port)
+    sock = netutil.bind_sockets(None, '127.0.0.1', family=socket.AF_INET,
+                                  reuse_port=reuse_port)[0]
     port = sock.getsockname()[1]
     return sock, port
 


### PR DESCRIPTION
This fixes #1573.