### PR TITLE
Add monotonic as an alternative to Monotime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
     - pypy3
 
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install futures mock Monotime trollius; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install futures mock monotonic trollius; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then travis_retry pip install futures mock; fi
     # TODO(bdarnell): pycares tests are currently disabled on travis due to ipv6 issues.
     #- if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install pycares; fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,8 @@ the following optional packages may be useful:
 * `Monotime <https://pypi.python.org/pypi/Monotime>`_ adds support for
   a monotonic clock, which improves reliability in environments
   where clock adjustments are frequent.  No longer needed in Python 3.3.
+* `monotonic <https://pypi.python.org/pypi/monotonic>`_ adds support for
+  a monotonic clock. Alternative to Monotime.  No longer needed in Python 3.3.
 
 **Platforms**: Tornado should run on any Unix-like platform, although
 for the best performance and scalability only Linux (with ``epoll``)

--- a/tornado/platform/auto.py
+++ b/tornado/platform/auto.py
@@ -47,8 +47,13 @@ try:
 except ImportError:
     pass
 try:
-    from time import monotonic as monotonic_time
+    # monotonic can provide a monotonic function in versions of python before
+    # 3.3, too.
+    from monotonic import monotonic as monotonic_time
 except ImportError:
-    monotonic_time = None
+    try:
+        from time import monotonic as monotonic_time
+    except ImportError:
+        monotonic_time = None
 
 __all__ = ['Waker', 'set_close_exec', 'monotonic_time']

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
      {py2,py27,pypy,py3,py33}-full: singledispatch
      py33-asyncio: asyncio
      trollius: trollius
-     py2-monotonic: Monotime
+     py2-monotonic: monotonic
      sphinx: sphinx
      sphinx: sphinx_rtd_theme
 


### PR DESCRIPTION
The `monotonic` pypi module is better maintained and much more widely used. Let's support it as an alternative to `Monotime`.