### PR TITLE
CurlAsyncHTTPClient: free_list starvation if setup fails

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -221,6 +221,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
                         # _process_queue() is called from
                         # _finish_pending_requests the exceptions have
                         # nowhere to go.
+                        self._free_list.append(curl)
                         callback(HTTPResponse(
                             request=request,
                             code=599,

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import, division, print_function, with_statement
 
 from hashlib import md5
@@ -83,8 +84,7 @@ class CustomFailReasonHandler(RequestHandler):
 class CurlHTTPClientTestCase(AsyncHTTPTestCase):
     def setUp(self):
         super(CurlHTTPClientTestCase, self).setUp()
-        self.http_client = CurlAsyncHTTPClient(self.io_loop,
-                                               defaults=dict(allow_ipv6=False))
+        self.http_client = self.create_client()
 
     def get_app(self):
         return Application([
@@ -92,6 +92,11 @@ class CurlHTTPClientTestCase(AsyncHTTPTestCase):
             ('/custom_reason', CustomReasonHandler),
             ('/custom_fail_reason', CustomFailReasonHandler),
         ])
+
+    def create_client(self, **kwargs):
+        return CurlAsyncHTTPClient(self.io_loop, force_instance=True,
+                                   defaults=dict(allow_ipv6=False),
+                                   **kwargs)
 
     def test_prepare_curl_callback_stack_context(self):
         exc_info = []
@@ -122,3 +127,8 @@ class CurlHTTPClientTestCase(AsyncHTTPTestCase):
         response = self.fetch('/custom_fail_reason')
         self.assertEqual(str(response.error), "HTTP 400: Custom reason")
 
+    def test_failed_setup(self):
+        self.http_client = self.create_client(max_clients=1)
+        for i in range(5):
+            response = self.fetch(u'/ユニコード')
+            self.assertIsNot(response.error, None)


### PR DESCRIPTION
If `_curl_setup_request` fails, the failing curl instance would be permanently excluded from free_list,  because `_finish` will never be called. Once this has happens `max_clients` times, no future request will ever complete.

This can be seen by requesting a non-ascii URL `max_clients + 1` times.