### PR TITLE
Missing hint in documentation

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -183,8 +183,8 @@ class RequestHandler(object):
         self.initialize(**kwargs)
 
     def initialize(self):
-        """Hook for subclass initialization.
-
+        """Hook for subclass initialization. Called for each request.
+          
         A dictionary passed as the third argument of a url spec will be
         supplied as keyword arguments to initialize().
 


### PR DESCRIPTION
I did not realize that RequestHandler.initialize() is called before every single request.
For me, 'subclass initialization' suggests that this function is called only once for each subclass definition.
Seems like I am not the only one, according to [this SO question] (http://stackoverflow.com/questions/15199028/does-initialize-in-tornado-web-requesthandler-get-called-every-time-for-a-reques)