### PR TITLE
Use super() to call super "__init__()"

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -128,8 +128,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
     to accept it before the websocket connection will succeed.
     """
     def __init__(self, application, request, **kwargs):
-        tornado.web.RequestHandler.__init__(self, application, request,
-                                            **kwargs)
+        super(WebSocketHandler, self).__init__(application, request, **kwargs)
         self.ws_connection = None
         self.close_code = None
         self.close_reason = None


### PR DESCRIPTION
Calling super method by `Request.__init__(self)` cannot handle MRO properly.