### PR TITLE
Django-style kwargs for reverse_url

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -660,6 +660,7 @@ class WSGISafeWebTest(WebTestCase):
             url("/header_injection", HeaderInjectionHandler),
             url("/get_argument", GetArgumentHandler),
             url("/get_arguments", GetArgumentsHandler),
+            url("/decode_optional_kw(?:/arg1/(?P<arg1>\d+))?(?:/arg2/(?P<arg2>\w+))?$", DecodeArgHandler, name="decode_optional_kw"),
         ]
         return urls
 
@@ -732,6 +733,12 @@ class WSGISafeWebTest(WebTestCase):
                          '/decode_arg/%C3%A9')
         self.assertEqual(self.app.reverse_url('decode_arg', '1 + 1'),
                          '/decode_arg/1%20%2B%201')
+
+    def test_reverse_url_optional_kw(self):
+        self.assertEqual(self.app.reverse_url('decode_optional_kw'), '/decode_optional_kw')
+        self.assertEqual(self.app.reverse_url('decode_optional_kw', arg1=1), '/decode_optional_kw/arg1/1')
+        self.assertEqual(self.app.reverse_url('decode_optional_kw', arg1=1, arg2='a'), '/decode_optional_kw/arg1/1/arg2/a')
+        self.assertEqual(self.app.reverse_url('decode_optional_kw', arg2='a'), '/decode_optional_kw/arg2/a')
 
     def test_uimodule_unescaped(self):
         response = self.fetch("/linkify")

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -12,7 +12,7 @@ from tornado.template import DictLoader
 from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
 from tornado.test.util import unittest, skipBefore35, exec_test
 from tornado.util import ObjectDict, unicode_type, timedelta_to_seconds
-from tornado.web import RequestHandler, authenticated, Application, asynchronous, url, HTTPError, StaticFileHandler, _create_signature_v1, create_signed_value, decode_signed_value, ErrorHandler, UIModule, MissingArgumentError, stream_request_body, Finish, removeslash, addslash, RedirectHandler as WebRedirectHandler, get_signature_key_version, GZipContentEncoding
+from tornado.web import RequestHandler, authenticated, Application, asynchronous, url, HTTPError, StaticFileHandler, _create_signature_v1, create_signed_value, decode_signed_value, ErrorHandler, UIModule, MissingArgumentError, stream_request_body, Finish, removeslash, addslash, RedirectHandler as WebRedirectHandler, get_signature_key_version, GZipContentEncoding, NoReverseMatch
 
 import binascii
 import contextlib
@@ -648,7 +648,7 @@ class WSGISafeWebTest(WebTestCase):
         urls = [
             url("/typecheck/(.*)", TypeCheckHandler, name='typecheck'),
             url("/decode_arg/(.*)", DecodeArgHandler, name='decode_arg'),
-            url("/decode_arg_kw/(?P<arg>.*)", DecodeArgHandler),
+            url("/decode_arg_kw/(?P<arg>.*)", DecodeArgHandler, name="decode_arg_kw"),
             url("/linkify", LinkifyHandler),
             url("/uimodule_resources", UIModuleResourceHandler),
             url("/optional_path/(.+)?", OptionalPathHandler),
@@ -739,6 +739,8 @@ class WSGISafeWebTest(WebTestCase):
         self.assertEqual(self.app.reverse_url('decode_optional_kw', arg1=1), '/decode_optional_kw/arg1/1')
         self.assertEqual(self.app.reverse_url('decode_optional_kw', arg1=1, arg2='a'), '/decode_optional_kw/arg1/1/arg2/a')
         self.assertEqual(self.app.reverse_url('decode_optional_kw', arg2='a'), '/decode_optional_kw/arg2/a')
+        with self.assertRaises(NoReverseMatch):
+            self.app.reverse_url('decode_arg_kw', not_an_argname='a')
 
     def test_uimodule_unescaped(self):
         response = self.fetch("/linkify")

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -3023,7 +3023,7 @@ class URLSpec(object):
                 s = str(s)
             return tornado.escape.url_escape(tornado.escape.utf8(s), plus=False)
 
-        kwargs = dict((_escape(k), _escape(v)) for k, v in kwargs.iteritems())
+        kwargs = dict((_escape(k), _escape(v)) for k, v in kwargs.items())
 
         for path, expected_args in self._path:
             if all(key in expected_args for key in kwargs):
@@ -3031,7 +3031,7 @@ class URLSpec(object):
         if args: 
             str_args = [str(x) for x in args]
         else:
-            str_args = ['{}={}'.format(k, v) for k, v in kwargs.iteritems()]
+            str_args = ['{}={}'.format(k, v) for k, v in kwargs.items()]
         raise NoReverseMatch('No reverse match for pattern "{}" with arguments {}'.format(
             self.regex.pattern, ', '.join(str_args)))
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -3005,7 +3005,7 @@ class URLSpec(object):
              self.handler_class, self.kwargs, self.name)
 
     def _find_groups(self):
-        paths = django.utils.regex_helper.normalize(tornado.escape.utf8(self.regex.pattern)) 
+        paths = django.utils.regex_helper.normalize(self.regex.pattern) 
         lengths = [len(x[1]) for x in paths]
         return paths, lengths
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -92,6 +92,10 @@ from tornado.escape import utf8, _unicode
 from tornado.util import (import_object, ObjectDict, raise_exc_info,
                           unicode_type, _websocket_mask)
 from tornado.httputil import split_host_and_port
+import django.utils.regex_helper
+
+class NoReverseMatch(Exception):
+    pass
 
 
 try:
@@ -1325,9 +1329,9 @@ class RequestHandler(object):
             raise Exception("You must define the '%s' setting in your "
                             "application to use %s" % (name, feature))
 
-    def reverse_url(self, name, *args):
+    def reverse_url(self, name, *args, **kwargs):
         """Alias for `Application.reverse_url`."""
-        return self.application.reverse_url(name, *args)
+        return self.application.reverse_url(name, *args, **kwargs)
 
     def compute_etag(self):
         """Computes the etag header to be used for this request.
@@ -1911,7 +1915,7 @@ class Application(httputil.HTTPServerConnectionDelegate):
         dispatcher.set_request(request)
         return dispatcher.execute()
 
-    def reverse_url(self, name, *args):
+    def reverse_url(self, name, *args, **kwargs):
         """Returns a URL path for handler named ``name``
 
         The handler must be added to the application as a named `URLSpec`.
@@ -1921,7 +1925,7 @@ class Application(httputil.HTTPServerConnectionDelegate):
         and url-escaped.
         """
         if name in self.named_handlers:
-            return self.named_handlers[name].reverse(*args)
+            return self.named_handlers[name].reverse(*args, **kwargs)
         raise KeyError("%s not found in named urls" % name)
 
     def log_request(self, handler):
@@ -3001,46 +3005,35 @@ class URLSpec(object):
              self.handler_class, self.kwargs, self.name)
 
     def _find_groups(self):
-        """Returns a tuple (reverse string, group count) for a url.
+        paths = django.utils.regex_helper.normalize(tornado.escape.utf8(self.regex.pattern)) 
+        lengths = [len(x[1]) for x in paths]
+        return paths, lengths
 
-        For example: Given the url pattern /([0-9]{4})/([a-z-]+)/, this method
-        would return ('/%s/%s/', 2).
-        """
-        pattern = self.regex.pattern
-        if pattern.startswith('^'):
-            pattern = pattern[1:]
-        if pattern.endswith('$'):
-            pattern = pattern[:-1]
+    def reverse(self, *args, **kwargs):
+        if args and kwargs:
+            raise ValueError("Don't mix *args and **kwargs in call to reverse!")
 
-        if self.regex.groups != pattern.count('('):
-            # The pattern is too complicated for our simplistic matching,
-            # so we can't support reversing it.
-            return (None, None)
+        #convert args to kwargs 
+        if args: 
+            kwargs = dict(('_{}'.format(k), v) for k, v in zip(range(len(args)), args))
 
-        pieces = []
-        for fragment in pattern.split('('):
-            if ')' in fragment:
-                paren_loc = fragment.index(')')
-                if paren_loc >= 0:
-                    pieces.append('%s' + fragment[paren_loc + 1:])
-            else:
-                pieces.append(fragment)
+        #escape everything
+        def _escape(s):
+            if not isinstance(s, (unicode_type, bytes)):
+                s = str(s)
+            return tornado.escape.url_escape(tornado.escape.utf8(s), plus=False)
 
-        return (''.join(pieces), self.regex.groups)
+        kwargs = dict((_escape(k), _escape(v)) for k, v in kwargs.iteritems())
 
-    def reverse(self, *args):
-        assert self._path is not None, \
-            "Cannot reverse url regex " + self.regex.pattern
-        assert len(args) == self._group_count, "required number of arguments "\
-            "not found"
-        if not len(args):
-            return self._path
-        converted_args = []
-        for a in args:
-            if not isinstance(a, (unicode_type, bytes)):
-                a = str(a)
-            converted_args.append(escape.url_escape(utf8(a), plus=False))
-        return self._path % tuple(converted_args)
+        for path, expected_args in self._path:
+            if all(key in expected_args for key in kwargs):
+                return str(path % kwargs)
+        if args: 
+            str_args = [str(x) for x in args]
+        else:
+            str_args = ['{}={}'.format(k, v) for k, v in kwargs.iteritems()]
+        raise NoReverseMatch('No reverse match for pattern "{}" with arguments {}'.format(
+            self.regex.pattern, ', '.join(str_args)))
 
 url = URLSpec
 


### PR DESCRIPTION
This adds Django-style url kwargs for Application.reverse_url without breaking the current args-only API. URLSpec.find_groups has been changed to a shameless theft of the core Django function that powers their url reverse functionality: django.utils.regex_helper.normalize. 

Example:

```
>>> import tornado.web
>>> optional_kwarg_scheme = r'so-many-possibilities(?:/kwarg1/(?P<kwarg1>\d+))?(?:/kwarg2/(?P<kwarg2>\w+))?$'
>>> u = tornado.web.URLSpec(optional_kwarg_scheme, None, 'options')
>>> u.reverse()
'so-many-possibilities'
>>> u.reverse(kwarg1=1)
'so-many-possibilities/kwarg1/1'
>>> u.reverse(kwarg2='a')
'so-many-possibilities/kwarg2/a'
>>> u.reverse(kwarg1=1, kwarg2='a')
'so-many-possibilities/kwarg1/1/kwarg2/a'
```

Notes: 
- Like the one this replaces, reverse does no checking that the kwargs (or args) match the regex scheme, other than that the kwarg keys must matched the named groups, so you could do this: 

```
>>> u.reverse(kwarg1='a')
'so-many-possibilities/kwarg1/a'
```

which creates a bad url. If desired, URLSpec.reverse could be changed to check the final result is a match to self.regex.
- I noticed that this had come up a few years ago, and it seems like some kw functionality was added, but I've found this to be quite helpful in django url routing. 
