### PR TITLE
make kwargs always work in AsyncHTTPClient.fetch()

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -227,6 +227,13 @@ class AsyncHTTPClient(Configurable):
             raise RuntimeError("fetch() called on closed AsyncHTTPClient")
         if not isinstance(request, HTTPRequest):
             request = HTTPRequest(url=request, **kwargs)
+        else:
+            for k, v in kwargs.items():
+                try:
+                    getattr(request, k)
+                except Exception as e:
+                    raise ValueError('HTTPRequest get an unexcept kwags %s' % k)
+                setattr(request, k, v)
         # We may modify this (to add Host, Accept-Encoding, etc),
         # so make sure we don't modify the caller's object.  This is also
         # where normal dicts get converted to HTTPHeaders objects.

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -228,12 +228,8 @@ class AsyncHTTPClient(Configurable):
         if not isinstance(request, HTTPRequest):
             request = HTTPRequest(url=request, **kwargs)
         else:
-            for k, v in kwargs.items():
-                try:
-                    getattr(request, k)
-                except Exception as e:
-                    raise ValueError('HTTPRequest get an unexcept kwags %s' % k)
-                setattr(request, k, v)
+            if kwargs:
+                raise ValueError("kwargs can't be used if request is an HTTPRequest object")
         # We may modify this (to add Host, Accept-Encoding, etc),
         # so make sure we don't modify the caller's object.  This is also
         # where normal dicts get converted to HTTPHeaders objects.


### PR DESCRIPTION
If request is HTTPRequest, then any kwargs in [fetch](https://github.com/tornadoweb/tornado/blob/master/tornado/httpclient.py#L206) won't work. And there is no warning or error happen.

Now we can do something like:

        req = httpclient.HTTPRequest(url, method="POST", body=data)
        response = httpclient.fetch(req, request_timeout=20)

I think it is a better fetch.