### PR TITLE
Update web.py

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1327,7 +1327,7 @@ class RequestHandler(object):
 
     def reverse_url(self, name, *args):
         """Alias for `Application.reverse_url`."""
-        return self.application.reverse_url(name, *args)
+        return self.application.reverse_url(name.replace("\\", r"\\"), *args)
 
     def compute_etag(self):
         """Computes the etag header to be used for this request.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1327,7 +1327,7 @@ class RequestHandler(object):
 
     def reverse_url(self, name, *args):
         """Alias for `Application.reverse_url`."""
-        return self.application.reverse_url(name, *args).replace("\\", r"\\")
+        return self.application.reverse_url(re.escape(name), *args)
 
     def compute_etag(self):
         """Computes the etag header to be used for this request.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1327,7 +1327,7 @@ class RequestHandler(object):
 
     def reverse_url(self, name, *args):
         """Alias for `Application.reverse_url`."""
-        return self.application.reverse_url(name.replace("\\", r"\\"), *args)
+        return self.application.reverse_url(name, *args).replace("\\", r"\\")
 
     def compute_etag(self):
         """Computes the etag header to be used for this request.


### PR DESCRIPTION
Issue #1609 reverse_url should unescape regex string
Fixed reverse_url by escaping backslashes in string 