### PR TITLE
Add support for static extensionless files.

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1245,6 +1245,25 @@ class StaticDefaultFilenameTest(WebTestCase):
 
 
 @wsgi_safe
+class StaticDefaultExtensionTest(WebTestCase):
+    def get_app_kwargs(self):
+        return dict(static_path=relpath('static'),
+                    static_handler_args=dict(default_extension='.html'))
+
+    def get_handlers(self):
+        return []
+
+    def test_static_default_extension(self):
+        response = self.fetch('/static/dir/index', follow_redirects=False)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(b'this is the index\n', response.body)
+
+    def test_static_default_extension_404(self):
+        response = self.fetch('/static/dir/missing', follow_redirects=False)
+        self.assertEqual(response.code, 404)
+
+
+@wsgi_safe
 class StaticFileWithPathTest(WebTestCase):
     def get_app_kwargs(self):
         return dict(static_path=relpath('static'),


### PR DESCRIPTION
Provides support for serving files without their extension. The requested URL `/path/to/file` will serve the file `/path/to/file.html`.  The feature is off by default (when `default_extension` is set to `None`), and is activated when `default_extension` is set to an extension (i.e. `".html"`).

Emulates the behavior of Jekyll's [Extensionless Permalinks][1]:

> Jekyll supports permalinks that contain neither a trailing slash nor a file extension, but this requires additional support from the web server to properly serve. When using extensionless permalinks, output files written to disk will still have the proper file extension (typically `.html`), so the web server must be able to map requests without file extensions to these files.

> Both [GitHub Pages](http://jekyllrb.com/docs/github-pages/) and the Jekyll’s built-in WEBrick server handle these requests properly without any additional work.

The Jekyll docs continue by demonstrating how to configure Apache and Nginx to behave the same way. This would be a useful feature to use in development servers for Python based static site generators (Jekyll clones/competitors).

[1]: http://jekyllrb.com/docs/permalinks/#extensionless-permalinks