### PR TITLE
[fea] Ability to inheritance the "execute" method

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2631,6 +2631,46 @@ class FinishExceptionTest(SimpleHandlerTestCase):
             self.assertEqual(b'authentication required', response.body)
 
 
+class HandleMethodResultTest(SimpleHandlerTestCase):
+    class SyncHandler(RequestHandler):
+        RESPONSE = repr(os.urandom(8))
+
+        @gen.coroutine
+        def execute(self, method, *args, **kwargs):
+            result = yield gen.maybe_future(method(*args, **kwargs))
+            self.write(result)
+
+        def get(self):
+            return self.RESPONSE
+
+    class AsyncHandler(RequestHandler):
+        RESPONSE = repr(os.urandom(8))
+
+        @gen.coroutine
+        def execute(self, method, *args, **kwargs):
+            result = yield gen.maybe_future(method(*args, **kwargs))
+            self.write(result)
+
+        @gen.coroutine
+        def get(self):
+            yield gen.sleep(0.1)
+            raise gen.Return(self.RESPONSE)
+
+    def get_handlers(self):
+        return (
+            ('/sync', self.SyncHandler),
+            ('/async', self.AsyncHandler),
+        )
+
+    def test_method_result_sync(self):
+        response = self.fetch('/sync')
+        self.assertEqual(response.body.decode('utf-8'), self.SyncHandler.RESPONSE)
+
+    def test_method_result_async(self):
+        response = self.fetch('/async')
+        self.assertEqual(response.body.decode('utf-8'), self.AsyncHandler.RESPONSE)
+
+
 @wsgi_safe
 class DecoratorTest(WebTestCase):
     def get_handlers(self):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1403,6 +1403,18 @@ class RequestHandler(object):
             self._handle_request_exception(value)
         return True
 
+    def execute(self, method, *args, **kwargs):
+        """The method is called before the end of the request handler.
+
+        You can inherit this method for if you want custom behavior::
+
+            @gen.coroutine
+            def execute(self, method, *args, **kwargs):
+                self.finish((yield gen.maybe_future(method(*args, **kwargs)))
+
+        """
+        return method(*args, **kwargs)
+
     @gen.coroutine
     def _execute(self, transforms, *args, **kwargs):
         """Executes this request with the given output transforms."""
@@ -1440,7 +1452,7 @@ class RequestHandler(object):
                     return
 
             method = getattr(self, self.request.method.lower())
-            result = method(*self.path_args, **self.path_kwargs)
+            result = self.execute(method, *self.path_args, **self.path_kwargs)
             if result is not None:
                 result = yield result
             if self._auto_finish and not self._finished:


### PR DESCRIPTION
Ability to inheritance the "execute" method. e.g:

```
class Handler(RequestHandler):
    def execute(self, method, *args, **kwargs):
        self.finish(method(*args, **kwargs))

    def get(self):
        return "Ok"

class HandlerAsync(RequestHandler):
    @gen.coroutine
    def execute(self, method, *args, **kwargs):
        self.finish((yield gen.maybe_future(method(*args, **kwargs))))

    @gen.coroutine
    def get(self):
        yield gen.sleep(1)
        raise gen.Return("Ok")
```
