### PR TITLE
Add a test for HTTPError.__str__ when it uses httputils.

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1476,6 +1476,8 @@ class RaiseWithReasonTest(SimpleHandlerTestCase):
     def test_httperror_str(self):
         self.assertEqual(str(HTTPError(682, reason="Foo")), "HTTP 682: Foo")
 
+    def test_httperror_str_from_httputil(self):
+        self.assertEqual(str(HTTPError(682)), "HTTP 682: Unknown")
 
 @wsgi_safe
 class ErrorHandlerXSRFTest(WebTestCase):


### PR DESCRIPTION
There is a gap in `RaiseWithReasonTest` test case. This PR adds a test method that calls `__str__` function from an instance of `HTTPError` class, without `reason` args. It should use `tornado.httputils` to define this HTTP status description or return "Unknown".