### PR TITLE
Verifying Facebook Graph API Calls

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -998,7 +998,7 @@ class FacebookGraphMixin(OAuth2Mixin):
             access_token=session["access_token"],
             appsecret_proof=hmac.new(key=client_secret.encode('utf8'),
                 msg=session["access_token"].encode('utf8'),
-                digestmod=hashlib.sha256).hexdigest()
+                digestmod=hashlib.sha256).hexdigest(),
             fields=",".join(fields)
         )
 

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -996,6 +996,9 @@ class FacebookGraphMixin(OAuth2Mixin):
             callback=functools.partial(
                 self._on_get_user_info, future, session, fields),
             access_token=session["access_token"],
+            appsecret_proof=hmac.new(key=client_secret.encode('utf8'),
+                msg=session["access_token"].encode('utf8'),
+                digestmod=hashlib.sha256).hexdigest()
             fields=",".join(fields)
         )
 


### PR DESCRIPTION
Verification with appsecret_proof can be used: See https://developers.facebook.com/docs/graph-api/securing-requests