### PR TITLE
Update concurrent.py for proper callbacks processing in class Future, method _set_done()

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -323,7 +323,7 @@ class Future(object):
             except Exception:
                 app_log.exception('Exception in callback %r for %r',
                                   cb, self)
-        self._callbacks = None
+        self._callbacks = []
 
     # On Python 3.3 or older, objects with a destructor part of a reference
     # cycle are never destroyed. It's no longer the case on Python 3.4 thanks to


### PR DESCRIPTION
In method **__init__()** , class **Future** set **self._callbacks = []** indicates that there are no callbacks. Whereas in method **_set_done()** set **self._callbacks = None** (after calling of all callbacks) may cause exception in case of reuse of **Future** instance.
