### PR TITLE
Make StaticFileHandler HEAD requests a coroutine

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2252,8 +2252,9 @@ class StaticFileHandler(RequestHandler):
         with cls._lock:
             cls._static_hashes = {}
 
+    @gen.coroutine
     def head(self, path):
-        return self.get(path, include_body=False)
+        yield self.get(path, include_body=False)
 
     @gen.coroutine
     def get(self, path, include_body=True):


### PR DESCRIPTION
Since HEAD calls GET, and GET is a coroutine, we need HEAD to be a coroutine as well.