### PR TITLE
Add method to define additional HTTP headers for websocket handshake response

### DIFF
--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -29,7 +29,6 @@
    .. automethod:: WebSocketHandler.check_origin
    .. automethod:: WebSocketHandler.get_compression_options
    .. automethod:: WebSocketHandler.set_nodelay
-   .. automethod:: WebSocketHandler.get_handshake_response_headers
 
    Other
    -----

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -29,6 +29,7 @@
    .. automethod:: WebSocketHandler.check_origin
    .. automethod:: WebSocketHandler.get_compression_options
    .. automethod:: WebSocketHandler.set_nodelay
+   .. automethod:: WebSocketHandler.get_handshake_response_headers
 
    Other
    -----

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -94,7 +94,7 @@ class PathArgsHandler(TestWebSocketHandler):
 
 class HandshakeResponseHeadersHandler(TestWebSocketHandler):
 
-    def set_default_headers(self):
+    def prepare(self):
         self._headers['Set-Cookie'] = 'hello=1'
 
 

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -92,6 +92,11 @@ class PathArgsHandler(TestWebSocketHandler):
         self.write_message(arg)
 
 
+class HandshakeResponseHeadersHandler(TestWebSocketHandler):
+    def get_handshake_response_headers(self):
+        return [('Set-Cookie', 'hello=1')]
+
+
 class WebSocketBaseTestCase(AsyncHTTPTestCase):
     @gen.coroutine
     def ws_connect(self, path, compression_options=None):
@@ -125,6 +130,8 @@ class WebSocketTest(WebSocketBaseTestCase):
             ('/async_prepare', AsyncPrepareHandler,
              dict(close_future=self.close_future)),
             ('/path_args/(.*)', PathArgsHandler,
+             dict(close_future=self.close_future)),
+            ('/handshake_response_headers', HandshakeResponseHeadersHandler,
              dict(close_future=self.close_future)),
         ])
 
@@ -328,6 +335,13 @@ class WebSocketTest(WebSocketBaseTestCase):
                                     io_loop=self.io_loop)
 
         self.assertEqual(cm.exception.code, 403)
+
+    @gen_test
+    def test_handshake_response_headers(self):
+        ws = yield self.ws_connect('/handshake_response_headers')
+
+        self.assertEqual(ws.headers.get('Set-Cookie'), 'hello=1')
+
 
 
 class CompressionTestMixin(object):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -93,8 +93,9 @@ class PathArgsHandler(TestWebSocketHandler):
 
 
 class HandshakeResponseHeadersHandler(TestWebSocketHandler):
-    def get_handshake_response_headers(self):
-        return [('Set-Cookie', 'hello=1')]
+
+    def set_default_headers(self):
+        self._headers['Set-Cookie'] = 'hello=1'
 
 
 class WebSocketBaseTestCase(AsyncHTTPTestCase):


### PR DESCRIPTION
According  to websocket protocol RFC 6455 - "Additional header fields may also be present, such as cookies..." for both client and server handshakes.
This PR adds a method for defining custom headers for server handshake response.
In particular this can be useful for setting cookie through websocket handshake.
