### PR TITLE
Custom encoder for JSON

### DIFF
--- a/docs/web.rst
+++ b/docs/web.rst
@@ -190,7 +190,7 @@
            and/or dicts.  See :ref:`ui-modules` for more details.
          * ``json_custom_encoder``: May be set to a function with a
            single argument, which returns a textual format for a type
-           not supported by `json_encode` by default. It will be passed to
+           not supported by ``json_encode`` by default. It will be passed to
            that method when `RequestHandler.write` is called with a dict
            as the only argument.
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -188,6 +188,11 @@
            of `UIModule` or UI methods to be made available to templates.
            May be set to a module, dictionary, or a list of modules
            and/or dicts.  See :ref:`ui-modules` for more details.
+         * ``json_custom_encoder``: May be set to a function with a
+           single argument, which returns a textual format for a type
+           not supported by `json_encode` by default. It will be passed to
+           that method when `RequestHandler.write` is called with a dict
+           as the only argument.
 
          Authentication and security settings:
 

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -74,7 +74,7 @@ def xhtml_unescape(value):
 def json_encode(value, custom=None):
     """JSON-encodes the given Python object.
 
-    Optionally accepts a `custom` argument which is a callable with one argument,
+    Optionally accepts a ``custom`` argument which is a callable with one argument,
     returning a string representation of any values not supported by default.
     """
     # JSON permits but does not require forward slashes to be escaped.
@@ -86,13 +86,9 @@ def json_encode(value, custom=None):
     return json.dumps(value, default=custom).replace("</", "<\\/")
 
 
-def json_decode(value, cls=None):
-    """Returns Python objects for the given JSON string.
-
-    Optionally accepts a `cls` argument which can be a JSONDecoder subclass instance,
-    customising the behaviour of data types not supported by json.dumps by default.
-    """
-    return json.loads(to_basestring(value), cls=cls)
+def json_decode(value):
+    """Returns Python objects for the given JSON string."""
+    return json.loads(to_basestring(value))
 
 
 def squeeze(value):

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -71,20 +71,28 @@ def xhtml_unescape(value):
 # The fact that json_encode wraps json.dumps is an implementation detail.
 # Please see https://github.com/tornadoweb/tornado/pull/706
 # before sending a pull request that adds **kwargs to this function.
-def json_encode(value):
-    """JSON-encodes the given Python object."""
+def json_encode(value, custom=None):
+    """JSON-encodes the given Python object.
+
+    Optionally accepts a `custom` argument which is a callable with one argument,
+    returning a string representation of any values not supported by default.
+    """
     # JSON permits but does not require forward slashes to be escaped.
     # This is useful when json data is emitted in a <script> tag
     # in HTML, as it prevents </script> tags from prematurely terminating
     # the javascript.  Some json libraries do this escaping by default,
     # although python's standard library does not, so we do it here.
     # http://stackoverflow.com/questions/1580647/json-why-are-forward-slashes-escaped
-    return json.dumps(value).replace("</", "<\\/")
+    return json.dumps(value, default=custom).replace("</", "<\\/")
 
 
-def json_decode(value):
-    """Returns Python objects for the given JSON string."""
-    return json.loads(to_basestring(value))
+def json_decode(value, cls=None):
+    """Returns Python objects for the given JSON string.
+
+    Optionally accepts a `cls` argument which can be a JSONDecoder subclass instance,
+    customising the behaviour of data types not supported by json.dumps by default.
+    """
+    return json.loads(to_basestring(value), cls=cls)
 
 
 def squeeze(value):

--- a/tornado/test/escape_test.py
+++ b/tornado/test/escape_test.py
@@ -2,6 +2,9 @@
 
 
 from __future__ import absolute_import, division, print_function, with_statement
+import json
+from datetime import datetime, date
+
 import tornado.escape
 
 from tornado.escape import utf8, xhtml_escape, xhtml_unescape, url_escape, url_unescape, to_unicode, json_decode, json_encode, squeeze, recursive_unicode
@@ -228,6 +231,14 @@ class EscapeTestCase(unittest.TestCase):
         if bytes is str:
             self.assertEqual(json_decode(json_encode(utf8(u"\u00e9"))), u"\u00e9")
             self.assertRaises(UnicodeDecodeError, json_encode, b"\xe9")
+
+    def test_json_encode_custom_encoder(self):
+        def custom_encoder(obj):
+            if isinstance(obj, (datetime, date)):
+                return str(obj.strftime('%Y-%m-%d'))
+            return str(obj)
+        payload = datetime(2008, 5, 5, 11, 30)
+        self.assertEqual(json_encode(payload, custom_encoder), u'"2008-05-05"')
 
     def test_squeeze(self):
         self.assertEqual(squeeze(u'sequences     of    whitespace   chars'), u'sequences of whitespace chars')

--- a/tornado/test/escape_test.py
+++ b/tornado/test/escape_test.py
@@ -233,10 +233,6 @@ class EscapeTestCase(unittest.TestCase):
             self.assertRaises(UnicodeDecodeError, json_encode, b"\xe9")
 
     def test_json_encode_custom_encoder(self):
-        def custom_encoder(obj):
-            if isinstance(obj, (datetime, date)):
-                return str(obj.strftime('%Y-%m-%d'))
-            return str(obj)
         payload = datetime(2008, 5, 5, 11, 30)
         self.assertEqual(json_encode(payload, custom_encoder), u'"2008-05-05"')
 
@@ -254,3 +250,11 @@ class EscapeTestCase(unittest.TestCase):
         self.assertEqual(recursive_unicode(tests['list']), [u"foo", u"bar"])
         self.assertEqual(recursive_unicode(tests['tuple']), (u"foo", u"bar"))
         self.assertEqual(recursive_unicode(tests['bytes']), u"foo")
+
+
+# helpers
+
+def custom_encoder(obj):
+    if isinstance(obj, (datetime, date)):
+        return str(obj.strftime('%Y-%m-%d'))
+    return str(obj)

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -11,6 +11,7 @@ from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from tornado.template import DictLoader
 from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
 from tornado.test.util import unittest, skipBefore35, exec_test
+from tornado.test.escape_test import custom_encoder
 from tornado.util import ObjectDict, unicode_type, timedelta_to_seconds, PY3
 from tornado.web import RequestHandler, authenticated, Application, asynchronous, url, HTTPError, StaticFileHandler, _create_signature_v1, create_signed_value, decode_signed_value, ErrorHandler, UIModule, MissingArgumentError, stream_request_body, Finish, removeslash, addslash, RedirectHandler as WebRedirectHandler, get_signature_key_version, GZipContentEncoding
 
@@ -2019,6 +2020,26 @@ class HandlerByNameTest(WebTestCase):
         self.assertEqual(resp.body, b'hello')
         resp = self.fetch('/hello3')
         self.assertEqual(resp.body, b'hello')
+
+
+class CustomEncoderHandler(RequestHandler):
+    def get(self):
+        value = datetime.datetime(2008, 5, 5)
+        self.write({'datetime': value})
+
+
+@wsgi_safe
+class CustomEncoderTest(WebTestCase):
+
+    def get_app_kwargs(self):
+        return {"json_custom_encoder": custom_encoder}
+
+    def get_handlers(self):
+        return [('/custom_encoder', CustomEncoderHandler)]
+
+    def test_handler_by_name(self):
+        resp = self.fetch('/custom_encoder')
+        self.assertEqual(resp.body, '{"datetime": "2008-05-05"}')
 
 
 class StreamingRequestBodyTest(WebTestCase):

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2039,7 +2039,7 @@ class CustomEncoderTest(WebTestCase):
 
     def test_handler_by_name(self):
         resp = self.fetch('/custom_encoder')
-        self.assertEqual(resp.body, '{"datetime": "2008-05-05"}')
+        self.assertEqual(json_decode(resp.body), {"datetime": "2008-05-05"})
 
 
 class StreamingRequestBodyTest(WebTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -707,7 +707,7 @@ class RequestHandler(object):
                 message += ". Lists not accepted for security reasons; see http://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write"
             raise TypeError(message)
         if isinstance(chunk, dict):
-            chunk = escape.json_encode(chunk)
+            chunk = escape.json_encode(chunk, self.settings.get('json_custom_encoder'))
             self.set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = utf8(chunk)
         self._write_buffer.append(chunk)


### PR DESCRIPTION
I've been needing the functionality to set a custom encoder for dates, both on the `json.escape.json_encode` function as well as on the `Application.write` when a dict is passed. This should handle both cases.