### PR TITLE
fix `replace_callback` argument that is not used

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -242,7 +242,7 @@ def coroutine(func, replace_callback=True):
        to `.IOLoop.add_future`.
 
     """
-    return _make_coroutine_wrapper(func, replace_callback=True)
+    return _make_coroutine_wrapper(func, replace_callback=replace_callback)
 
 
 def _make_coroutine_wrapper(func, replace_callback):


### PR DESCRIPTION
fix `replace_callback` argument in `gen.coroutine` that is not used before