### PR TITLE
add str and repr method of HTTPHeader

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -238,14 +238,9 @@ class HTTPHeaders(collections.MutableMapping):
         lines = []
         for name, value in self.get_all():
             lines.append("%s: %s" % (name, value))
-        return "HTTPHeaders(\n%s\n)" % ("\n".join(lines))
-    __unicode__ = __str__
-
-    def __repr__(self):
-        lines = []
-        for name, value in self.get_all():
-            lines.append("%s: %s" % (name, value))
         return "\n%s\n" % ("\n".join(lines))
+
+    __unicode__ = __str__
 
 
 class HTTPServerRequest(object):

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -234,6 +234,19 @@ class HTTPHeaders(collections.MutableMapping):
     # the appearance that HTTPHeaders is a single container.
     __copy__ = copy
 
+    def __str__(self):
+        lines = []
+        for name, value in self.get_all():
+            lines.append("%s: %s" % (name, value))
+        return "HTTPHeaders(\n%s\n)" % ("\n".join(lines))
+    __unicode__ = __str__
+
+    def __repr__(self):
+        lines = []
+        for name, value in self.get_all():
+            lines.append("%s: %s" % (name, value))
+        return "\n%s\n" % ("\n".join(lines))
+
 
 class HTTPServerRequest(object):
     """A single HTTP request.

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -323,27 +323,7 @@ Foo: even
         headers.add("Foo", "1")
         headers.add("Foo", "2")
         headers.add("Foo", "3")
-        self.assertTrue(str(headers).startswith("HTTPHeaders"))
-        self.assertIn("Foo: 1", str(headers))
-        self.assertIn("Foo: 2", str(headers))
-        self.assertIn("Foo: 3", str(headers))
-
-        headers = HTTPHeaders()
-        headers.add('Set-Cookie', 'a=b')
-        headers.add('Set-Cookie', 'c=d')
-        headers.add('Content-Type', 'text/html')
-        self.assertTrue(str(headers).startswith("HTTPHeaders"))
-        self.assertIn("Set-Cookie: a=b", str(headers))
-        self.assertIn("Set-Cookie: c=d", str(headers))
-        self.assertIn("Content-Type: text/html", str(headers))
-
-    def test_repr(self):
-        headers = HTTPHeaders()
-        headers.add("Foo", "1")
-        headers.add("Foo", "2")
-        headers.add("Foo", "3")
-
-        headers2 = HTTPHeaders.parse(repr(headers))
+        headers2 = HTTPHeaders.parse(str(headers))
         self.assertEquals(headers, headers2)
 
 

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -318,6 +318,34 @@ Foo: even
         self.assertEqual(headers['quux'], 'xyzzy')
         self.assertEqual(sorted(headers.get_all()), [('Foo', 'bar'), ('Quux', 'xyzzy')])
 
+    def test_string(self):
+        headers = HTTPHeaders()
+        headers.add("Foo", "1")
+        headers.add("Foo", "2")
+        headers.add("Foo", "3")
+        self.assertTrue(str(headers).startswith("HTTPHeaders"))
+        self.assertIn("Foo: 1", str(headers))
+        self.assertIn("Foo: 2", str(headers))
+        self.assertIn("Foo: 3", str(headers))
+
+        headers = HTTPHeaders()
+        headers.add('Set-Cookie', 'a=b')
+        headers.add('Set-Cookie', 'c=d')
+        headers.add('Content-Type', 'text/html')
+        self.assertTrue(str(headers).startswith("HTTPHeaders"))
+        self.assertIn("Set-Cookie: a=b", str(headers))
+        self.assertIn("Set-Cookie: c=d", str(headers))
+        self.assertIn("Content-Type: text/html", str(headers))
+
+    def test_repr(self):
+        headers = HTTPHeaders()
+        headers.add("Foo", "1")
+        headers.add("Foo", "2")
+        headers.add("Foo", "3")
+
+        headers2 = HTTPHeaders.parse(repr(headers))
+        self.assertEquals(headers, headers2)
+
 
 class FormatTimestampTest(unittest.TestCase):
     # Make sure that all the input types are supported.


### PR DESCRIPTION
fix issue https://github.com/tornadoweb/tornado/issues/1708
```
> python -m tornado.httpclient --print_headers --print_body=false http://www.google.com
HTTPHeaders(
X-Consumed-Content-Encoding: gzip
Content-Length: 19073
X-Xss-Protection: 1; mode=block
Set-Cookie: NID=79=m5s4FozJ5MFZgp9IWYzKo8Dny3TaWs5-YzYWQ6J_rXVDBzk5fhzurZhyw23LrlvbfkyQ1pMdJgp0tSyjz9QnUIpDGaSPcC4e5HMdQpfLRulkF655AU3KvZf7FqnNN0x-; expires=Thu, 03-Nov-2016 02:59:37 GMT; path=/; domain=.google.com.hk; HttpOnly
Expires: -1
Server: gws
Connection: close
Cache-Control: private, max-age=0
Date: Wed, 04 May 2016 02:59:37 GMT
P3p: CP="This is not a P3P policy! See https://www.google.com/support/accounts/answer/151657?hl=en for more info."
Content-Type: text/html; charset=Big5
X-Frame-Options: SAMEORIGIN
)
```
and add unittest