### PR TITLE
Don't require backports.ssl_match_hostname on Python 2.7.9 and newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ if setuptools is not None:
     if sys.version_info < (2, 7):
         # Only needed indirectly, for singledispatch.
         install_requires.append('ordereddict')
-    if sys.version_info < (3, 2):
+    if sys.version_info < (2, 7, 9):
         install_requires.append('backports.ssl_match_hostname')
     if sys.version_info < (3, 4):
         install_requires.append('singledispatch')


### PR DESCRIPTION
As Python 3.2 support was dropped one can check 2.7.x dependency only.

Tornado running on Python 2.7.9+ doesn't need this backported package,
but some Python packages like circus check package dependencies at
runtime and insist on having backports.ssl_match_hostname installed,
though they don't even use this particular feature.

So checking for exact version makes life of package maintainer easier
especially on embedded Linux distributions like Buildroot.