### PR TITLE
Update options to have same behavior from config file or command line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ setup(
             "gettext_translations/fr_FR/LC_MESSAGES/tornado_test.mo",
             "gettext_translations/fr_FR/LC_MESSAGES/tornado_test.po",
             "options_test.cfg",
+            "options_test_types.cfg",
             "static/robots.txt",
             "static/sample.xml",
             "static/sample.xml.gz",

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ setup(
             "gettext_translations/fr_FR/LC_MESSAGES/tornado_test.po",
             "options_test.cfg",
             "options_test_types.cfg",
+            "options_test_types_str.cfg",
             "static/robots.txt",
             "static/sample.xml",
             "static/sample.xml.gz",

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -324,7 +324,12 @@ class OptionParser(object):
                     if not isinstance(config[name], list):
                         raise Error("Option %r is required to be a list of %s" %
                                     (option.name, option.type.__name__))
-                option.parse(config[name])
+
+                if type(config[name]) == str and option.type != str:
+                    option.parse(config[name])
+                else:
+                    option.set(config[name])
+
 
         if final:
             self.run_parse_callbacks()

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -24,6 +24,13 @@ except ImportError:
         mock = None
 
 
+class email(str):
+   def __new__(cls, value):
+        if '@' not in value:
+            raise ValueError()
+        return str.__new__(cls, value)
+
+
 class OptionsTest(unittest.TestCase):
     def test_parse_command_line(self):
         options = OptionParser()
@@ -189,14 +196,7 @@ class OptionsTest(unittest.TestCase):
             self.assertEqual(options.foo, 5)
         self.assertEqual(options.foo, 2)
 
-    def test_types(self):
-
-        class email(str):
-           def __new__(cls, value):
-                if '@' not in value:
-                    raise ValueError()
-                return str.__new__(cls, value)
-
+    def _define_options(self):
         options = OptionParser()
         options.define('str', type=str)
         options.define('basestring', type=basestring_type)
@@ -206,6 +206,10 @@ class OptionsTest(unittest.TestCase):
         options.define('timedelta', type=datetime.timedelta)
         options.define('email', type=email)
         options.define('list-of-int', type=int, multiple=True)
+        return options
+
+    def test_types(self):
+        options = self._define_options()
         options.parse_command_line(['main.py',
                                     '--str=asdf',
                                     '--basestring=qwer',
@@ -228,34 +232,21 @@ class OptionsTest(unittest.TestCase):
         self.assertEqual(options.list_of_int, [1, 2, 3])
 
     def test_types_with_conf_file(self):
-
-        class email(str):
-           def __new__(cls, value):
-                if '@' not in value:
-                    raise ValueError()
-                return str.__new__(cls, value)
-
-        options = OptionParser()
-        options.define('str', type=str)
-        options.define('basestring', type=basestring_type)
-        options.define('int', type=int)
-        options.define('float', type=float)
-        options.define('datetime', type=datetime.datetime)
-        options.define('timedelta', type=datetime.timedelta)
-        options.define('email', type=email)
-        options.define('list-of-int', type=int, multiple=True)
-        options.parse_config_file(os.path.join(os.path.dirname(__file__),
-                                               "options_test_types.cfg"))
-        self.assertEqual(options.str, 'asdf')
-        self.assertEqual(options.basestring, 'qwer')
-        self.assertEqual(options.int, 42)
-        self.assertEqual(options.float, 1.5)
-        self.assertEqual(options.datetime,
-                         datetime.datetime(2013, 4, 28, 5, 16))
-        self.assertEqual(options.timedelta, datetime.timedelta(seconds=45))
-        self.assertEqual(options.email, 'tornado@web.com')
-        self.assertTrue(isinstance(options.email, email))
-        self.assertEqual(options.list_of_int, [1, 2, 3])
+        options = self._define_options()
+        for config_file_name in ("options_test_types.cfg",
+                                 "options_test_types_str.cfg"):
+            options.parse_config_file(os.path.join(os.path.dirname(__file__),
+                                      config_file_name))
+            self.assertEqual(options.str, 'asdf')
+            self.assertEqual(options.basestring, 'qwer')
+            self.assertEqual(options.int, 42)
+            self.assertEqual(options.float, 1.5)
+            self.assertEqual(options.datetime,
+                             datetime.datetime(2013, 4, 28, 5, 16))
+            self.assertEqual(options.timedelta, datetime.timedelta(seconds=45))
+            self.assertEqual(options.email, 'tornado@web.com')
+            self.assertTrue(isinstance(options.email, email))
+            self.assertEqual(options.list_of_int, [1, 2, 3])
 
     def test_multiple_string(self):
         options = OptionParser()

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -190,6 +190,13 @@ class OptionsTest(unittest.TestCase):
         self.assertEqual(options.foo, 2)
 
     def test_types(self):
+
+        class email(str):
+           def __new__(cls, value):
+                if '@' not in value:
+                    raise ValueError()
+                return str.__new__(cls, value)
+
         options = OptionParser()
         options.define('str', type=str)
         options.define('basestring', type=basestring_type)
@@ -197,13 +204,18 @@ class OptionsTest(unittest.TestCase):
         options.define('float', type=float)
         options.define('datetime', type=datetime.datetime)
         options.define('timedelta', type=datetime.timedelta)
+        options.define('email', type=email)
+        options.define('list-of-int', type=int, multiple=True)
         options.parse_command_line(['main.py',
                                     '--str=asdf',
                                     '--basestring=qwer',
                                     '--int=42',
                                     '--float=1.5',
                                     '--datetime=2013-04-28 05:16',
-                                    '--timedelta=45s'])
+                                    '--timedelta=45s',
+                                    '--email=tornado@web.com',
+                                    '--list-of-int=1,2,3'])
+
         self.assertEqual(options.str, 'asdf')
         self.assertEqual(options.basestring, 'qwer')
         self.assertEqual(options.int, 42)
@@ -211,6 +223,39 @@ class OptionsTest(unittest.TestCase):
         self.assertEqual(options.datetime,
                          datetime.datetime(2013, 4, 28, 5, 16))
         self.assertEqual(options.timedelta, datetime.timedelta(seconds=45))
+        self.assertEqual(options.email, 'tornado@web.com')
+        self.assertTrue(isinstance(options.email, email))
+        self.assertEqual(options.list_of_int, [1, 2, 3])
+
+    def test_types_with_conf_file(self):
+
+        class email(str):
+           def __new__(cls, value):
+                if '@' not in value:
+                    raise ValueError()
+                return str.__new__(cls, value)
+
+        options = OptionParser()
+        options.define('str', type=str)
+        options.define('basestring', type=basestring_type)
+        options.define('int', type=int)
+        options.define('float', type=float)
+        options.define('datetime', type=datetime.datetime)
+        options.define('timedelta', type=datetime.timedelta)
+        options.define('email', type=email)
+        options.define('list-of-int', type=int, multiple=True)
+        options.parse_config_file(os.path.join(os.path.dirname(__file__),
+                                               "options_test_types.cfg"))
+        self.assertEqual(options.str, 'asdf')
+        self.assertEqual(options.basestring, 'qwer')
+        self.assertEqual(options.int, 42)
+        self.assertEqual(options.float, 1.5)
+        self.assertEqual(options.datetime,
+                         datetime.datetime(2013, 4, 28, 5, 16))
+        self.assertEqual(options.timedelta, datetime.timedelta(seconds=45))
+        self.assertEqual(options.email, 'tornado@web.com')
+        self.assertTrue(isinstance(options.email, email))
+        self.assertEqual(options.list_of_int, [1, 2, 3])
 
     def test_multiple_string(self):
         options = OptionParser()

--- a/tornado/test/options_test_types.cfg
+++ b/tornado/test/options_test_types.cfg
@@ -1,8 +1,16 @@
+from datetime import datetime, timedelta
+import sys
+import os
+sys.path.insert(0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+)
+from tornado.test.options_test import email
+
 str = 'asdf'
 basestring = 'qwer'
 int = 42
 float = 1.5
-datetime = '2013-04-28 05:16'
-timedelta = '45s'
+datetime = datetime(2013, 4, 28, 5, 16)
+timedelta = timedelta(0, 45)
+email = email('tornado@web.com')
 list_of_int = [1, 2, 3]
-email = 'tornado@web.com'

--- a/tornado/test/options_test_types.cfg
+++ b/tornado/test/options_test_types.cfg
@@ -1,0 +1,8 @@
+str = 'asdf'
+basestring = 'qwer'
+int = 42
+float = 1.5
+datetime = '2013-04-28 05:16'
+timedelta = '45s'
+list_of_int = [1, 2, 3]
+email = 'tornado@web.com'

--- a/tornado/test/options_test_types.cfg
+++ b/tornado/test/options_test_types.cfg
@@ -1,10 +1,5 @@
 from datetime import datetime, timedelta
-import sys
-import os
-sys.path.insert(0,
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-)
-from tornado.test.options_test import email
+from tornado.test.options_test import Email
 
 str = 'asdf'
 basestring = 'qwer'
@@ -12,5 +7,5 @@ int = 42
 float = 1.5
 datetime = datetime(2013, 4, 28, 5, 16)
 timedelta = timedelta(0, 45)
-email = email('tornado@web.com')
+email = Email('tornado@web.com')
 list_of_int = [1, 2, 3]

--- a/tornado/test/options_test_types_str.cfg
+++ b/tornado/test/options_test_types_str.cfg
@@ -1,0 +1,8 @@
+str = 'asdf'
+basestring = 'qwer'
+int = 42
+float = 1.5
+datetime = '2013-04-28 05:16'
+timedelta = '45s'
+email = 'tornado@web.com'
+list_of_int = [1, 2, 3]


### PR DESCRIPTION
Currently, Tornado raise an error when we use types option in configuration file such as 
options.define('datetime', type=datetime.datetime)
