### PR TITLE
Fixed #1718

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -540,7 +540,13 @@ class HTTP1Connection(httputil.HTTPConnection):
                         "Multiple unequal Content-Lengths: %r" %
                         headers["Content-Length"])
                 headers["Content-Length"] = pieces[0]
-            content_length = int(headers["Content-Length"])
+
+            try:
+                content_length = int(headers["Content-Length"])
+            except ValueError:
+                # Handles non-integer Content-Length value.
+                raise httputil.HTTPInputError(
+                    "Only integer Content-Length is allowed: %s" % headers["Content-Length"])
 
             if content_length > self._max_body_size:
                 raise httputil.HTTPInputError("Content-Length too long")

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -450,7 +450,7 @@ Content-Length: foo
 bar
 
 """.replace(b"\n", b"\r\n"))
-            self.io_loop.add_timeout(datetime.timedelta(seconds=0.01), self.stop)
+            self.stream.read_until_close(self.stop)
             self.wait()
 
 

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -441,6 +441,18 @@ bar
         headers, response = self.wait()
         self.assertEqual(json_decode(response), {u'foo': [u'bar']})
 
+    def test_invalid_content_length(self):
+        with ExpectLog(gen_log, '.*Only integer Content-Length is allowed'):
+            self.stream.write(b"""\
+POST /echo HTTP/1.1
+Content-Length: foo
+
+bar
+
+""".replace(b"\n", b"\r\n"))
+            self.io_loop.add_timeout(datetime.timedelta(seconds=0.01), self.stop)
+            self.wait()
+
 
 class XHeaderTest(HandlerBaseTestCase):
     class Handler(RequestHandler):


### PR DESCRIPTION
This fixes #1718 .
As many HTTP clients allow to override Content-Length value to something which is non-integer, I think closing the connection immediately for this case is far more better than raising `ValueError`.