### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/guide/coroutines.rst
+++ b/docs/guide/coroutines.rst
@@ -242,7 +242,7 @@ Looping is tricky with coroutines since there is no way in Python
 to ``yield`` on every iteration of a ``for`` or ``while`` loop and
 capture the result of the yield.  Instead, you'll need to separate
 the loop condition from accessing the results, as in this example
-from `Motor <http://motor.readthedocs.org/en/stable/>`_::
+from `Motor <https://motor.readthedocs.io/en/stable/>`_::
 
     import motor
     db = motor.MotorClient().test

--- a/docs/releases/v4.2.0.rst
+++ b/docs/releases/v4.2.0.rst
@@ -23,7 +23,7 @@ New modules: `tornado.locks` and `tornado.queues`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These modules provide classes for coordinating coroutines, merged from
-`Toro <http://toro.readthedocs.org>`_.
+`Toro <https://toro.readthedocs.io>`_.
 
 To port your code from Toro's queues to Tornado 4.2, import `.Queue`,
 `.PriorityQueue`, or `.LifoQueue` from `tornado.queues` instead of from

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Tox (http://tox.readthedocs.org) is a tool for running tests
+# Tox (https://tox.readthedocs.io) is a tool for running tests
 # in multiple virtualenvs.  This configuration file will run the tornado
 # test suite on all supported python versions.  To use it, "pip install tox"
 # and then run "tox" from this directory.


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.