### PR TITLE
Add mypy to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,27 @@
 # https://travis-ci.org/tornadoweb/tornado
 language: python
-python:
-    - 2.7.8
-    - 2.7
-    - pypy
-    - 3.3
-    - 3.4
-    - 3.5
-    - nightly
-    - pypy3
-env:
-    - TEST_SUITE=main
 
 matrix:
     fast_finish: true
     include:
-      - python: "3.5"
+      - python: 3.5
         env: TEST_SUITE=mypy
+      - python: 2.7.8
+        env: TEST_SUITE=main
+      - python: 2.7
+        env: TEST_SUITE=main
+      - python: pypy
+        env: TEST_SUITE=main
+      - python: 3.3
+        env: TEST_SUITE=main
+      - python: 3.4
+        env: TEST_SUITE=main
+      - python: 3.5
+        env: TEST_SUITE=main
+      - python: nightly
+        env: TEST_SUITE=main
+      - python: pypy3
+        env: TEST_SUITE=main
 
 install: travis_retry ./maint/travis/setup-$TEST_SUITE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       - python: "3.5"
         env: TEST_SUITE=mypy
 
-install: ./maint/travis/setup-$TEST_SUITE
+install: travis_retry ./maint/travis/setup-$TEST_SUITE
 
 script: ./maint/travis/$TEST_SUITE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ python:
     - pypy3
 env:
     - TEST_SUITE=main
+
 matrix:
     fast_finish: true
+    include:
+      - python: "3.5"
+        env: TEST_SUITE=mypy
 
 install: ./maint/travis/setup-$TEST_SUITE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,14 @@ python:
     - 3.5
     - nightly
     - pypy3
+env:
+    - TEST_SUITE=main
+matrix:
+    fast_finish: true
 
-install: ./maint/travis/setup-main
+install: ./maint/travis/setup-$TEST_SUITE
 
-script: ./maint/travis/main
+script: ./maint/travis/$TEST_SUITE
 
 after_success:
     # call codecov from project root
@@ -22,6 +26,3 @@ after_success:
 # travis.  Consider removing this after the underlying issue is fixed.
 # https://github.com/travis-ci/travis-ci/issues/2389
 sudo: false
-
-matrix:
-    fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,63 +10,9 @@ python:
     - nightly
     - pypy3
 
-install:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install futures mock monotonic trollius; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then travis_retry pip install futures mock; fi
-    # TODO(bdarnell): pycares tests are currently disabled on travis due to ipv6 issues.
-    #- if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install pycares; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install pycurl; fi
-    # Twisted runs on 2.x and 3.3+, but is flaky on pypy.
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install Twisted; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
-    # On travis the extension should always be built
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
-    - travis_retry python setup.py install
-    - travis_retry pip install codecov
-    # Create a separate no-dependencies virtualenv to make sure all imports
-    # of optional-dependencies are guarded.
-    - virtualenv ./nodeps
-    - ./nodeps/bin/python setup.py install
-    - curl-config --version; pip freeze
+install: ./maint/travis/setup-main
 
-script:
-    # Get out of the source directory before running tests to avoid PYTHONPATH
-    # confusion.  This is necessary to ensure that the speedups module can
-    # be found in the installation directory.
-    - cd maint
-    # Copy the coveragerc down so coverage.py can find it.
-    - cp ../.coveragerc .
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
-    - export TARGET="-m tornado.test.runtests"
-    # Travis workers are often overloaded and cause our tests to exceed
-    # the default timeout of 5s.
-    - export ASYNC_TEST_TIMEOUT=15
-    # We use "python -m coverage" instead of the "bin/coverage" script
-    # so we can pass additional arguments to python.
-    # coverage needs a function that was removed in python 3.6 so we can't
-    # run it with nightly cpython.
-    - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then export TARGET="-m coverage run $TARGET"; fi
-    - python $TARGET
-    - python $TARGET --ioloop=tornado.platform.select.SelectIOLoop
-    - python -O $TARGET
-    - LANG=C python $TARGET
-    - LANG=en_US.utf-8 python $TARGET
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python -bb $TARGET; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.netutil.ThreadedResolver; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop_time_monotonic; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --resolver=tornado.platform.twisted.TwistedResolver; fi
-    #- if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python $TARGET --ioloop_time_monotonic; fi
-    - ../nodeps/bin/python -m tornado.test.runtests
-    # make coverage reports for Codecov to find
-    - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then coverage xml; fi
-    - export TORNADO_EXTENSION=0
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
+script: ./maint/travis/main
 
 after_success:
     # call codecov from project root

--- a/maint/travis/main
+++ b/maint/travis/main
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -ex
+
+# Get out of the source directory before running tests to avoid PYTHONPATH
+# confusion.  This is necessary to ensure that the speedups module can
+# be found in the installation directory.
+cd maint
+
+# Copy the coveragerc down so coverage.py can find it.
+cp ../.coveragerc .
+
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+    export TORNADO_EXTENSION=1
+fi
+
+# Travis workers are often overloaded and cause our tests to exceed
+# the default timeout of 5s.
+export ASYNC_TEST_TIMEOUT=15
+
+export TARGET="-m tornado.test.runtests"
+
+# We use "python -m coverage" instead of the "bin/coverage" script
+# so we can pass additional arguments to python.
+# coverage needs a function that was removed in python 3.6 so we can't
+# run it with nightly cpython.
+if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then
+    export TARGET="-m coverage run $TARGET"
+fi
+
+python $TARGET
+python $TARGET --ioloop=tornado.platform.select.SelectIOLoop
+python -O $TARGET
+LANG=C python $TARGET
+LANG=en_US.utf-8 python $TARGET
+if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
+    python -bb $TARGET
+fi
+if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then
+    python $TARGET --resolver=tornado.netutil.ThreadedResolver
+fi
+if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
+    python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient
+fi
+if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
+    python $TARGET --ioloop_time_monotonic
+fi
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+    python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop
+fi
+if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 ]]; then
+    python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop
+fi
+if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
+    python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop
+fi
+if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
+    python $TARGET --resolver=tornado.platform.twisted.TwistedResolver
+fi
+# if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then
+#     python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver
+# fi
+if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
+    python $TARGET --ioloop_time_monotonic
+fi
+../nodeps/bin/python -m tornado.test.runtests
+
+# make coverage reports for Codecov to find
+if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then
+    coverage xml
+fi
+
+export TORNADO_EXTENSION=0
+if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then
+    cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out
+fi
+if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then
+    cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out
+fi

--- a/maint/travis/mypy
+++ b/maint/travis/mypy
@@ -1,0 +1,15 @@
+#!/bin/bash
+# no `set -ex`; this script is all about doing a more verbose version by hand
+
+echo '+ ./maint/types/run-mypy'
+./maint/types/run-mypy
+retcode="$?"
+
+if [ "$retcode" == "0" ]; then
+    echo "The mypy static type checker for Python detected no errors!"
+else
+    echo
+    echo "The mypy static type checker for Python threw some errors,"
+    echo "which indicates either a bug in your code or incorrect type annotations."
+    exit "$retcode"
+fi

--- a/maint/travis/setup-main
+++ b/maint/travis/setup-main
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -ex
+
+if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
+    travis_retry pip install futures mock monotonic trollius
+fi
+
+if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then
+    travis_retry pip install futures mock
+fi
+
+# TODO(bdarnell): pycares tests are currently disabled on travis due to ipv6 issues.
+# if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+#     travis_retry pip install pycares
+# fi
+
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+    travis_retry pip install pycurl
+fi
+
+# Twisted runs on 2.x and 3.3+, but is flaky on pypy.
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+    travis_retry pip install Twisted
+fi
+
+if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then
+    travis_retry pip install sphinx sphinx_rtd_theme
+fi
+
+# On travis the extension should always be built
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+    export TORNADO_EXTENSION=1
+fi
+
+travis_retry python setup.py install
+
+travis_retry pip install codecov
+
+# Create a separate no-dependencies virtualenv to make sure all imports
+# of optional-dependencies are guarded.
+virtualenv ./nodeps
+./nodeps/bin/python setup.py install
+
+curl-config --version
+pip freeze

--- a/maint/travis/setup-main
+++ b/maint/travis/setup-main
@@ -2,29 +2,29 @@
 set -ex
 
 if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
-    travis_retry pip install futures mock monotonic trollius
+    pip install futures mock monotonic trollius
 fi
 
 if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then
-    travis_retry pip install futures mock
+    pip install futures mock
 fi
 
 # TODO(bdarnell): pycares tests are currently disabled on travis due to ipv6 issues.
 # if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-#     travis_retry pip install pycares
+#     pip install pycares
 # fi
 
 if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-    travis_retry pip install pycurl
+    pip install pycurl
 fi
 
 # Twisted runs on 2.x and 3.3+, but is flaky on pypy.
 if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-    travis_retry pip install Twisted
+    pip install Twisted
 fi
 
 if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then
-    travis_retry pip install sphinx sphinx_rtd_theme
+    pip install sphinx sphinx_rtd_theme
 fi
 
 # On travis the extension should always be built
@@ -32,12 +32,13 @@ if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
     export TORNADO_EXTENSION=1
 fi
 
-travis_retry python setup.py install
+python setup.py install
 
-travis_retry pip install codecov
+pip install codecov
 
 # Create a separate no-dependencies virtualenv to make sure all imports
 # of optional-dependencies are guarded.
+rm -rf ./nodeps
 virtualenv ./nodeps
 ./nodeps/bin/python setup.py install
 

--- a/maint/travis/setup-mypy
+++ b/maint/travis/setup-mypy
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+travis_retry pip install -r maint/types/requirements.in
+
+pip freeze

--- a/maint/travis/setup-mypy
+++ b/maint/travis/setup-mypy
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
 
-travis_retry pip install -r maint/types/requirements.in
+pip install -r maint/types/requirements.in
 
 pip freeze

--- a/maint/types/lister.py
+++ b/maint/types/lister.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+from os.path import abspath
+import sys
+import subprocess
+import re
+from collections import defaultdict
+import argparse
+from six.moves import filter
+from typing import Union, List, Dict
+
+
+def get_ftype(fpath, use_shebang):
+    # type: (str, bool) -> str
+    ext = os.path.splitext(fpath)[1]
+    if ext:
+        return ext[1:]
+    elif use_shebang:
+        # opening a file may throw an OSError
+        with open(fpath) as f:
+            first_line = f.readline()
+            if re.search(r'^#!.*\bpython', first_line):
+                return 'py'
+            elif re.search(r'^#!.*sh', first_line):
+                return 'sh'
+            elif re.search(r'^#!.*\bperl', first_line):
+                return 'pl'
+            elif re.search(r'^#!.*\bnode', first_line):
+                return 'js'
+            elif re.search(r'^#!.*\bruby', first_line):
+                return 'rb'
+            elif re.search(r'^#!', first_line):
+                print('Error: Unknown shebang in file "%s":\n%s' % (fpath, first_line), file=sys.stderr)
+                return ''
+            else:
+                return ''
+    else:
+        return ''
+
+
+def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
+               exclude=[], group_by_ftype=False):
+    # type: (List[str], List[str], bool, bool, List[str], bool) -> Union[Dict[str, List[str]], List[str]]
+    """
+    List files tracked by git.
+    Returns a list of files which are either in targets or in directories in targets.
+    If targets is [], list of all tracked files in current directory is returned.
+
+    Other arguments:
+    ftypes - List of file types on which to filter the search.
+        If ftypes is [], all files are included.
+    use_shebang - Determine file type of extensionless files from their shebang.
+    modified_only - Only include files which have been modified.
+    exclude - List of paths to be excluded.
+    group_by_ftype - If True, returns a dict of lists keyed by file type.
+        If False, returns a flat list of files.
+    """
+    ftypes = [x.strip('.') for x in ftypes]
+    ftypes_set = set(ftypes)
+
+    cmdline = ['git', 'ls-files'] + targets
+    if modified_only:
+        cmdline.append('-m')
+
+    files_gen = (x.strip() for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n'))
+    # throw away empty lines and non-files (like symlinks)
+    files = list(filter(os.path.isfile, files_gen))
+
+    result_dict = defaultdict(list) # type: Dict[str, List[str]]
+    result_list = [] # type: List[str]
+
+    for fpath in files:
+        # this will take a long time if exclude is very large
+        in_exclude = False
+        absfpath = abspath(fpath)
+        for expath in exclude:
+            expath = abspath(expath.rstrip('/'))
+            if absfpath == expath or absfpath.startswith(expath + '/'):
+                in_exclude = True
+        if in_exclude:
+            continue
+
+        if ftypes or group_by_ftype:
+            try:
+                filetype = get_ftype(fpath, use_shebang)
+            except (OSError, UnicodeDecodeError) as e:
+                etype = e.__class__.__name__
+                print('Error: %s while determining type of file "%s":' % (etype, fpath), file=sys.stderr)
+                print(e, file=sys.stderr)
+                filetype = ''
+            if ftypes and filetype not in ftypes_set:
+                continue
+
+        if group_by_ftype:
+            result_dict[filetype].append(fpath)
+        else:
+            result_list.append(fpath)
+
+    if group_by_ftype:
+        return result_dict
+    else:
+        return result_list
+
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description="List files tracked by git and optionally filter by type")
+    parser.add_argument('targets', nargs='*', default=[],
+                        help='''files and directories to include in the result.
+                        If this is not specified, the current directory is used''')
+    parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
+    parser.add_argument('-f', '--ftypes', nargs='+', default=[],
+                        help="list of file types to filter on. All files are included if this option is absent")
+    parser.add_argument('--ext-only', dest='extonly', action='store_true', default=False,
+                        help='only use extension to determine file type')
+    parser.add_argument('--exclude', nargs='+', default=[],
+                        help='list of files and directories to exclude from listing')
+    args = parser.parse_args()
+    listing = list_files(targets=args.targets, ftypes=args.ftypes, use_shebang=not args.extonly,
+                         modified_only=args.modified, exclude=args.exclude)
+    for l in listing:
+        print(l)

--- a/maint/types/requirements.in
+++ b/maint/types/requirements.in
@@ -1,0 +1,2 @@
+six
+git+https://github.com/python/mypy.git@e45ac1085

--- a/maint/types/run-mypy
+++ b/maint/types/run-mypy
@@ -44,7 +44,7 @@ mypy_command = "mypy"
 # run mypy
 if python_files:
     try:
-        # TODO --fast-import
+        # TODO --fast-parser
         # TODO --check-untyped-defs
         rc = subprocess.call([mypy_command, "--silent-imports", "--py2"] + python_files)
     except OSError:

--- a/maint/types/run-mypy
+++ b/maint/types/run-mypy
@@ -13,8 +13,12 @@ import six
 import lister
 
 exclude = """
+tornado/platform/auto.py
+tornado/test/gettext_translations/extract_me.py
 demos/
 maint/test/
+docs/conf.py
+setup.py
 """.split()
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")

--- a/maint/types/run-mypy
+++ b/maint/types/run-mypy
@@ -51,7 +51,8 @@ else:
 # run mypy
 if python_files:
     # TODO --fast-import
-    rc = subprocess.call([mypy_command, "--silent-imports", "--py2", "--check-untyped-defs"] + python_files)
+    # TODO --check-untyped-defs
+    rc = subprocess.call([mypy_command, "--silent-imports", "--py2"] + python_files)
     sys.exit(rc)
 else:
     print("There are no files to run mypy on.")

--- a/maint/types/run-mypy
+++ b/maint/types/run-mypy
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import os
+from os.path import dirname, abspath
+import subprocess
+import sys
+
+import six
+
+import lister
+
+exclude = """
+demos/
+maint/test/
+""".split()
+
+parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
+parser.add_argument('targets', nargs='*', default=[],
+                    help="""files and directories to include in the result.
+                    If this is not specified, the current directory is used""")
+parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
+parser.add_argument('-a', '--all', dest='all', action='store_true', default=False,
+                    help="""run mypy on all python files, ignoring the exclude list.
+                    This is useful if you have to find out which files fail mypy check.""")
+args = parser.parse_args()
+if args.all:
+    exclude = []
+
+# find all non-excluded files in current directory
+BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+exclude = [os.path.join(BASE_DIR, fpath) for fpath in exclude]
+python_files = lister.list_files(targets=args.targets, ftypes=['py'], use_shebang=False,
+                                 modified_only=args.modified, exclude=exclude)
+
+if False:
+    # TODO
+    # Use zulip-py3-venv's mypy if it's available and we're on python 2
+    PY3_VENV_DIR = "/srv/zulip-py3-venv"
+    MYPY_VENV_PATH = os.path.join(PY3_VENV_DIR, "bin", "mypy")
+    if six.PY2 and os.path.exists(MYPY_VENV_PATH):
+        mypy_command = MYPY_VENV_PATH
+        print("Using mypy from", mypy_command)
+    else:
+        mypy_command = "mypy"
+else:
+    mypy_command = "mypy"
+
+# run mypy
+if python_files:
+    # TODO --fast-import
+    rc = subprocess.call([mypy_command, "--silent-imports", "--py2", "--check-untyped-defs"] + python_files)
+    sys.exit(rc)
+else:
+    print("There are no files to run mypy on.")

--- a/maint/types/run-mypy
+++ b/maint/types/run-mypy
@@ -13,7 +13,6 @@ import six
 import lister
 
 exclude = """
-tornado/platform/auto.py
 tornado/test/gettext_translations/extract_me.py
 demos/
 maint/test/

--- a/maint/types/run-mypy
+++ b/maint/types/run-mypy
@@ -38,24 +38,18 @@ exclude = [os.path.join(BASE_DIR, fpath) for fpath in exclude]
 python_files = lister.list_files(targets=args.targets, ftypes=['py'], use_shebang=False,
                                  modified_only=args.modified, exclude=exclude)
 
-if False:
-    # TODO
-    # Use zulip-py3-venv's mypy if it's available and we're on python 2
-    PY3_VENV_DIR = "/srv/zulip-py3-venv"
-    MYPY_VENV_PATH = os.path.join(PY3_VENV_DIR, "bin", "mypy")
-    if six.PY2 and os.path.exists(MYPY_VENV_PATH):
-        mypy_command = MYPY_VENV_PATH
-        print("Using mypy from", mypy_command)
-    else:
-        mypy_command = "mypy"
-else:
-    mypy_command = "mypy"
+# TODO provide a handy way to install mypy, and use the result here if present
+mypy_command = "mypy"
 
 # run mypy
 if python_files:
-    # TODO --fast-import
-    # TODO --check-untyped-defs
-    rc = subprocess.call([mypy_command, "--silent-imports", "--py2"] + python_files)
+    try:
+        # TODO --fast-import
+        # TODO --check-untyped-defs
+        rc = subprocess.call([mypy_command, "--silent-imports", "--py2"] + python_files)
+    except OSError:
+        print("Failed to start mypy -- do you have it installed?")
+        sys.exit(2)
     sys.exit(rc)
 else:
     print("There are no files to run mypy on.")

--- a/tornado/platform/auto.py
+++ b/tornado/platform/auto.py
@@ -33,10 +33,10 @@ if 'APPENGINE_RUNTIME' in os.environ:
     def set_close_exec(fd):
         pass
 elif os.name == 'nt':
-    from tornado.platform.common import Waker
+    from tornado.platform.common import Waker  # type: ignore
     from tornado.platform.windows import set_close_exec
 else:
-    from tornado.platform.posix import set_close_exec, Waker
+    from tornado.platform.posix import set_close_exec, Waker  # type: ignore
 
 try:
     # monotime monkey-patches the time module to have a monotonic function
@@ -52,7 +52,7 @@ try:
     from monotonic import monotonic as monotonic_time
 except ImportError:
     try:
-        from time import monotonic as monotonic_time
+        from time import monotonic as monotonic_time  # type: ignore
     except ImportError:
         monotonic_time = None
 


### PR DESCRIPTION
This will let us ensure the type-check results stay clean and type annotations remain valid as new changes come in.

While we're here, pull out the Travis build steps into a cleaner format as separate scripts, as they've gotten rather longer than they were when they started.

