### PR TITLE
Static method for determining if an IOLoop is installed and running

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -166,6 +166,11 @@ class IOLoop(Configurable):
         """Returns true if the singleton instance has been created."""
         return hasattr(IOLoop, "_instance")
 
+    @staticmethod
+    def running():
+        """Returns true if the global instance is present running"""
+        return hasattr(IOLoop, "_instance") and IOLoop._instance._running
+
     def install(self):
         """Installs this `IOLoop` object as the singleton instance.
 


### PR DESCRIPTION
In some cases, it might be helpful to know if an IOLoop is already running to avoid raising a `RuntimeError` by attempting to start a running loop. 