### PR TITLE
Fix SVG file recognition on StaticFileHandler

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2579,6 +2579,9 @@ class StaticFileHandler(RequestHandler):
         # per RFC 6713, use the appropriate type for a gzip compressed file
         if encoding == "gzip":
             return "application/gzip"
+        # Bugfix recognition svg file
+        if self.absolute_path.endswith(".svg"):
+            return "image/svg+xml"
         # As of 2015-07-21 there is no bzip2 encoding defined at
         # http://www.iana.org/assignments/media-types/media-types.xhtml
         # So for that (and any other encoding), use octet-stream.


### PR DESCRIPTION
This pull request, fix SVG file recognition on StaticFileHandler. Currently the mime-type returned is 'octet-stream' and svg files are forced to download.