### PR TITLE
Add __slots__ for HTTPHeaders

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -129,6 +129,9 @@ class HTTPHeaders(collections.MutableMapping):
     Set-Cookie: A=B
     Set-Cookie: C=D
     """
+
+    __slots__ = ("_dict", "_as_list", "_last_key")
+
     def __init__(self, *args, **kwargs):
         self._dict = {}  # type: typing.Dict[str, str]
         self._as_list = {}  # type: typing.Dict[str, typing.List[str]]

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -228,6 +228,19 @@ class HTTPHeaders(collections.MutableMapping):
     def __iter__(self):
         return iter(self._dict)
 
+    # required for pickle: becaused __slots__ defined
+    def __getstate__(self):
+        return {
+            slot: getattr(self, slot)
+            for slot in self.__slots__
+            if hasattr(self, slot)
+        }
+
+    # required for pickle: becaused __slots__ defined
+    def __setstate__(self, state):
+        for slot, value in state.items():
+            setattr(self, slot, value)
+
     def copy(self):
         # defined in dict but not in MutableMapping.
         return HTTPHeaders(self)


### PR DESCRIPTION
As I reviewing the httputil.py for `HTTPHeaders`, I found that there are not `__slots__` defined. 

As I know, `__slots__` can reduce memory usage for such objects, the `HTTPHeaders` are used largely in **RequestHandlers** and **HTTPClients** , and their attributes are static and limited to the three internal fields: `_dict`, `_as_list` and `_last_key` .

So why not use `__slots__` ?

Further more, attributes defined in `__slots__` can be looked up more quickly than those without `__slots__` . In this case, the attribute **_dict** is referenced a lot, so i think this will make a big difference. And I made some tests as below:

```
In [11]: class C(object):
   ....:     def __init__(self, name):
   ....:         self.name = name
      
In [12]: class D(object):
   ....:     __slots__ = ('name',)
   ....:     def __init__(self, name):
   ....:         self.name = name
      
In [13]: c = C('hello')
In [14]: d = D('hello')

In [17]: %timeit c.name
The slowest run took 28.13 times longer than the fastest. This could mean that an intermediate result is being cached 
10000000 loops, best of 3: 66.1 ns per loop

In [18]: %timeit d.name
The slowest run took 32.02 times longer than the fastest. This could mean that an intermediate result is being cached 
10000000 loops, best of 3: 54.5 ns per loop
```
reference for name of `class D(with __slots__)` takes less time than `class C` . This test is ran under Python3.4 . 

But it seems it will not work in Python2, because `collections.MutableMapping` in Python2 doesn't have 
`__slots__` defined.


