### PR TITLE
Allow 204 responses without Content-Length/Transfer-Encoding

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -351,7 +351,7 @@ class HTTP1Connection(httputil.HTTPConnection):
                 # 304 responses have no body (not even a zero-length body), and so
                 # should not have either Content-Length or Transfer-Encoding.
                 # headers.
-                start_line.code != 304 and
+                start_line.code not in (204, 304) and
                 # No need to chunk the output if a Content-Length is specified.
                 'Content-Length' not in headers and
                 # Applications are discouraged from touching Transfer-Encoding,

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -631,10 +631,11 @@ class HTTP204NoContentTestCase(AsyncHTTPTestCase):
 
     def test_204_invalid_content_length(self):
         # 204 status with non-zero content length is malformed
-        with ExpectLog(gen_log, "Malformed HTTP message"):
-            response = self.fetch("/?error=1")
-            if not self.http1:
-                self.skipTest("requires HTTP/1.x")
+        response = self.fetch("/?error=1")
+        if not self.http1:
+            self.skipTest("requires HTTP/1.x")
+        if self.http_client.configured_class != SimpleAsyncHTTPClient:
+            self.skipTest("curl client accepts invalid headers")
         self.assertEqual(response.code, 599)
 
 

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1397,6 +1397,19 @@ class ClearHeaderTest(SimpleHandlerTestCase):
         self.assertEqual(response.headers["h2"], "bar")
 
 
+class Header204Test(SimpleHandlerTestCase):
+    class Handler(RequestHandler):
+        def get(self):
+            self.set_status(204)
+            self.finish()
+
+    def test_204_headers(self):
+        response = self.fetch('/')
+        self.assertEqual(response.code, 204)
+        self.assertNotIn("Content-Length", response.headers)
+        self.assertNotIn("Transfer-Encoding", response.headers)
+
+
 @wsgi_safe
 class Header304Test(SimpleHandlerTestCase):
     class Handler(RequestHandler):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -935,8 +935,8 @@ class RequestHandler(object):
                 if self.check_etag_header():
                     self._write_buffer = []
                     self.set_status(304)
-            if self._status_code == 304:
-                assert not self._write_buffer, "Cannot send body with 304"
+            if self._status_code in (204, 304):
+                assert not self._write_buffer, "Cannot send body with %s" % self._status_code
                 self._clear_headers_for_304()
             elif "Content-Length" not in self._headers:
                 content_length = sum(len(part) for part in self._write_buffer)


### PR DESCRIPTION
These changes relate to #1736:

* http1connection now also considers 204 to decide when chunking isn't necessary
* RequestHandler now also asserts the write buffer is empty for 204 responses