### PR TITLE
Fix pycurl UnicodeEncodeError

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -281,8 +281,6 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         return curl
 
     def _curl_setup_request(self, curl, request, buffer, headers):
-        curl.setopt(pycurl.URL, native_str(request.url))
-
         # libcurl's magic "Expect: 100-continue" behavior causes delays
         # with servers that don't support it (which include, among others,
         # Google's OpenID endpoint).  Additionally, this behavior has
@@ -311,6 +309,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         else:
             write_function = buffer.write
         if bytes is str:  # py2
+            curl.setopt(pycurl.URL, native_str(request.url))
             curl.setopt(pycurl.WRITEFUNCTION, write_function)
         else:  # py3
             # Upstream pycurl doesn't support py3, but ubuntu 12.10 includes
@@ -320,6 +319,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             # download arbitrary binary data.  This needs to be fixed in the
             # ported pycurl package, but in the meantime this lambda will
             # make it work for downloading (utf8) text.
+            curl.setopt(pycurl.URL, native_str(request.url).encode())
             curl.setopt(pycurl.WRITEFUNCTION, lambda s: write_function(utf8(s)))
         curl.setopt(pycurl.FOLLOWLOCATION, request.follow_redirects)
         curl.setopt(pycurl.MAXREDIRS, request.max_redirects)


### PR DESCRIPTION
Under Python 3, PycURL accepts bytes values for options.

[pycurl-setting-options-in-python3.x](http://pycurl.io/docs/latest/unicode.html#setting-options-python-3-x)


    url = 'http://m.sohu.com/weather/?v=1&city=北京'
    c.setopt(pycurl.URL, native_str(url))
    UnicodeEncodeError: 'ascii' codec can't encode characters in position 36-37: ordinal not in range(128)