### PR TITLE
Fail early if a v1 cookie is submitted to a service configured with v2

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -3189,7 +3189,7 @@ def decode_signed_value(secret, name, value, max_age_days=31,
 
     if version < min_version:
         return None
-    if version == 1:
+    if version == 1 and not isinstance(secret, dict):
         return _decode_signed_value_v1(secret, name, value,
                                        max_age_days, clock)
     elif version == 2:


### PR DESCRIPTION
Currently, if 'secret' is a dict and a v1 cookie is submitted, the utf8() function that is later called on secret in the v1 signing function throws a ValueError. The correct behaviour would be to return None.
