### PR TITLE
Mocks for async tornado functions

### DIFF
--- a/docs/mock.rst
+++ b/docs/mock.rst
@@ -1,0 +1,8 @@
+``tornado.mock`` --- Mocks for asynchronous code
+================================================
+
+.. automodule:: tornado.mock
+
+   .. autoclass:: TaskMock
+
+   .. autoclass:: FutureMock

--- a/docs/mock.rst
+++ b/docs/mock.rst
@@ -3,6 +3,4 @@
 
 .. automodule:: tornado.mock
 
-   .. autoclass:: TaskMock
-
-   .. autoclass:: FutureMock
+   .. autoclass:: AsyncMock

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -8,4 +8,5 @@ Utilities
    options
    stack_context
    testing
+   mock
    util

--- a/tornado/mock.py
+++ b/tornado/mock.py
@@ -1,0 +1,66 @@
+"""
+Mocks for mocking-out asynchronous functions. Works the same way as
+`unittest.mock.Mock` from Python standard library.
+
+Note when you are using older Python than 3.3 you have to install
+module ``mock``.
+"""
+from __future__ import absolute_import
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from tornado import gen
+
+
+class TaskMock(mock.Mock):
+    """
+    Mock allowing to mock-out code wrapped in `tornado.gen.Task`. Function
+    ``Task`` passes param ``callback`` which has to be called to resolve
+    `Future <tornado.concurrent.Future>` instance.
+
+    Suitable for mocking ``call_some_sync_api`` from following example:
+
+    .. code-block:: python
+
+        @tornado.gen.coroutine
+        def post():
+            value = yield self.method()
+
+        @tornado.gen.coroutine
+        def method():
+            yield tornado.gen.Task(call_some_sync_api)
+    """
+    def _mock_call(self, *args, **kwds):
+        res = super(TaskMock, self)._mock_call(*args, **kwds)
+        callback = kwds.get('callback')
+        if callback:
+            callback(res)
+        return res
+
+
+class FutureMock(mock.Mock):
+    """
+    Mock allowing to mock-out code which should return
+    `Future <tornado.concurrent.Future>` instance. For example
+    code decorated by `tornado.gen.coroutine`.
+
+    Suitable for mocking ``method`` from following example:
+
+    .. code-block:: python
+
+        @tornado.gen.coroutine
+        def post():
+            value = yield self.method()
+
+        @tornado.gen.coroutine
+        def method():
+            yield tornado.gen.Task(call_some_sync_api)
+    """
+    def _mock_call(self, *args, **kwds):
+        res = super(FutureMock, self)._mock_call(*args, **kwds)
+        future = gen.Future()
+        future.set_result(res)
+        return future

--- a/tornado/test/mock_test.py
+++ b/tornado/test/mock_test.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from tornado.test.util import unittest
+from tornado.mock import FutureMock, TaskMock
+from tornado import gen
+
+
+class TaskMockTest(unittest.TestCase):
+    def test_called_callback(self):
+        callback = mock.Mock()
+        task_mock = TaskMock(return_value=42)
+        result = task_mock(callback=callback)
+        self.assertEqual(result, 42)
+        callback.assert_called_once_with(42)
+
+
+class FutureMockTest(unittest.TestCase):
+    def test_returns_future(self):
+        future_mock = FutureMock(return_value=42)
+        result = future_mock()
+        self.assertIsInstance(result, gen.Future)
+        self.assertEqual(result.result(), 42)

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -40,6 +40,7 @@ TEST_MODULES = [
     'tornado.test.locks_test',
     'tornado.test.netutil_test',
     'tornado.test.log_test',
+    'tornado.test.mock_test',
     'tornado.test.options_test',
     'tornado.test.process_test',
     'tornado.test.queues_test',


### PR DESCRIPTION
Hi. I created some mocks to be able mock-out some async tornado functions. I used them a lot in several projects and I wanted to make library, but I think it can be included in Tornado which is more handy.

I made it in separate module because it needs also mock library which has to be installed prior Python 3.3. So it's not problem if someone don't want use those mocks in older Python but wants use testing module.
