### PR TITLE
This unit test demonstrates a breaking change between 4.3 and 4.4

### DIFF
--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -782,3 +782,21 @@ class ChunkedWithContentLengthTest(AsyncHTTPTestCase):
                                  "with both Transfer-Encoding and Content-Length")):
             response = self.fetch('/chunkwithcl')
         self.assertEqual(response.code, 599)
+
+
+class RawStringRegexTest(AsyncHTTPTestCase):
+
+    def get_http_client(self):
+        return SimpleAsyncHTTPClient()
+
+    def get_app(self):
+        class RawStringRegex(RequestHandler):
+            def get(self, bar):
+                self.write(bar)
+
+        return Application([(r'^/api/v\d+/foo/(\w+)$', RawStringRegex)])
+
+    def test_raw_string_regex(self):
+        response = self.fetch('/api/v1/foo/bar')
+        response.rethrow()
+        self.assertEqual(response.body, b'bar')


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/aheinz-fe/Documents/GitHub/tornado/tornado/testing.py", line 380, in setUp
    self._app = self.get_app()
  File "/Users/aheinz-fe/Documents/GitHub/tornado/tornado/test/simple_httpclient_test.py", line 797, in get_app
    return Application([(r'^/api/v\d+/foo/(\w+)$', RawStringRegex)])
  File "/Users/aheinz-fe/Documents/GitHub/tornado/tornado/web.py", line 1814, in __init__
    self.add_handlers(".*$", handlers)
  File "/Users/aheinz-fe/Documents/GitHub/tornado/tornado/web.py", line 1875, in add_handlers
    spec = URLSpec(*spec)
  File "/Users/aheinz-fe/Documents/GitHub/tornado/tornado/web.py", line 3028, in __init__
    self._path, self._group_count = self._find_groups()
  File "/Users/aheinz-fe/Documents/GitHub/tornado/tornado/web.py", line 3062, in _find_groups
    raise ValueError(exc.args[0] + '; invalid url: %r' % pattern)
ValueError: cannot unescape '\\d'; invalid url: '/api/v\\d+/foo/(\\w+)'
```