### PR TITLE
HTTPResponse.body is bytes instead of str in Python 3

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -43,6 +43,7 @@ from __future__ import absolute_import, division, print_function, with_statement
 import functools
 import time
 import weakref
+import cgi
 
 from tornado.concurrent import TracebackFuture
 from tornado.escape import utf8, native_str
@@ -577,7 +578,20 @@ class HTTPResponse(object):
         if self.buffer is None:
             return None
         elif self._body is None:
-            self._body = self.buffer.getvalue()
+            encoding = 'ascii'
+
+            if 'Content-Type' in self.headers:
+                _content_type, params = cgi.parse_header(
+                    self.headers['Content-Type'])
+
+                if 'charset' in params:
+                    encoding = params['charset'].strip("'\"")
+
+            try:
+                self._body = self.buffer.getvalue().decode(encoding=encoding)
+            except UnicodeError:
+                self._body = self.buffer.getvalue().decode(encoding=encoding,
+                                                           errors='replace')
 
         return self._body
 


### PR DESCRIPTION
The documentation of `HTTPResponse` states as follows:
`body: response body as string (created on demand from ``self.buffer``)`

In Python 3, body has type `bytes` which causes problems with dependent libraries (e.g., `nsq-py`).

```
from tornado.httpclient import HTTPRequest, AsyncHTTPClient
import tornado.ioloop


def _callback(response):
    print(repr(response.body))

http_client = AsyncHTTPClient()

req = HTTPRequest(
    "https://httpbin.org/get", method='GET')
http_client.fetch(req, callback=_callback)

tornado.ioloop.IOLoop.current().start()
```