### PR TITLE
Fix for uppercase "Transfer-Encoding" values

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -565,7 +565,7 @@ class HTTP1Connection(httputil.HTTPConnection):
 
         if content_length is not None:
             return self._read_fixed_body(content_length, delegate)
-        if headers.get("Transfer-Encoding") == "chunked":
+        if headers.get("Transfer-Encoding", "").lower() == "chunked":
             return self._read_chunked_body(delegate)
         if self.is_client:
             return self._read_body_until_close(delegate)

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -441,6 +441,25 @@ bar
         headers, response = self.wait()
         self.assertEqual(json_decode(response), {u'foo': [u'bar']})
 
+    def test_chunked_request_uppercase(self):
+        # As per RFC 2616 section 3.6, "Transfer-Encoding" header's value is
+        # case-insensitive.
+        self.stream.write(b"""\
+POST /echo HTTP/1.1
+Transfer-Encoding: Chunked
+Content-Type: application/x-www-form-urlencoded
+
+4
+foo=
+3
+bar
+0
+
+""".replace(b"\n", b"\r\n"))
+        read_stream_body(self.stream, self.stop)
+        headers, response = self.wait()
+        self.assertEqual(json_decode(response), {u'foo': [u'bar']})
+
     def test_invalid_content_length(self):
         with ExpectLog(gen_log, '.*Only integer Content-Length is allowed'):
             self.stream.write(b"""\


### PR DESCRIPTION
As per [RFC 2616 section 3.6](https://tools.ietf.org/html/rfc2616#section-3.6), "Transfer-Encoding" header's value is case-insensitive.

It turned out that Cocoa's NSURLConnection sends `Transfer-Encoding: Chunked` (starting with a capital letter), which makes Tornado ignore the actual request body. 