### PR TITLE
Tie Runner lifetime to lifetime of result future or coroutine function (whichever is GCed first)

### DIFF
--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, with_statement
 
+import gc
 import contextlib
 import datetime
 import functools
@@ -24,7 +25,6 @@ try:
     from concurrent import futures
 except ImportError:
     futures = None
-
 
 class GenEngineTest(AsyncTestCase):
     def setUp(self):
@@ -1367,6 +1367,29 @@ class WaitIteratorTest(AsyncTestCase):
         yield gen.with_timeout(datetime.timedelta(seconds=0.1),
                                gen.WaitIterator(gen.sleep(0)).next())
 
+
+class RunnerGCTest(AsyncTestCase):
+    """Github issue 1769: Runner objects can get GCed unexpectedly"""
+    @gen_test
+    def test_gc(self):
+        """Runners shouldn't GC if future is alive"""
+        # Create the weakref
+        weakref_scope = [None]
+        def callback():
+            gc.collect(2)
+            weakref_scope[0]().set_result(123)
+
+        @gen.coroutine
+        def tester():
+            fut = Future()
+            weakref_scope[0] = weakref.ref(fut)
+            self.io_loop.add_callback(callback)
+            yield fut
+
+        yield gen.with_timeout(
+            datetime.timedelta(seconds=0.2),
+            tester()
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This changeset fixes #1769 to my satisfaction (and I hope everyone else's).

My changeset causes the `gen.coroutine` (and `gen.engine`, I think) to keep a `WeakKeyDictionary` mapping result futures to `Runner` objects. This `WeakKeyDictionary` is ~~closured to the coroutine generator function itself~~ a global.

The resulting behavior is that, if there exists hard references to the result future object ~~*and* to the coroutine function~~, the `Runner` object will not die.

**Everything below is no longer relevant but I'm keeping it for historical reasons**

In addition, I added a `__del__` method to the `Runner` object (In Python > 3.4 only) which causes it to "cancel" (load with an exception, since tornado's futures don't have cancel semantics) the result future if the `Runner` is collected before it is completed. This prevents applications from hanging forever waiting on futures that will never complete.

Things I'm still concerned about:

 * I am a little bit concerned about my last change with `__del__` since it could cause "working" code to start spamming "future exception never cleaned up" notices if they somehow made a habit out of getting their `Runner`'s collected. It is difficult to imagine a situation where `Runner`s being garbage collected before the future has a result being a desired behavior, though.

* I'm also not entirely sure how this interacts with other code like `WaitIterator` where multiple futures' results are tied together (would their runners get GCed and give weird exceptions in the log instead of finishing?). But the unit tests pass so what could go wrong right?

* I copy and pasted `_GC_CYCLE_FINALIZERS` from `tornado.concurrent`. Maybe the symbol should have been imported instead, but the fact it is "private" made me a bit nervous about that.