### PR TITLE
Add import tcpclient test in import_test

### DIFF
--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -11,7 +11,6 @@ class ImportTest(unittest.TestCase):
         import tornado.auth
         import tornado.autoreload
         import tornado.concurrent
-        # import tornado.curl_httpclient  # depends on pycurl
         import tornado.escape
         import tornado.gen
         import tornado.http1connection
@@ -28,6 +27,7 @@ class ImportTest(unittest.TestCase):
         import tornado.simple_httpclient
         import tornado.stack_context
         import tornado.tcpserver
+        import tornado.tcpclient
         import tornado.template
         import tornado.testing
         import tornado.util


### PR DESCRIPTION
When I read the import_test.py, I found out the the import test for tcpclient is missing. This PR add the missing import check.

- Add test for import tcpclient
- Remove comment line.