### PR TITLE
Deprecate libcurl < 7.21.5 ?

### DIFF
--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, with_statement
 
 from hashlib import md5
 
+from tornado import netutil
 from tornado.escape import utf8
 from tornado.httpclient import HTTPRequest
 from tornado.stack_context import ExceptionStackContext
@@ -132,3 +133,25 @@ class CurlHTTPClientTestCase(AsyncHTTPTestCase):
         for i in range(5):
             response = self.fetch(u'/ユニコード')
             self.assertIsNot(response.error, None)
+
+    def test_timeout_must_close_connection(self):
+        server_sock, port = httpclient_test.bind_unused_port()
+        client_sock = [None]
+
+        def accept_callback(conn, address):
+            client_sock[0] = conn
+            conn.recv(1024)
+
+        netutil.add_accept_handler(server_sock, accept_callback, self.io_loop)
+        self.http_client.fetch(HTTPRequest("http://127.0.0.1:%d/" % port, request_timeout=1), self.stop)
+        response = self.wait()
+
+        self.assertEqual(response.code, 599)
+
+        # The socket must be closed
+        client_sock[0].setblocking(0)
+
+        try:
+            self.assertEqual(client_sock[0].recv(1024), b"", msg="Socket must be closed")
+        except IOError as e:
+            self.fail("Socket must be closed, but instead %s was raised" % e)


### PR DESCRIPTION
libcurl < 7.21.5 has a nasty bug in Curl_multi implementation — when a request times out, the connection is not closed properly. Later this connection could be reused and you could find yourself with the response from an another request.

We actually ran into this problem a couple of years ago with libcurl 7.21.3, but as we didn't realize that this was a libcurl bug, we just turned on the FRESH_CONNECT option (it's turned off by default and turning it on may affect performance).

The bug was fixed in version 7.21.5 (https://github.com/curl/curl/commit/c4369f34b9b493cbed4e7bcafa77614e9d55055d), but Tornado supports libcurl from 7.21.1 (https://github.com/tornadoweb/tornado/blob/d1cab4aff57e000d351d168210a71377c8111726/tornado/httpclient.py#L27). (Ubuntu 11.10 is shipped with libcurl 7.21.6)

In this pull request I added a simple unittest that reproduces the problem: it fails with libcurl < 7.21.5 and works correctly with newer versions.

I guess there are several ways to fix this problem:
* update the minimum supported libcurl version in the docs
* check libcurl version during CurlAsyncHTTPClient initialization and issue a deprecation warning or raise an exception

I propose that we do both (an update of the docs and a deprecation warning) — these old libcurl versions just don't work properly with the default settings and it could be a huge pain in all sorts of places to fix that. If that's ok, I'm prepared to commit the neccessary changes.