### PR TITLE
Enable color logging on Windows via colorama

### DIFF
--- a/tornado/log.py
+++ b/tornado/log.py
@@ -57,15 +57,16 @@ gen_log = logging.getLogger("tornado.general")
 
 def _stderr_supports_color():
     color = False
-    if curses and hasattr(sys.stderr, 'isatty') and sys.stderr.isatty():
-        try:
-            curses.setupterm()
-            if curses.tigetnum("colors") > 0:
-                color = True
-        except Exception:
-            pass
-    elif colorama and os.isatty(sys.stderr.fileno()):
-        color = True
+    if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty():
+        if curses:
+            try:
+                curses.setupterm()
+                if curses.tigetnum("colors") > 0:
+                    color = True
+            except Exception:
+                pass
+        elif colorama:
+            color = True
     return color
 
 

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -119,26 +119,29 @@ class LogFormatter(logging.Formatter):
         self._fmt = fmt
 
         self._colors = {}
-        if color and _stderr_supports_color() and curses is not None:
-            # The curses module has some str/bytes confusion in
-            # python3.  Until version 3.2.3, most methods return
-            # bytes, but only accept strings.  In addition, we want to
-            # output these strings with the logging module, which
-            # works with unicode strings.  The explicit calls to
-            # unicode() below are harmless in python2 but will do the
-            # right conversion in python 3.
-            fg_color = (curses.tigetstr("setaf") or
-                        curses.tigetstr("setf") or "")
-            if (3, 0) < sys.version_info < (3, 2, 3):
-                fg_color = unicode_type(fg_color, "ascii")
+        if color and _stderr_supports_color():
+            if curses is not None:
+                # The curses module has some str/bytes confusion in
+                # python3.  Until version 3.2.3, most methods return
+                # bytes, but only accept strings.  In addition, we want to
+                # output these strings with the logging module, which
+                # works with unicode strings.  The explicit calls to
+                # unicode() below are harmless in python2 but will do the
+                # right conversion in python 3.
+                fg_color = (curses.tigetstr("setaf") or
+                            curses.tigetstr("setf") or "")
+                if (3, 0) < sys.version_info < (3, 2, 3):
+                    fg_color = unicode_type(fg_color, "ascii")
 
-            for levelno, code in colors.items():
-                self._colors[levelno] = unicode_type(curses.tparm(fg_color, code), "ascii")
-            self._normal = unicode_type(curses.tigetstr("sgr0"), "ascii")
-        elif colorama is not None:
-            for levelno, code in colors.items():
-                self._colors[levelno] = '\033[2;3%dm' % code
-            self._normal = '\033[0m'
+                for levelno, code in colors.items():
+                    self._colors[levelno] = unicode_type(curses.tparm(fg_color, code), "ascii")
+                self._normal = unicode_type(curses.tigetstr("sgr0"), "ascii")
+            elif colorama is not None:
+                for levelno, code in colors.items():
+                    self._colors[levelno] = '\033[2;3%dm' % code
+                self._normal = '\033[0m'
+            else:
+                raise RuntimeError("No supported color terminal library")
         else:
             self._normal = ''
 

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -40,7 +40,6 @@ from tornado.util import unicode_type, basestring_type
 
 try:
     import colorama
-    colorama.init()
 except ImportError:
     colorama = None
 
@@ -89,6 +88,13 @@ class LogFormatter(logging.Formatter):
     This formatter is enabled automatically by
     `tornado.options.parse_command_line` or `tornado.options.parse_config_file`
     (unless ``--logging=none`` is used).
+
+    Color support on Windows versions that do not support ANSI color codes is
+    enabled by use of the colorama__ library. Applications that wish to use
+    this must first initialize colorama with a call to :func:`colorama.init`.
+    See the colorama documentation for details.
+
+    __ https://pypi.python.org/pypi/colorama
     """
     DEFAULT_FORMAT = '%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]%(end_color)s %(message)s'
     DEFAULT_DATE_FORMAT = '%y%m%d %H:%M:%S'
@@ -137,7 +143,7 @@ class LogFormatter(logging.Formatter):
                 for levelno, code in colors.items():
                     self._colors[levelno] = unicode_type(curses.tparm(fg_color, code), "ascii")
                 self._normal = unicode_type(curses.tigetstr("sgr0"), "ascii")
-            elif colorama is not None:
+            elif sys.stderr is getattr(colorama, 'wrapped_stderr', object()):
                 for levelno, code in colors.items():
                     self._colors[levelno] = '\033[2;3%dm' % code
                 self._normal = '\033[0m'

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -91,7 +91,7 @@ class LogFormatter(logging.Formatter):
 
     Color support on Windows versions that do not support ANSI color codes is
     enabled by use of the colorama__ library. Applications that wish to use
-    this must first initialize colorama with a call to :func:`colorama.init`.
+    this must first initialize colorama with a call to ``colorama.init``.
     See the colorama documentation for details.
 
     __ https://pypi.python.org/pypi/colorama

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -119,7 +119,7 @@ class LogFormatter(logging.Formatter):
         self._fmt = fmt
 
         self._colors = {}
-        if color and _stderr_supports_color() and not colorama:
+        if color and _stderr_supports_color() and curses is not None:
             # The curses module has some str/bytes confusion in
             # python3.  Until version 3.2.3, most methods return
             # bytes, but only accept strings.  In addition, we want to
@@ -135,9 +135,9 @@ class LogFormatter(logging.Formatter):
             for levelno, code in colors.items():
                 self._colors[levelno] = unicode_type(curses.tparm(fg_color, code), "ascii")
             self._normal = unicode_type(curses.tigetstr("sgr0"), "ascii")
-        elif colorama:
+        elif colorama is not None:
             for levelno, code in colors.items():
-                self._colors[levelno] = '\033[3{}m'.format(code)
+                self._colors[levelno] = '\033[2;3%dm' % code
             self._normal = '\033[0m'
         else:
             self._normal = ''


### PR DESCRIPTION
This is a slight rework of #1487 which was closed when I reorganized my clone. I'm not sure what the proper way to test this would be, but I used the following script to visually check that the output does as expected:

``` python
import logging
from tornado.log import enable_pretty_logging

logger = logging.getLogger()
enable_pretty_logging()
logger.setLevel(logging.DEBUG)

logger.info("INFO")
logger.warning("WARNING")
logger.debug("DEBUG")
logger.error("ERROR")
print("normal")
```
