### PR TITLE
404 if no handlers are configured and default_host is empty

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2834,3 +2834,16 @@ class URLSpecReverseTest(unittest.TestCase):
     def test_reverse_arguments(self):
         self.assertEqual('/api/v1/foo/bar',
                          url(r'^/api/v1/foo/(\w+)$', None).reverse('bar'))
+
+
+@wsgi_safe
+class EmptyHandlerListTest(WebTestCase):
+    # issue #1738
+    # If the handler list is empty and default_host is not configured,
+    # tornado should return 404 instead of redirecting (301) to http:///
+    def get_handlers(self):
+        return []
+
+    def test_404_when_no_handlers_configured(self):
+        response = self.fetch('/404')
+        self.assertEqual(response.code, 404)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2001,29 +2001,31 @@ class _RequestDispatcher(httputil.HTTPMessageDelegate):
         app = self.application
         handlers = app._get_host_handlers(self.request)
         if not handlers:
-            self.handler_class = RedirectHandler
-            self.handler_kwargs = dict(url="%s://%s/"
-                                       % (self.request.protocol,
-                                          app.default_host))
-            return
-        for spec in handlers:
-            match = spec.regex.match(self.request.path)
-            if match:
-                self.handler_class = spec.handler_class
-                self.handler_kwargs = spec.kwargs
-                if spec.regex.groups:
-                    # Pass matched groups to the handler.  Since
-                    # match.groups() includes both named and
-                    # unnamed groups, we want to use either groups
-                    # or groupdict but not both.
-                    if spec.regex.groupindex:
-                        self.path_kwargs = dict(
-                            (str(k), _unquote_or_none(v))
-                            for (k, v) in match.groupdict().items())
-                    else:
-                        self.path_args = [_unquote_or_none(s)
-                                          for s in match.groups()]
+            if app.default_host:
+                self.handler_class = RedirectHandler
+                self.handler_kwargs = dict(url="%s://%s/"
+                                           % (self.request.protocol,
+                                              app.default_host))
                 return
+        else:
+            for spec in handlers:
+                match = spec.regex.match(self.request.path)
+                if match:
+                    self.handler_class = spec.handler_class
+                    self.handler_kwargs = spec.kwargs
+                    if spec.regex.groups:
+                        # Pass matched groups to the handler.  Since
+                        # match.groups() includes both named and
+                        # unnamed groups, we want to use either groups
+                        # or groupdict but not both.
+                        if spec.regex.groupindex:
+                            self.path_kwargs = dict(
+                                (str(k), _unquote_or_none(v))
+                                for (k, v) in match.groupdict().items())
+                        else:
+                            self.path_args = [_unquote_or_none(s)
+                                              for s in match.groups()]
+                    return
         if app.settings.get('default_handler_class'):
             self.handler_class = app.settings['default_handler_class']
             self.handler_kwargs = app.settings.get(


### PR DESCRIPTION
For #1738:
- Guard the `RedirectHandler` with `if app.default_host` in `_RequestDispatcher._find_handler`
- Added `web_test.EmptyHandlerListTest`

Maybe consider updating the comment in `web_test.ErrorHandlerXSRFTest.get_handlers`
