### PR TITLE
io_loop: Don't spin CPU if callback returns {}

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -616,9 +616,13 @@ class IOLoop(Configurable):
                     # result, which should just be ignored.
                     pass
                 else:
-                    self.add_future(ret, lambda f: f.result())
+                    self.add_future(ret, self._discard_future_result)
         except Exception:
             self.handle_callback_exception(callback)
+
+    def _discard_future_result(self, future):
+        """Avoid unhandled-exception warnings from spawned coroutines."""
+        future.result()
 
     def handle_callback_exception(self, callback):
         """This method is called whenever a callback run by the `IOLoop`


### PR DESCRIPTION
Fixes #1803 by preventing _run_callback from directly calling
add_callback again when a callback returns {} or [].