### PR TITLE
Simple refactoring: Isolating parameters as class member variables

### DIFF
--- a/tornado/platform/common.py
+++ b/tornado/platform/common.py
@@ -30,6 +30,11 @@ class Waker(interface.Waker):
     be passed to select()), but do have sockets.  This includes Windows
     and Jython.
     """
+
+    BUFFER_SIZE = 1024  # Socket communication buffer size
+    MAX_QUEUED_CONNECTIONS = 1  # Maximum number of queued connections
+    LOCAL_ADDR = "127.0.0.1"
+
     def __init__(self):
         # Based on Zope select_trigger.py:
         # https://github.com/zopefoundation/Zope/blob/master/src/ZServer/medusa/thread/select_trigger.py
@@ -40,7 +45,7 @@ class Waker(interface.Waker):
         self.writer.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
         count = 0
-        while 1:
+        while True:
             count += 1
             # Bind to a local port; for efficiency, let the OS pick
             # a free port for us.
@@ -53,8 +58,9 @@ class Waker(interface.Waker):
             # http://mail.zope.org/pipermail/zope/2005-July/160433.html
             # for hideous details.
             a = socket.socket()
-            a.bind(("127.0.0.1", 0))
-            a.listen(1)
+            a.bind((self.LOCAL_ADDR, 0))
+            a.listen(self.MAX_QUEUED_CONNECTIONS)
+
             connect_address = a.getsockname()  # assigned (host, port) pair
             try:
                 self.writer.connect(connect_address)
@@ -97,8 +103,7 @@ class Waker(interface.Waker):
     def consume(self):
         try:
             while True:
-                result = self.reader.recv(1024)
-                if not result:
+                if not self.reader.recv(self.BUFFER_SIZE):
                     break
         except (IOError, socket.error):
             pass


### PR DESCRIPTION
This pull request has only simple modifications on the Waker class.

Generally, I've isolated parameters like, buffer size, local address and maximum number of queued connections to be a class members. Ii turns the class more extensible. 

No big logic modification or interface changes were made.  