### PR TITLE
Avoid spurious warnings at shutdown

### DIFF
--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -25,9 +25,10 @@ from tornado.concurrent import Future, return_future, ReturnValueIgnoredError, r
 from tornado.escape import utf8, to_unicode
 from tornado import gen
 from tornado.iostream import IOStream
+from tornado.log import app_log
 from tornado import stack_context
 from tornado.tcpserver import TCPServer
-from tornado.testing import AsyncTestCase, LogTrapTestCase, bind_unused_port, gen_test
+from tornado.testing import AsyncTestCase, ExpectLog, LogTrapTestCase, bind_unused_port, gen_test
 from tornado.test.util import unittest
 
 
@@ -170,6 +171,23 @@ class ReturnFutureTest(AsyncTestCase):
         except ZeroDivisionError:
             tb = traceback.extract_tb(sys.exc_info()[2])
             self.assertIn(self.expected_frame, tb)
+
+    @gen_test
+    def test_uncaught_exception_log(self):
+        @gen.coroutine
+        def f():
+            yield gen.moment
+            1/0
+
+        g = f()
+
+        with ExpectLog(app_log,
+                       "(?s)Future.* exception was never retrieved:"
+                       ".*ZeroDivisionError"):
+            yield gen.moment
+            yield gen.moment
+            del g
+
 
 # The following series of classes demonstrate and test various styles
 # of use, with and without generators and futures.

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -15,6 +15,7 @@
 # under the License.
 from __future__ import absolute_import, division, print_function, with_statement
 
+import gc
 import logging
 import re
 import socket
@@ -187,6 +188,7 @@ class ReturnFutureTest(AsyncTestCase):
             yield gen.moment
             yield gen.moment
             del g
+            gc.collect()  # for PyPy
 
 
 # The following series of classes demonstrate and test various styles

--- a/tornado/test/util_test.py
+++ b/tornado/test/util_test.py
@@ -6,7 +6,7 @@ import datetime
 
 import tornado.escape
 from tornado.escape import utf8
-from tornado.util import raise_exc_info, Configurable, exec_in, ArgReplacer, timedelta_to_seconds, import_object, re_unescape, PY3
+from tornado.util import raise_exc_info, Configurable, exec_in, ArgReplacer, timedelta_to_seconds, import_object, re_unescape, is_finalizing, PY3
 from tornado.test.util import unittest
 
 if PY3:
@@ -220,3 +220,8 @@ class ReUnescapeTest(unittest.TestCase):
             re_unescape('\\b')
         with self.assertRaises(ValueError):
             re_unescape('\\Z')
+
+
+class IsFinalizingTest(unittest.TestCase):
+    def test_basic(self):
+        self.assertFalse(is_finalizing())

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -76,7 +76,8 @@ except ImportError:
         atexit.register(lambda: L.append(None))
 
         def is_finalizing():
-            return bool(L)
+            # Not referencing any globals here
+            return L != []
 
         return is_finalizing
 

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -13,6 +13,7 @@ and `.Resolver`.
 from __future__ import absolute_import, division, print_function, with_statement
 
 import array
+import atexit
 import os
 import re
 import sys
@@ -64,6 +65,22 @@ else:
         _BaseString = str
     else:
         _BaseString = Union[bytes, unicode_type]
+
+
+try:
+    from sys import is_finalizing
+except ImportError:
+    # Emulate it
+    def _get_emulated_is_finalizing():
+        L = []
+        atexit.register(lambda: L.append(None))
+
+        def is_finalizing():
+            return bool(L)
+
+        return is_finalizing
+
+    is_finalizing = _get_emulated_is_finalizing()
 
 
 class ObjectDict(_ObjectDictBase):


### PR DESCRIPTION
When there are still active coroutines at interpreter shutdown, you can see sometimes warnings such as:
```
Exception ignored in: <bound method Future.__del__ of <tornado.concurrent.Future object at 0x7f56a8b142e8>>
Traceback (most recent call last):
  File "/home/antoine/tornado/tornado/concurrent.py", line 338, in __del__
TypeError: 'NoneType' object is not callable
```

These are distracting and don't bear any useful information, so silence them.