### PR TITLE
Fix #1901: fix TCPServer.stop() when called twice

### DIFF
--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -109,6 +109,7 @@ class TCPServer(object):
         self._sockets = {}  # fd -> socket object
         self._pending_sockets = []
         self._started = False
+        self._stopped = False
         self.max_buffer_size = max_buffer_size
         self.read_chunk_size = read_chunk_size
 
@@ -227,7 +228,11 @@ class TCPServer(object):
         Requests currently in progress may still continue after the
         server is stopped.
         """
+        if self._stopped:
+            return
+        self._stopped = True
         for fd, sock in self._sockets.items():
+            assert sock.fileno() == fd
             self.io_loop.remove_handler(fd)
             sock.close()
 

--- a/tornado/test/tcpserver_test.py
+++ b/tornado/test/tcpserver_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, with_statement
+
 import socket
 
 from tornado import gen
@@ -37,3 +38,11 @@ class TCPServerTest(AsyncTestCase):
                 server.stop()
             if client is not None:
                 client.close()
+
+    def test_stop_twice(self):
+        sock, port = bind_unused_port()
+        server = TCPServer()
+        server.add_socket(sock)
+        server.stop()
+        server.stop()
+


### PR DESCRIPTION
If called a second time, `TCPServer.stop` could call `remove_handler()` with its file descriptors *again*, which really means unregistering the file descriptors of non-TCPServer sockets (since the average Unix system will tend to re-use fd numbers), leading to obscure bugs.