### PR TITLE
sphinx: Set the html_theme variable explicitly.

### DIFF
--- a/website/sphinx/conf.py
+++ b/website/sphinx/conf.py
@@ -41,6 +41,7 @@ coverage_ignore_functions = [
 ]
     
 html_static_path = [os.path.abspath("../static")]
+html_theme = 'default'
 html_style = "sphinx.css"
 highlight_language = "none"
 html_theme_options = dict(


### PR DESCRIPTION
This should let our custom css show on readthedocs.org.