### PR TITLE
Catch AttributeError in cpu_count()

### DIFF
--- a/tornado/process.py
+++ b/tornado/process.py
@@ -67,7 +67,7 @@ def cpu_count():
         pass
     try:
         return os.sysconf("SC_NPROCESSORS_CONF")
-    except ValueError:
+    except (AttributeError, ValueError):
         pass
     gen_log.error("Could not detect number of processors; assuming 1")
     return 1


### PR DESCRIPTION
```
=================================== ERRORS ====================================
______________________________ ERROR collecting  ______________________________
.tox\tox\lib\site-packages\py\_path\common.py:332: in visit
    for x in Visitor(fil, rec, ignore, bf, sort).gen(self):
.tox\tox\lib\site-packages\py\_path\common.py:378: in gen
    for p in self.gen(subdir):
.tox\tox\lib\site-packages\py\_path\common.py:368: in gen
    if p.check(dir=1) and (rec is None or rec(p))])
.tox\tox\lib\site-packages\_pytest\main.py:670: in _recurse
    ihook = self.gethookproxy(path)
.tox\tox\lib\site-packages\_pytest\main.py:575: in gethookproxy
    my_conftestmodules = pm._getconftestmodules(fspath)
.tox\tox\lib\site-packages\_pytest\config.py:339: in _getconftestmodules
    mod = self._importconftest(conftestpath)
.tox\tox\lib\site-packages\_pytest\config.py:364: in _importconftest
    raise ConftestImportFailure(conftestpath, sys.exc_info())
E   ConftestImportFailure: AttributeError("'module' object has no attribute 'sysconf'",)
```

Running
```Python 2.7.12 (v2.7.12:d33e0cf91556, Jun 27 2016, 15:24:40) [MSC v.1500 64 bit (AMD64)] on win32```
on Windows 10 64 Bit.

Noticed this issue while running ```tox 2.5.0``` with ```pytest-tornado 0.4.5``` and ```tornado 4.4.2```.

The issue is that [os.sysconf()](https://docs.python.org/2/library/os.html#os.sysconf) is only available for Unix systems.