### PR TITLE
Allow custom websocket upgrade response headers

### DIFF
--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -22,7 +22,7 @@
 
    .. automethod:: WebSocketHandler.write_message
    .. automethod:: WebSocketHandler.close
-   .. automethod:: WebSocketHandler.upgrade_response_headers
+   .. automethod:: WebSocketHandler.set_default_headers
 
    Configuration
    -------------

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -22,6 +22,7 @@
 
    .. automethod:: WebSocketHandler.write_message
    .. automethod:: WebSocketHandler.close
+   .. automethod:: WebSocketHandler.upgrade_response_headers
 
    Configuration
    -------------

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -22,7 +22,6 @@
 
    .. automethod:: WebSocketHandler.write_message
    .. automethod:: WebSocketHandler.close
-   .. automethod:: WebSocketHandler.set_default_headers
 
    Configuration
    -------------

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -145,6 +145,13 @@ class WebSocketTest(WebSocketBaseTestCase):
         response = self.fetch('/echo')
         self.assertEqual(response.code, 400)
 
+    def test_bad_websocket_version(self):
+        response = self.fetch('/echo',
+                              headers={'Connection': 'Upgrade',
+                                       'Upgrade': 'WebSocket',
+                                       'Sec-WebSocket-Version': '12'})
+        self.assertEqual(response.code, 426)
+
     @gen_test
     def test_websocket_gen(self):
         ws = yield self.ws_connect('/echo')

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -70,12 +70,11 @@ class HeaderHandler(TestWebSocketHandler):
 
 
 class HeaderEchoHandler(TestWebSocketHandler):
-    def upgrade_response_headers(self):
-        return ''.join(
-            "{}: {}\r\n".format(k, v)
-            for k, v in self.request.headers.get_all()
-            if k.lower().startswith('x-test')
-        )
+    def set_default_headers(self):
+        for k, v in self.request.headers.get_all():
+            if k.lower().startswith('x-test'):
+                self.set_header(k, v)
+        self.set_header("X-Extra-Response-Header", "Extra-Response-Value")
 
 
 class NonWebSocketHandler(RequestHandler):
@@ -249,6 +248,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         self.assertEqual(ws.headers.get('X-Test-Hello'), 'hello')
         self.assertEqual(ws.headers.get('X-Test-Goodbye'), 'goodbye')
         self.assertEqual(ws.headers.get('X-Test-Random'), random_str)
+        self.assertEqual(ws.headers.get('X-Extra-Response-Header'), 'Extra-Response-Value')
         yield self.close(ws)
 
     @gen_test

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -66,7 +66,8 @@ class WebSocketHandler(tornado.web.RequestHandler):
     connections.
 
     Custom upgrade response headers can be sent by overriding
-    `set_default_headers` or `prepare`.
+    `~tornado.web.RequestHandler.set_default_headers` or
+    `~tornado.web.RequestHandler.prepare`.
 
     See http://dev.w3.org/html5/websockets/ for details on the
     JavaScript interface.  The protocol is specified at

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -183,7 +183,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
         if self.ws_connection:
             self.ws_connection.accept_connection()
         else:
-            self.set_status(426)
+            self.set_status(426, "Upgrade Required")
             self.set_header("Sec-WebSocket-Version", "7, 8, 13")
             self.finish()
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -66,7 +66,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
     connections.
 
     Custom upgrade response headers can be sent by overriding
-    `set_default_headers`.
+    `set_default_headers` or `prepare`.
 
     See http://dev.w3.org/html5/websockets/ for details on the
     JavaScript interface.  The protocol is specified at
@@ -235,17 +235,6 @@ class WebSocketHandler(tornado.web.RequestHandler):
         .. versionadded:: 4.1
         """
         return None
-
-    def set_default_headers(self):
-        """Override this to set HTTP headers at the beginning of the
-           WebSocket upgrade request.
-
-        For example, this is the place to set a custom ``Server`` header.
-        Note that setting such headers in the normal flow of request
-        processing may not do what you want, since headers may be reset
-        during error handling.
-        """
-        pass
 
     def open(self, *args, **kwargs):
         """Invoked when a new WebSocket is opened.

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -66,7 +66,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
     connections.
 
     Custom upgrade response headers can be sent by overriding
-    `upgrade_response_headers`.
+    `set_default_headers`.
 
     See http://dev.w3.org/html5/websockets/ for details on the
     JavaScript interface.  The protocol is specified at
@@ -127,12 +127,12 @@ class WebSocketHandler(tornado.web.RequestHandler):
     to accept it before the websocket connection will succeed.
     """
     def __init__(self, application, request, **kwargs):
-        super(WebSocketHandler, self).__init__(application, request, **kwargs)
         self.ws_connection = None
         self.close_code = None
         self.close_reason = None
         self.stream = None
         self._on_close_called = False
+        super(WebSocketHandler, self).__init__(application, request, **kwargs)
 
     @tornado.web.asynchronous
     def get(self, *args, **kwargs):
@@ -179,18 +179,13 @@ class WebSocketHandler(tornado.web.RequestHandler):
             gen_log.debug(log_msg)
             return
 
-        self.stream = self.request.connection.detach()
-        self.stream.set_close_callback(self.on_connection_close)
-
         self.ws_connection = self.get_websocket_protocol()
         if self.ws_connection:
             self.ws_connection.accept_connection()
         else:
-            if not self.stream.closed():
-                self.stream.write(tornado.escape.utf8(
-                    "HTTP/1.1 426 Upgrade Required\r\n"
-                    "Sec-WebSocket-Version: 7, 8, 13\r\n\r\n"))
-                self.stream.close()
+            self.set_status(426)
+            self.set_header("Sec-WebSocket-Version", "7, 8, 13")
+            self.finish()
 
     def write_message(self, message, binary=False):
         """Sends the given message to the client of this Web Socket.
@@ -241,11 +236,16 @@ class WebSocketHandler(tornado.web.RequestHandler):
         """
         return None
 
-    def upgrade_response_headers(self):
-        """Override to return additional headers to send in the websocket
-           upgrade response.
+    def set_default_headers(self):
+        """Override this to set HTTP headers at the beginning of the
+           WebSocket upgrade request.
+
+        For example, this is the place to set a custom ``Server`` header.
+        Note that setting such headers in the normal flow of request
+        processing may not do what you want, since headers may be reset
+        during error handling.
         """
-        return ""
+        pass
 
     def open(self, *args, **kwargs):
         """Invoked when a new WebSocket is opened.
@@ -401,6 +401,10 @@ class WebSocketHandler(tornado.web.RequestHandler):
         if websocket_version in ("7", "8", "13"):
             return WebSocketProtocol13(
                 self, compression_options=self.get_compression_options())
+
+    def _attach_stream(self):
+        self.stream = self.request.connection.detach()
+        self.stream.set_close_callback(self.on_connection_close)
 
 
 def _wrap_method(method):
@@ -578,8 +582,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             selected = self.handler.select_subprotocol(subprotocols)
             if selected:
                 assert selected in subprotocols
-                subprotocol_header = ("Sec-WebSocket-Protocol: %s\r\n"
-                                      % selected)
+                self.handler.set_header("Sec-WebSocket-Protocol", selected)
 
         extension_header = ''
         extensions = self._parse_extensions_header(self.request.headers)
@@ -594,23 +597,20 @@ class WebSocketProtocol13(WebSocketProtocol):
                     # Don't echo an offered client_max_window_bits
                     # parameter with no value.
                     del ext[1]['client_max_window_bits']
-                extension_header = ('Sec-WebSocket-Extensions: %s\r\n' %
-                                    httputil._encode_header(
-                                        'permessage-deflate', ext[1]))
+                self.handler.set_header("Sec-WebSocket-Extensions",
+                                        httputil._encode_header(
+                                            'permessage-deflate', ext[1]))
                 break
 
-        if self.stream.closed():
-            self._abort()
-            return
-        self.stream.write(tornado.escape.utf8(
-            "HTTP/1.1 101 Switching Protocols\r\n"
-            "Upgrade: websocket\r\n"
-            "Connection: Upgrade\r\n"
-            "Sec-WebSocket-Accept: %s\r\n"
-            "%s%s%s"
-            "\r\n" % (self._challenge_response(),
-                      subprotocol_header, extension_header,
-                      self.handler.upgrade_response_headers())))
+        self.handler.clear_header("Content-Type")
+        self.handler.set_status(101)
+        self.handler.set_header("Upgrade", "websocket")
+        self.handler.set_header("Connection", "Upgrade")
+        self.handler.set_header("Sec-WebSocket-Accept", self._challenge_response())
+        self.handler.finish()
+
+        self.handler._attach_stream()
+        self.stream = self.handler.stream
 
         self._run_callback(self.handler.open, *self.handler.open_args,
                            **self.handler.open_kwargs)

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -65,6 +65,9 @@ class WebSocketHandler(tornado.web.RequestHandler):
     override `open` and `on_close` to handle opened and closed
     connections.
 
+    Custom upgrade response headers can be sent by overriding
+    `upgrade_response_headers`.
+
     See http://dev.w3.org/html5/websockets/ for details on the
     JavaScript interface.  The protocol is specified at
     http://tools.ietf.org/html/rfc6455.
@@ -237,6 +240,12 @@ class WebSocketHandler(tornado.web.RequestHandler):
         .. versionadded:: 4.1
         """
         return None
+
+    def upgrade_response_headers(self):
+        """Override to return additional headers to send in the websocket
+           upgrade response.
+        """
+        return ""
 
     def open(self, *args, **kwargs):
         """Invoked when a new WebSocket is opened.
@@ -598,9 +607,10 @@ class WebSocketProtocol13(WebSocketProtocol):
             "Upgrade: websocket\r\n"
             "Connection: Upgrade\r\n"
             "Sec-WebSocket-Accept: %s\r\n"
-            "%s%s"
+            "%s%s%s"
             "\r\n" % (self._challenge_response(),
-                      subprotocol_header, extension_header)))
+                      subprotocol_header, extension_header,
+                      self.handler.upgrade_response_headers())))
 
         self._run_callback(self.handler.open, *self.handler.open_args,
                            **self.handler.open_kwargs)


### PR DESCRIPTION
A new method, upgrade_response_headers, is introduced to WebSocketHandler that a user can override to return custom headers in the websocket upgrade response.