### PR TITLE
Add Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - nightly
     - pypy3
 
@@ -18,7 +19,7 @@ install:
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install pycurl; fi
     # Twisted runs on 2.x and 3.3+, but is flaky on pypy.
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install Twisted; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' || $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
     # On travis the extension should always be built
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
     - travis_retry python setup.py install
@@ -60,7 +61,7 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --resolver=tornado.platform.twisted.TwistedResolver; fi
     #- if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi
@@ -69,8 +70,8 @@ script:
     # make coverage reports for Codecov to find
     - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then coverage xml; fi
     - export TORNADO_EXTENSION=0
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.5' || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.5' || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
 
 after_success:
     # call codecov from project root

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ envlist =
         # Basic configurations: Run the tests in both minimal installations
         # and with all optional dependencies.
         # (pypy3 doesn't have any optional deps yet)
-        {py27,pypy,py33,py34,py35,pypy3},
-        {py27,pypy,py33,py34,py35}-full,
+        {py27,pypy,py33,py34,py35,py36,pypy3},
+        {py27,pypy,py33,py34,py35,py36}-full,
 
         # Also run the tests with each possible replacement of a default
         # component.  Run each test on both python 2 and 3 where possible.
@@ -57,6 +57,7 @@ basepython =
            py33: python3.3
            py34: python3.4
            py35: python3.5
+           py36: python3.6
            pypy: pypy
            pypy3: pypy3
            py2: python2.7
@@ -69,14 +70,14 @@ deps =
      py3-unittest2: unittest2py3k
      # cpython-only deps: pycurl installs but curl_httpclient doesn't work;
      # twisted mostly works but is a bit flaky under pypy.
-     {py27,py33,py34,py35}-full: pycurl
+     {py27,py33,py34,py35,py36}-full: pycurl
      {py2,py3}: pycurl>=7.19.3.1
      # twisted is cpython only.
-     {py27,py33,py34,py35}-full: twisted
+     {py27,py33,py34,py35,py36}-full: twisted
      {py2,py3}: twisted
      # pycares installation currently fails on py33
      # (https://github.com/pypa/pip/pull/816)
-     {py2,py3,py27,py33,py34,py35}-full: pycares
+     {py2,py3,py27,py33,py34,py35,py36}-full: pycares
      # futures became standard in py32
      {py2,py27,pypy}-full: futures
      # mock became standard in py33
@@ -91,7 +92,7 @@ deps =
 
 setenv =
        # The extension is mandatory on cpython.
-       {py2,py27,py3,py33,py34,py35}: TORNADO_EXTENSION=1
+       {py2,py27,py3,py33,py34,py35,py36}: TORNADO_EXTENSION=1
        # In python 3, opening files in text mode uses a
        # system-dependent encoding by default.  Run the tests with "C"
        # (ascii) and "utf-8" locales to ensure we don't have hidden
@@ -100,7 +101,7 @@ setenv =
        lang_utf8: LANG=en_US.utf-8
        # tox's parser chokes if all the setenv entries are conditional.
        DUMMY=dummy
-       {py2,py27,py3,py33,py34,py35}-no-ext: TORNADO_EXTENSION=0
+       {py2,py27,py3,py33,py34,py35,py36}-no-ext: TORNADO_EXTENSION=0
 
 # All non-comment lines but the last must end in a backslash.
 # Tox filters line-by-line based on the environment name.
@@ -108,7 +109,7 @@ commands =
          python \
          # py3*: -b turns on an extra warning when calling
          # str(bytes), and -bb makes it an error.
-         {py3,py33,py34,py35,pypy3}: -bb \
+         {py3,py33,py34,py35,py36,pypy3}: -bb \
          # Python's optimized mode disables the assert statement, so
          # run the tests in this mode to ensure we haven't fallen into
          # the trap of relying on an assertion's side effects or using


### PR DESCRIPTION
Python 3.6.0 is the newest major release of the Python language, and it contains many new features and optimizations.

Add it to CI configuration files and add latest python versions (3.5 and 3.6) to setup.py