### PR TITLE
copy handler list in IOLoop.close(all_fds=True)

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -715,7 +715,7 @@ class PollIOLoop(IOLoop):
         self._closing = True
         self.remove_handler(self._waker.fileno())
         if all_fds:
-            for fd, handler in self._handlers.values():
+            for fd, handler in list(self._handlers.values()):
                 self.close_fd(fd)
         self._waker.close()
         self._impl.close()


### PR DESCRIPTION
avoids modifying dict during iteration if close method on fd triggers something like `IOLoop.remove_handler`, which can happen on Python 3 (not Python 2, where `dict.values()` is already a copy).

This is coming up in https://github.com/zeromq/pyzmq/issues/963, where FutureSocket calls `io_loop.remove_handler(self)` in close.