### PR TITLE
Fix document PyPI download url

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ latex_documents = [
 # this link must be referenced as :current_tarball:`z`
 extlinks = {
     'current_tarball': (
-        'https://pypi.python.org/packages/source/t/tornado/tornado-%s.tar.g%%s' % version,
+        'https://pypi.org/packages/source/t/tornado/tornado-%s.tar.g%%s' % version,
         'tornado-%s.tar.g' % version),
     }
 


### PR DESCRIPTION
Because PyPI has changed the download url rules, the download url on document has broken.


Before the download url is

```
 https://pypi.python.org/packages/source/t/tornado/tornado-4.4.2.tar.gz
```



After change 

```
https://pypi.org/packages/source/t/tornado/tornado-4.4.2.tar.gz
```


The new format should have a long term support: https://bitbucket.org/pypa/pypi/issues/438.

And [pypi.org](https://pypi.org/) is PyPI 2.0's domain name.