### PR TITLE
Documentation Typo

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -489,7 +489,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         elif ("Content-Length" in headers or
               headers.get("Transfer-Encoding", "").lower() == "chunked" or
               getattr(start_line, 'method', None) in ("HEAD", "GET")):
-            # start_line may be a request or reponse start line; only
+            # start_line may be a request or response start line; only
             # the former has a method attribute.
             return connection_header == "keep-alive"
         return False


### PR DESCRIPTION
I kept misspelling "response" in my own project's docstrings and upon grepping to make sure it was totally wiped out, discovered it was also misspelled in here. Clearly the word has been misspelled since it's inception, but since we can't change English, let's update it here.