### PR TITLE
RequestHandler.current()

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2821,6 +2821,7 @@ def out_of_scope_method():
     data = handler.data
     return "%s%s" % (data, query_parameter)
 
+
 class RequestHandlerCurrentTest(WebTestCase):
     def get_handlers(self):
         class BaseHandler(RequestHandler):
@@ -2849,9 +2850,6 @@ class RequestHandlerCurrentTest(WebTestCase):
         unrequested = out_of_scope_method()
         self.assertEqual(unrequested, "None")
 
-    def test_missing_remote_ip(self):
-        resp = self.fetch("/")
-        self.assertEqual(resp.body, b"GET / (None)")
 
 @wsgi_safe
 class RequestSummaryTest(SimpleHandlerTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1583,9 +1583,13 @@ class RequestHandler(object):
         Walks the call-stack until it finds the correct requesthandler
         """
         call_stack = stack()
-        for i in range(len(call_stack) - 1, -1, -1):
-            if 'self' in call_stack[i].frame.f_locals and isinstance(call_stack[i].frame.f_locals['self'], cls):
-                return call_stack[i].frame.f_locals['self']
+        for stack_entry in call_stack[::-1]:
+            if isinstance(stack_entry,tuple):
+                frame = stack_entry[0]
+            else:
+                frame = stack_entry.frame
+            if 'self' in frame.f_locals and isinstance(frame.f_locals['self'], cls):
+                return frame.f_locals['self']
         return None
 
 def asynchronous(method):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -77,7 +77,7 @@ import time
 import tornado
 import traceback
 import types
-from inspect import isclass
+from inspect import isclass, stack
 from io import BytesIO
 
 from tornado.concurrent import Future
@@ -1576,6 +1576,17 @@ class RequestHandler(object):
         for h in headers:
             self.clear_header(h)
 
+    @classmethod
+    def current(cls):
+        """Returns the request handler serving this request, or None
+
+        Walks the call-stack until it finds the correct requesthandler
+        """
+        call_stack = stack()
+        for i in range(len(call_stack) - 1, -1, -1):
+            if 'self' in call_stack[i].frame.f_locals and isinstance(call_stack[i].frame.f_locals['self'], cls):
+                return call_stack[i].frame.f_locals['self']
+        return None
 
 def asynchronous(method):
     """Wrap request handler methods with this if they are asynchronous.


### PR DESCRIPTION
This is the webserver equivalent of `tornado.ioloop.IOLoop.current()`.
The class method basically just walks the call stack from oldest to newest until it finds an instance of RequestHandler (or a derived class), and then returns it.