### PR TITLE
[Routing / Python 3.6] Defining routing rules from a RequestHandler subclass definition 

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1751,9 +1751,11 @@ class _ApplicationRouter(ReversibleRuleRouter):
         `_ApplicationRouter` instance.
     """
 
-    def __init__(self, application, rules=[]):
+    def __init__(self, application, rules=None):
         assert isinstance(application, Application)
         self.application = application
+        if not rules:
+            rules = []
         if not isinstance(rules, list):
             rules = list(rules)
         while RequestHandler.rules:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -164,15 +164,15 @@ class RequestHandler(object):
     _template_loaders = {}  # type: typing.Dict[str, template.BaseLoader]
     _template_loader_lock = threading.Lock()
     _remove_control_chars_regex = re.compile(r"[\x00-\x08\x0e-\x1f]")
-    routes = collections.defaultdict(list)
+    rules = collections.defaultdict(list)
 
     def __init_subclass__(cls, **kwargs):
         if sys.version_info < (3,6):
             raise NotImplementedError()
         if "route" in kwargs:
-            route = (kwargs.pop("route"), cls)
+            rule = (kwargs.pop("route"), cls)
             router = kwargs.pop("router", "_ApplicationRouter")
-            RequestHandler.routes[router].append(route)
+            RequestHandler.rules[router].append(rule)
         super().__init_subclass__(**kwargs)
 
     def __init__(self, application, request, **kwargs):
@@ -1757,9 +1757,9 @@ class _ApplicationRouter(ReversibleRuleRouter):
         assert isinstance(application, Application)
         self.application = application
         clsName = self.__class__.__name__
-        if clsName in RequestHandler.routes:
-            while RequestHandler.routes[clsName]:
-                rules.append(RequestHandler.routes[clsName].pop(0))
+        if clsName in RequestHandler.rules:
+            while RequestHandler.rules[clsName]:
+                rules.append(RequestHandler.rules[clsName].pop(0))
         super(_ApplicationRouter, self).__init__(rules)
 
     def process_rule(self, rule):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -169,9 +169,17 @@ class RequestHandler(object):
         if sys.version_info < (3,6):
             raise NotImplementedError()
         if "route" in kwargs:
-            rule = (kwargs.pop("route"), cls)
+            route = kwargs.pop("route")
+            name = kwargs.pop("name", None)
+            target_kwargs = {}
+            for key in kwargs:
+                #All remaining keys must be fed to target_kwargs
+                target_kwargs[key] = kwargs[key]
+            if len(target_kwargs) == 0:
+                target_kwargs = None
+            rule = (route, cls, target_kwargs, name)
             RequestHandler.rules.append(rule)
-        super().__init_subclass__(**kwargs)
+        super().__init_subclass__() #No remaining kwargs transmitted up
 
     def __init__(self, application, request, **kwargs):
         super(RequestHandler, self).__init__()


### PR DESCRIPTION
Hello,

Python 3.6 introduced [the   `__init_subclass__()` hook](https://docs.python.org/3/reference/datamodel.html#object.__init_subclass__) (PEP 487), offering a new lightweight method to customise subclasses at creation.

I thought it'd be interesting to combine it with the routing module to get routing directly from RequestHandler subclass definitions:
`class MessagesHandler(RequestHandler, route=r"/messages"):`
It's meant to be somewhat similar to Flask's routing style: allowing routes to be defined close to the handlers with all the app logic may be clearer. If you need a quick example to try out, here's another branch where [I've adapted the chat demo](https://github.com/Rastagong/tornado/blob/chatdemo_new_routing/demos/chat/chatdemo.py) to this syntax.

Internally, the RequestHandler mother class just stores the route and subclass of each kind of handler as a tuple during subclassing. Then, when the `_ApplicationRouter` is instantiated by the Application, it fetches these tuples and appends them to the handler rules already defined in the Application settings.

This shouldn't break backwards compatibility in any way since `__init_subclass__()` isn't implemented at all prior to Python 3.6.

(Note: If you check the first two commits, you'll see I was initially thinking of making it possible to choose a custom router class to use, but it required a subclass of Application to use a subclass of `_ApplicationRouter`, which seemed a bit overboard? For this purpose it might be easier to define one's own routers instead of messing with application internals.)

Hope this may prove useful!