### PR TITLE
websocket: fix client message callback error

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -426,7 +426,7 @@ class WebSocketProtocol(object):
             callback(*args, **kwargs)
         except Exception:
             app_log.error("Uncaught exception in %s",
-                          self.request.path, exc_info=True)
+                          getattr(self.request, 'path', None), exc_info=True)
             self._abort()
 
     def on_connection_close(self):


### PR DESCRIPTION
Fixes #938 
This fixes the problem of exceptions being swallowed in websocket client on_message callbacks. As @bdarnell pointed out in the issue, there should be some changes made to WebSocketProtocol to know what attributes it does and does not have, but this will at least prevent the `AttributeError` which causes the callback to silently be called again with `None` whenever any exceptions are raised in the original callback.