### PR TITLE
Make `tornado.log.LogFormatter` compatible with `logging.config.dictConfig`.

### DIFF
--- a/tornado/log.py
+++ b/tornado/log.py
@@ -89,8 +89,8 @@ class LogFormatter(logging.Formatter):
         logging.ERROR: 1,  # Red
     }
 
-    def __init__(self, color=True, fmt=DEFAULT_FORMAT,
-                 datefmt=DEFAULT_DATE_FORMAT, colors=DEFAULT_COLORS):
+    def __init__(self, fmt=DEFAULT_FORMAT, datefmt=DEFAULT_DATE_FORMAT,
+                 style='%', color=True, colors=DEFAULT_COLORS):
         r"""
         :arg bool color: Enables color support.
         :arg string fmt: Log message format.


### PR DESCRIPTION
see also [this issue](https://github.com/tornadoweb/tornado/issues/1960)

Use it the right way is as follows

```python
#!/usr/bin/env python3
# coding: utf-8


import logging
import logging.config

logging.config.dictConfig({
    'version': 1,
    'incremental': False,
    'disable_existing_loggers': False,
    'formatters': {
        'color_formatter': {
            'class': 'tornado.log.LogFormatter',
            # if you want to use color feature,
            # `format` must has '%(color)s' and '%(end_color)s'.
            'format': '%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]%(end_color)s %(message)s',
            'datefmt': '%y%m%d %H%M%S',
        },
    },
    'handlers': {
        'color_handler': {
            'class': 'logging.StreamHandler',
            'formatter': 'color_formatter',
        },
    },
    'loggers': {
        'mylogger': {
            'level': 'DEBUG',
            'handlers': ['color_handler'],
        },
    },
})


logger = logging.getLogger('mylogger')
logger.debug("message")
logger.info("message")
logger.warn("message")
logger.error("message")
logger.fatal("message")
```