### PR TITLE
Add a hook method in `tornado.web.RequestHandler`

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -265,6 +265,16 @@ class RequestHandler(object):
         """
         pass
 
+    def on_complete(self):
+        """Called after the end of http method.
+
+        Override this method to perform cleanup, logging, etc.
+        This method is a counterpart to `prepare`. But different from
+        `on_finish`. This method can be asynchronous decoration like
+        `prepare`.
+        """
+        pass
+
     def on_connection_close(self):
         """Called in async handlers if the client closed the connection.
 
@@ -1504,6 +1514,9 @@ class RequestHandler(object):
 
             method = getattr(self, self.request.method.lower())
             result = method(*self.path_args, **self.path_kwargs)
+            if result is not None:
+                result = yield result
+            result = self.on_complete()
             if result is not None:
                 result = yield result
             if self._auto_finish and not self._finished:


### PR DESCRIPTION
This hook is added in order to solve the some problems.

For example:

```python
class AsyncHandler(tornado.web.RequestHandler):

    def initialize(self, db_session):
        self.db_session = db_session

    @tornado.gen.coroutine
    def get(self):
        # do something.
        self.finish()
        # use `self.db_session` to do something.

    def on_complete(self):
        self.db_session.close()

    pass
```