### PR TITLE
Add compression_level and mem_level to WebSocketHandler.get_compression_options()

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -689,7 +689,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             else:
                 raise ValueError("unsupported extension %r", ext)
 
-    def _get_compressor_options(self, side, agreed_parameters):
+    def _get_compressor_options(self, side, agreed_parameters, compression_options):
         """Converts a websocket agreed_parameters set to keyword arguments
         for our compressor objects.
         """
@@ -700,6 +700,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             options['max_wbits'] = zlib.MAX_WBITS
         else:
             options['max_wbits'] = int(wbits_header)
+        options['compression_options'] = compression_options
         return options
 
     def _create_compressors(self, side, agreed_parameters, compression_options=None):
@@ -713,7 +714,7 @@ class WebSocketProtocol13(WebSocketProtocol):
                 raise ValueError("unsupported compression parameter %r" % key)
         other_side = 'client' if (side == 'server') else 'server'
         self._compressor = _PerMessageDeflateCompressor(
-            **self._get_compressor_options(side, agreed_parameters), compression_options=compression_options)
+            **self._get_compressor_options(side, agreed_parameters, compression_options))
         self._decompressor = _PerMessageDeflateDecompressor(
             **self._get_compressor_options(other_side, agreed_parameters))
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -689,7 +689,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             else:
                 raise ValueError("unsupported extension %r", ext)
 
-    def _get_compressor_options(self, side, agreed_parameters, compression_options):
+    def _get_compressor_options(self, side, agreed_parameters, compression_options=None):
         """Converts a websocket agreed_parameters set to keyword arguments
         for our compressor objects.
         """

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -504,15 +504,15 @@ class _PerMessageDeflateCompressor(object):
             self._mem_level = compression_options['mem_level']
 
         if persistent:
-            self._compressor = self._create_compressor(self._compression_level, self._mem_level)
+            self._compressor = self._create_compressor()
         else:
             self._compressor = None
 
-    def _create_compressor(self, compression_level, mem_level):
-        return zlib.compressobj(compression_level, zlib.DEFLATED, -self._max_wbits, mem_level)
+    def _create_compressor(self):
+        return zlib.compressobj(self._compression_level, zlib.DEFLATED, -self._max_wbits, self._mem_level)
 
     def compress(self, data):
-        compressor = self._compressor or self._create_compressor(self._compression_level, self._mem_level)
+        compressor = self._compressor or self._create_compressor()
         data = (compressor.compress(data) +
                 compressor.flush(zlib.Z_SYNC_FLUSH))
         assert data.endswith(b'\x00\x00\xff\xff')

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -520,7 +520,7 @@ class _PerMessageDeflateCompressor(object):
 
 
 class _PerMessageDeflateDecompressor(object):
-    def __init__(self, persistent, max_wbits):
+    def __init__(self, persistent, max_wbits, compression_options=None):
         if max_wbits is None:
             max_wbits = zlib.MAX_WBITS
         if not (8 <= max_wbits <= zlib.MAX_WBITS):
@@ -716,7 +716,7 @@ class WebSocketProtocol13(WebSocketProtocol):
         self._compressor = _PerMessageDeflateCompressor(
             **self._get_compressor_options(side, agreed_parameters, compression_options))
         self._decompressor = _PerMessageDeflateDecompressor(
-            **self._get_compressor_options(other_side, agreed_parameters))
+            **self._get_compressor_options(other_side, agreed_parameters, compression_options))
 
     def _write_frame(self, fin, opcode, data, flags=0):
         if fin:


### PR DESCRIPTION
This pull-request adds support for specifying compression_level and mem_level to WebSocketHandler.get_compression_options(). 

These parameters are documented here: https://docs.python.org/3.6/library/zlib.html#zlib.compressobj

The default compression level is currently 6, but sometimes it can be useful to configure this to some other value. I have not tried to make wbits configurable, that would be more complex.