### PR TITLE
autoreload: Don't close the IOLoop on reload

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -103,10 +103,6 @@ except ImportError:
 # os.execv is broken on Windows and can't properly parse command line
 # arguments and executable name if they contain whitespaces. subprocess
 # fixes that behavior.
-# This distinction is also important because when we use execv, we want to
-# close the IOLoop and all its file descriptors, to guard against any
-# file descriptors that were not set CLOEXEC. When execv is not available,
-# we must not close the IOLoop because we want the process to exit cleanly.
 _has_execv = sys.platform != 'win32'
 
 _watched_files = set()
@@ -127,8 +123,6 @@ def start(io_loop=None, check_time=500):
     _io_loops[io_loop] = True
     if len(_io_loops) > 1:
         gen_log.warning("tornado.autoreload started more than once in the same process")
-    if _has_execv:
-        add_reload_hook(functools.partial(io_loop.close, all_fds=True))
     modify_times = {}
     callback = functools.partial(_reload_on_update, modify_times)
     scheduler = ioloop.PeriodicCallback(callback, check_time, io_loop=io_loop)


### PR DESCRIPTION
This was a last-ditch effort to close file descriptors that were not
marked as CLOEXEC. However, it was never complete (it didn't touch
file descriptors that were not registered on the IOLoop), and it can't
work with asyncio (which does not allow closing the IOLoop without
stopping it and unwinding the stack first). Since Tornado (and
hopefully all major libraries using the IOLoop) is careful about
setting CLOEXEC when needed, just get rid of the close.

Fixes #1543