### PR TITLE
Update auth.py

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -981,7 +981,7 @@ class FacebookGraphMixin(OAuth2Mixin):
         args = escape.json_decode(response.body)
         session = {
             "access_token": args.get("access_token"),
-            "expires": args.get("expires_in")
+            "expires_in": args.get("expires_in")
         }
 
         self.facebook_request(
@@ -1004,7 +1004,7 @@ class FacebookGraphMixin(OAuth2Mixin):
         for field in fields:
             fieldmap[field] = user.get(field)
 
-        fieldmap.update({"access_token": session["access_token"], "session_expires": session.get("expires")})
+        fieldmap.update({"access_token": session["access_token"], "session_expires": session.get("expires_in")})
         future.set_result(fieldmap)
 
     @_auth_return_future

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -981,7 +981,7 @@ class FacebookGraphMixin(OAuth2Mixin):
         args = escape.json_decode(response.body)
         session = {
             "access_token": args.get("access_token"),
-            "expires": args.get("expires")
+            "expires": args.get("expires_in")
         }
 
         self.facebook_request(

--- a/tornado/test/auth_test.py
+++ b/tornado/test/auth_test.py
@@ -149,7 +149,7 @@ class FacebookClientLoginHandler(RequestHandler, FacebookGraphMixin):
 
 class FacebookServerAccessTokenHandler(RequestHandler):
     def get(self):
-        self.write(dict(access_token="asdf"))
+        self.write(dict(access_token="asdf", expires_in=54770))
 
 
 class FacebookServerMeHandler(RequestHandler):


### PR DESCRIPTION
Response from Facebook Login doesn't contain the expires field. 

For example :
The response you will receive from this endpoint will be returned in JSON format and, if successful, is:

{
  "access_token": {access-token}, 
  "token_type": {type},
  "expires_in":  {seconds-til-expiration}
}

Would you be so kind to fix it.
Thanks in advance .