### PR TITLE
iostream: Fix unreleased memoryview

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -907,9 +907,8 @@ class BaseIOStream(object):
             return b""
         assert loc <= self._read_buffer_size
         # Slice the bytearray buffer into bytes, without intermediate copying
-        b = (memoryview(self._read_buffer)
-             [self._read_buffer_pos:self._read_buffer_pos + loc]
-             ).tobytes()
+        with memoryview(self._read_buffer) as m:
+            b = m[self._read_buffer_pos:self._read_buffer_pos + loc].tobytes()
         self._read_buffer_pos += loc
         self._read_buffer_size -= loc
         # Amortized O(1) shrink

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -908,7 +908,8 @@ class BaseIOStream(object):
         assert loc <= self._read_buffer_size
         # Slice the bytearray buffer into bytes, without intermediate copying
         with memoryview(self._read_buffer) as m:
-            b = m[self._read_buffer_pos:self._read_buffer_pos + loc].tobytes()
+            with m[self._read_buffer_pos:self._read_buffer_pos + loc] as m2:
+                b = m2.tobytes()
         self._read_buffer_pos += loc
         self._read_buffer_size -= loc
         # Amortized O(1) shrink


### PR DESCRIPTION
memoryview should be released explicitly.  Otherwise, a bytearray
holded by the memoryview is not resizable until GC.

See also: https://bugs.python.org/issue29178