### PR TITLE
Fix color logs on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,9 @@ install:
 
   - "pip install tox wheel"
 
+  # Install colorama to make sure no failures when it exists
+  - "pip install colorama"
+
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:

--- a/demos/colored_log/colored_log.py
+++ b/demos/colored_log/colored_log.py
@@ -1,0 +1,29 @@
+import sys
+import logging
+
+# For Windows versions not supporting ANSI terminal codes, we need colorama
+# installed to get colored output
+if sys.platform.startswith('win32'):
+    try:
+        import colorama
+    except ImportError:
+        colorama = None
+
+import tornado.log
+
+# First initialize colorama on Windows
+if sys.platform.startswith('win'):
+    if colorama is not None:
+        colorama.init()
+
+# Setup pretty logging
+tornado.log.enable_pretty_logging()
+
+logger = logging.getLogger("colored")
+logger.setLevel(logging.DEBUG)
+
+logger.info("some information")
+logger.warning("a warning")
+logger.error("an error")
+logger.critical("a critical error")
+logger.debug("debug info")

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import logging.handlers
 import sys
+import warnings
 
 from tornado.escape import _unicode
 from tornado.util import unicode_type, basestring_type
@@ -131,6 +132,7 @@ class LogFormatter(logging.Formatter):
         self._fmt = fmt
 
         self._colors = {}
+        self._normal = ''
         if color and _stderr_supports_color():
             if curses is not None:
                 # The curses module has some str/bytes confusion in
@@ -153,9 +155,7 @@ class LogFormatter(logging.Formatter):
                     self._colors[levelno] = '\033[2;3%dm' % code
                 self._normal = '\033[0m'
             else:
-                raise RuntimeError("No supported color terminal library")
-        else:
-            self._normal = ''
+                warnings.warn("No supported color terminal library", RuntimeWarning)
 
     def format(self, record):
         try:

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -39,6 +39,7 @@ from tornado.util import unicode_type, basestring_type
 
 try:
     import colorama
+    import colorama.initialise
 except ImportError:
     colorama = None
 
@@ -63,8 +64,9 @@ def _stderr_supports_color():
                     color = True
             except Exception:
                 pass
-        elif colorama:
-            color = True
+        elif colorama is not None:
+            if colorama.initialise.wrapped_stderr is not None:
+                color = True
     return color
 
 
@@ -146,7 +148,7 @@ class LogFormatter(logging.Formatter):
                 for levelno, code in colors.items():
                     self._colors[levelno] = unicode_type(curses.tparm(fg_color, code), "ascii")
                 self._normal = unicode_type(curses.tigetstr("sgr0"), "ascii")
-            elif sys.stderr is getattr(colorama, 'wrapped_stderr', object()):
+            elif sys.stderr is getattr(colorama.initialise, 'wrapped_stderr', object()):
                 for levelno, code in colors.items():
                     self._colors[levelno] = '\033[2;3%dm' % code
                 self._normal = '\033[0m'

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -66,8 +66,11 @@ def _stderr_supports_color():
                 pass
         elif sys.platform.startswith('win') and colorama is not None:
             # colorama has been initialized
-            if isinstance(sys.stderr, colorama.ansitowin32.StreamWrapper):
-                color = True
+            try:
+                if isinstance(sys.stderr, colorama.ansitowin32.StreamWrapper):
+                    color = True
+            except AttributeError:  # in case colorama's API changes in the future
+                warnings.warn("Problem with initializing colorama.")
     return color
 
 

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -40,7 +40,6 @@ from tornado.util import unicode_type, basestring_type
 
 try:
     import colorama
-    import colorama.initialise
 except ImportError:
     colorama = None
 
@@ -65,8 +64,9 @@ def _stderr_supports_color():
                     color = True
             except Exception:
                 pass
-        elif colorama is not None:
-            if colorama.initialise.wrapped_stderr is not None:
+        elif sys.platform.startswith('win') and colorama is not None:
+            # colorama has been initialized
+            if isinstance(sys.stderr, colorama.ansitowin32.StreamWrapper):
                 color = True
     return color
 
@@ -150,7 +150,7 @@ class LogFormatter(logging.Formatter):
                 for levelno, code in colors.items():
                     self._colors[levelno] = unicode_type(curses.tparm(fg_color, code), "ascii")
                 self._normal = unicode_type(curses.tigetstr("sgr0"), "ascii")
-            elif sys.stderr is getattr(colorama.initialise, 'wrapped_stderr', object()):
+            elif colorama is not None:
                 for levelno, code in colors.items():
                     self._colors[levelno] = '\033[2;3%dm' % code
                 self._normal = '\033[0m'


### PR DESCRIPTION
Fixes #2013.

I'm not sure how I missed this error. My apologies.

I would also like to change the `RuntimeError` to just be a warning since it seems like there is no reason we should not be able to gracefully fall back to non-color logging if there is a problem.