### PR TITLE
fix backwards compatibility of url_concat for args=None

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -603,6 +603,8 @@ def url_concat(url, args):
     >>> url_concat("http://example.com/foo?a=b", [("c", "d"), ("c", "d2")])
     'http://example.com/foo?a=b&c=d&c=d2'
     """
+    if args is None:
+        return url
     parsed_url = urlparse(url)
     if isinstance(args, dict):
         parsed_query = parse_qsl(parsed_url.query, keep_blank_values=True)

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -66,6 +66,13 @@ class TestUrlConcat(unittest.TestCase):
         )
         self.assertEqual(url, "https://localhost/path?r=1&t=2")
 
+    def test_url_concat_none_params(self):
+        url = url_concat(
+            "https://localhost/path?r=1&t=2",
+            None,
+        )
+        self.assertEqual(url, "https://localhost/path?r=1&t=2")
+
     def test_url_concat_with_frag(self):
         url = url_concat(
             "https://localhost/path#tab",


### PR DESCRIPTION
A change made in 4.5 to the `url_concat` function broke some assumptions used in external code.

Notably, in SaltStack, this breaks parsing for some states people are using in production. See this issue: https://github.com/saltstack/salt/issues/40749

This patch fixes that external code to once again allow `url_concat("foo", None)` and adds a test to check this behavior.

My first time contributing - let me know if I missed something big. 

Thanks!