### PR TITLE
Fix CurlAsyncHTTPClient cause memory leak with `force_instance=True`

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -74,6 +74,12 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         self._multi.close()
         super(CurlAsyncHTTPClient, self).close()
 
+        # Set below properties to None to reduce the reference count of current
+        # instance, because those properties hold some methods of current
+        # instance that will case circular reference.
+        self._force_timeout_callback = None
+        self._multi = None
+
     def fetch_impl(self, request, callback):
         self._requests.append((request, callback))
         self._process_queue()


### PR DESCRIPTION
The `CurlAsyncHTTPClient` will cause memory leak when set `force_instance=True`,because the `self._multi` and `self._force_timeout_callback`hold some methods that belong the instance of `CurlAsyncHTTPClient`,it will cause circular reference.

Here is the test code:

```python
#!/usr/bin/env python
# -*- coding:utf-8 -*-
""" """
from __future__ import print_function, division, unicode_literals

import sys

from tornado.curl_httpclient import CurlAsyncHTTPClient

class Demo(object):

    def __init__(self):
        self._client = CurlAsyncHTTPClient(force_instance=True)

    def __del__(self):
        print(sys.getrefcount(self._client))        # 5
        self._client.close()
        print(sys.getrefcount(self._client))        # 5 (The reference count is not change)
        self._client._force_timeout_callback.callback = None
        print(sys.getrefcount(self._client))        # 4
        self._client._multi = None
        print(sys.getrefcount(self._client))        # 2


t = Demo()
del t
```

The above code will output:
```
5
5
4
2
```