### PR TITLE
TCPClient with connection timeout support. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,12 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python -bb $TARGET; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.netutil.ThreadedResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --resolver=tornado.platform.twisted.TwistedResolver; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic; fi
     #- if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then ../nodeps/bin/python -m tornado.test.runtests; fi
     # make coverage reports for Codecov to find
     - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then coverage xml; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,18 +9,22 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
+      TOX_ENV: "py35"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
+      TOX_ENV: "py35"
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
+      TOX_ENV: "py36"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
+      TOX_ENV: "py36"
 
 install:
   # Make sure the right python version is first on the PATH.
@@ -44,7 +48,7 @@ test_script:
   # but for now it lets us avoid duplication with .travis.yml and tox.ini.
   # Running "py3x-full" would be nice but it's failing on installing
   # dependencies with no useful logs.
-  - "tox -e py35,py36 --skip-missing-interpreters"
+  - "tox -e %TOX_ENV%"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,26 +5,38 @@ environment:
 
   # We only build with 3.5+ because it works out of the box, while other
   # versions require lots of machinery.
+  #
+  # We produce binary wheels for 32- and 64-bit builds, but because
+  # the tests are so slow on Windows (6 minutes vs 15 seconds on Linux
+  # or MacOS), we don't want to test the full matrix. We do full
+  # tests on a couple of configurations and on the others we limit
+  # the tests to the websocket module (which, because it exercises the
+  # C extension module, is most likely to exhibit differences between
+  # 32- and 64-bits)
   matrix:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
       TOX_ENV: "py35"
+      TOX_ARGS: ""
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
       TOX_ENV: "py35"
+      TOX_ARGS: "tornado.test.websocket_test"
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
       TOX_ENV: "py36"
+      TOX_ARGS: "tornado.test.websocket_test"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       TOX_ENV: "py36"
+      TOX_ARGS: ""
 
 install:
   # Make sure the right python version is first on the PATH.
@@ -48,7 +60,7 @@ test_script:
   # but for now it lets us avoid duplication with .travis.yml and tox.ini.
   # Running "py3x-full" would be nice but it's failing on installing
   # dependencies with no useful logs.
-  - "tox -e %TOX_ENV%"
+  - "tox -e %TOX_ENV% -- %TOX_ARGS%"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/demos/file_upload/file_uploader.py
+++ b/demos/file_upload/file_uploader.py
@@ -9,6 +9,7 @@ single file without encoding.
 See also file_receiver.py in this directory, a server that receives uploads.
 """
 
+from __future__ import print_function
 import mimetypes
 import os
 import sys

--- a/docs/gen.rst
+++ b/docs/gen.rst
@@ -21,7 +21,6 @@
    .. autoexception:: Return
 
    .. autofunction:: with_timeout
-   .. autoexception:: TimeoutError
 
    .. autofunction:: sleep
 

--- a/docs/httpclient.rst
+++ b/docs/httpclient.rst
@@ -47,7 +47,7 @@ Implementations
 
 .. module:: tornado.curl_httpclient
 
-.. class:: CurlAsyncHTTPClient(io_loop, max_clients=10, defaults=None)
+.. class:: CurlAsyncHTTPClient(max_clients=10, defaults=None)
 
    ``libcurl``-based HTTP client.
 

--- a/docs/ioloop.rst
+++ b/docs/ioloop.rst
@@ -13,14 +13,15 @@
 
    .. automethod:: IOLoop.current
    .. automethod:: IOLoop.make_current
-   .. automethod:: IOLoop.instance
-   .. automethod:: IOLoop.initialized
-   .. automethod:: IOLoop.install
-   .. automethod:: IOLoop.clear_instance
+   .. automethod:: IOLoop.clear_current
    .. automethod:: IOLoop.start
    .. automethod:: IOLoop.stop
    .. automethod:: IOLoop.run_sync
    .. automethod:: IOLoop.close
+   .. automethod:: IOLoop.instance
+   .. automethod:: IOLoop.initialized
+   .. automethod:: IOLoop.install
+   .. automethod:: IOLoop.clear_instance
 
    I/O events
    ^^^^^^^^^^

--- a/docs/releases/v3.0.0.rst
+++ b/docs/releases/v3.0.0.rst
@@ -381,7 +381,7 @@ Multiple modules
   when it is available (and continue to use the standard ``unittest`` module
   when ``unittest2`` is not available)
 * `tornado.testing.ExpectLog` can be used as a finer-grained alternative
-  to `tornado.testing.LogTrapTestCase`
+  to ``tornado.testing.LogTrapTestCase``
 * The command-line interface to `tornado.testing.main` now supports
   additional arguments from the underlying `unittest` module:
   ``verbose``, ``quiet``, ``failfast``, ``catch``, ``buffer``.
@@ -395,9 +395,9 @@ Multiple modules
   instead of putting all possible options in `tornado.testing.main`.
 * `.AsyncHTTPTestCase` no longer calls `.AsyncHTTPClient.close` for tests
   that use the singleton `.IOLoop.instance`.
-* `.LogTrapTestCase` no longer fails when run in unknown logging
+* ``LogTrapTestCase`` no longer fails when run in unknown logging
   configurations.  This allows tests to be run under nose, which does its
-  own log buffering (`.LogTrapTestCase` doesn't do anything useful in this
+  own log buffering (``LogTrapTestCase`` doesn't do anything useful in this
   case, but at least it doesn't break things any more).
 
 ``tornado.util``

--- a/docs/releases/v3.0.1.rst
+++ b/docs/releases/v3.0.1.rst
@@ -14,7 +14,7 @@ Apr 8, 2013
   of the `ssl.match_hostname` function.
 * `tornado.websocket.websocket_connect` now fails cleanly when it attempts
   to connect to a non-websocket url.
-* `tornado.testing.LogTrapTestCase` once again works with byte strings
+* ``tornado.testing.LogTrapTestCase`` once again works with byte strings
   on Python 2.
 * The ``request`` attribute of `tornado.httpclient.HTTPResponse` is
   now always an `~tornado.httpclient.HTTPRequest`, never a ``_RequestProxy``.

--- a/docs/releases/v4.2.0.rst
+++ b/docs/releases/v4.2.0.rst
@@ -49,7 +49,7 @@ be unlocked *without* acquiring it. This encouraged unorthodox patterns; in
 Tornado, just use `~.Semaphore.acquire`.
 
 Toro's ``Event.wait`` raised a ``Timeout`` exception after a timeout. In
-Tornado, `.Event.wait` raises `tornado.gen.TimeoutError`.
+Tornado, `.Event.wait` raises ``tornado.gen.TimeoutError``.
 
 Toro's ``Condition.wait`` also raised ``Timeout``, but in Tornado, the `.Future`
 returned by `.Condition.wait` resolves to False after a timeout::

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -36,6 +36,4 @@
 
    .. autofunction:: bind_unused_port
 
-   .. autofunction:: get_unused_port
-
    .. autofunction:: get_async_test_timeout

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -23,9 +23,6 @@
    .. autoclass:: ExpectLog
       :members:
 
-   .. autoclass:: LogTrapTestCase
-      :members:
-
    Test runner
    -----------
 

--- a/maint/test/redbot/red_test.py
+++ b/maint/test/redbot/red_test.py
@@ -7,7 +7,7 @@ import thor
 import threading
 from tornado import gen
 from tornado.options import parse_command_line
-from tornado.testing import AsyncHTTPTestCase, LogTrapTestCase
+from tornado.testing import AsyncHTTPTestCase
 from tornado.web import RequestHandler, Application, asynchronous
 import unittest
 
@@ -229,11 +229,11 @@ class TestMixin(object):
             headers=[('If-None-Match', etags)],
             expected_status=200)
 
-class DefaultHTTPTest(AsyncHTTPTestCase, LogTrapTestCase, TestMixin):
+class DefaultHTTPTest(AsyncHTTPTestCase, TestMixin):
     def get_app(self):
         return Application(self.get_handlers(), **self.get_app_kwargs())
 
-class GzipHTTPTest(AsyncHTTPTestCase, LogTrapTestCase, TestMixin):
+class GzipHTTPTest(AsyncHTTPTestCase, TestMixin):
     def get_app(self):
         return Application(self.get_handlers(), gzip=True, **self.get_app_kwargs())
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ http://api.mongodb.org/python/current/installation.html#osx
 
 kwargs = {}
 
-version = "4.5.1"
+version = "5.0.dev1"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()

--- a/tornado/__init__.py
+++ b/tornado/__init__.py
@@ -25,5 +25,5 @@ from __future__ import absolute_import, division, print_function
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-version = "4.5.1"
-version_info = (4, 5, 1, 0)
+version = "5.0.dev1"
+version_info = (5, 0, 0, -100)

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -63,12 +63,11 @@ import sys
 # file.py gets added to the path, which can cause confusion as imports
 # may become relative in spite of the future import.
 #
-# We address the former problem by setting the $PYTHONPATH environment
-# variable before re-execution so the new process will see the correct
-# path.  We attempt to address the latter problem when tornado.autoreload
-# is run as __main__, although we can't fix the general case because
-# we cannot reliably reconstruct the original command line
-# (http://bugs.python.org/issue14208).
+# We address the former problem by reconstructing the original command
+# line (Python >= 3.4) or by setting the $PYTHONPATH environment
+# variable (Python < 3.4) before re-execution so the new process will
+# see the correct path.  We attempt to address the latter problem when
+# tornado.autoreload is run as __main__.
 
 if __name__ == "__main__":
     # This sys.path manipulation must come before our imports (as much
@@ -209,21 +208,29 @@ def _reload():
         # ioloop.set_blocking_log_threshold so it doesn't fire
         # after the exec.
         signal.setitimer(signal.ITIMER_REAL, 0, 0)
-    # sys.path fixes: see comments at top of file.  If sys.path[0] is an empty
-    # string, we were (probably) invoked with -m and the effective path
-    # is about to change on re-exec.  Add the current directory to $PYTHONPATH
-    # to ensure that the new process sees the same path we did.
-    path_prefix = '.' + os.pathsep
-    if (sys.path[0] == '' and
-            not os.environ.get("PYTHONPATH", "").startswith(path_prefix)):
-        os.environ["PYTHONPATH"] = (path_prefix +
-                                    os.environ.get("PYTHONPATH", ""))
+    # sys.path fixes: see comments at top of file.  If __main__.__spec__
+    # exists, we were invoked with -m and the effective path is about to
+    # change on re-exec.  Reconstruct the original command line to
+    # ensure that the new process sees the same path we did.  If
+    # __spec__ is not available (Python < 3.4), check instead if
+    # sys.path[0] is an empty string and add the current directory to
+    # $PYTHONPATH.
+    spec = getattr(sys.modules['__main__'], '__spec__', None)
+    if spec:
+        argv = ['-m', spec.name] + sys.argv[1:]
+    else:
+        argv = sys.argv
+        path_prefix = '.' + os.pathsep
+        if (sys.path[0] == '' and
+                not os.environ.get("PYTHONPATH", "").startswith(path_prefix)):
+            os.environ["PYTHONPATH"] = (path_prefix +
+                                        os.environ.get("PYTHONPATH", ""))
     if not _has_execv:
-        subprocess.Popen([sys.executable] + sys.argv)
+        subprocess.Popen([sys.executable] + argv)
         sys.exit(0)
     else:
         try:
-            os.execv(sys.executable, [sys.executable] + sys.argv)
+            os.execv(sys.executable, [sys.executable] + argv)
         except OSError:
             # Mac OS X versions prior to 10.6 do not support execv in
             # a process that contains multiple threads.  Instead of
@@ -236,8 +243,7 @@ def _reload():
             # Unfortunately the errno returned in this case does not
             # appear to be consistent, so we can't easily check for
             # this error specifically.
-            os.spawnv(os.P_NOWAIT, sys.executable,
-                      [sys.executable] + sys.argv)
+            os.spawnv(os.P_NOWAIT, sys.executable, [sys.executable] + argv)
             # At this point the IOLoop has been closed and finally
             # blocks will experience errors if we allow the stack to
             # unwind, so just exit uncleanly.

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -111,13 +111,13 @@ _reload_attempted = False
 _io_loops = weakref.WeakKeyDictionary()  # type: ignore
 
 
-def start(io_loop=None, check_time=500):
+def start(check_time=500):
     """Begins watching source files for changes.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
-    io_loop = io_loop or ioloop.IOLoop.current()
+    io_loop = ioloop.IOLoop.current()
     if io_loop in _io_loops:
         return
     _io_loops[io_loop] = True
@@ -125,7 +125,7 @@ def start(io_loop=None, check_time=500):
         gen_log.warning("tornado.autoreload started more than once in the same process")
     modify_times = {}
     callback = functools.partial(_reload_on_update, modify_times)
-    scheduler = ioloop.PeriodicCallback(callback, check_time, io_loop=io_loop)
+    scheduler = ioloop.PeriodicCallback(callback, check_time)
     scheduler.start()
 
 

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -74,6 +74,12 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         self._multi.close()
         super(CurlAsyncHTTPClient, self).close()
 
+        # Set below properties to None to reduce the reference count of current
+        # instance, because those properties hold some methods of current
+        # instance that will case circular reference.
+        self._force_timeout_callback = None
+        self._multi = None
+
     def fetch_impl(self, request, callback):
         self._requests.append((request, callback))
         self._process_queue()

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -37,8 +37,8 @@ curl_log = logging.getLogger('tornado.curl_httpclient')
 
 
 class CurlAsyncHTTPClient(AsyncHTTPClient):
-    def initialize(self, io_loop, max_clients=10, defaults=None):
-        super(CurlAsyncHTTPClient, self).initialize(io_loop, defaults=defaults)
+    def initialize(self, max_clients=10, defaults=None):
+        super(CurlAsyncHTTPClient, self).initialize(defaults=defaults)
         self._multi = pycurl.CurlMulti()
         self._multi.setopt(pycurl.M_TIMERFUNCTION, self._set_timeout)
         self._multi.setopt(pycurl.M_SOCKETFUNCTION, self._handle_socket)
@@ -53,7 +53,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         # SOCKETFUNCTION.  Mitigate the effects of such bugs by
         # forcing a periodic scan of all active requests.
         self._force_timeout_callback = ioloop.PeriodicCallback(
-            self._handle_force_timeout, 1000, io_loop=io_loop)
+            self._handle_force_timeout, 1000)
         self._force_timeout_callback.start()
 
         # Work around a bug in libcurl 7.29.0: Some fields in the curl

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -89,7 +89,7 @@ from tornado.concurrent import Future, TracebackFuture, is_future, chain_future
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 from tornado import stack_context
-from tornado.util import PY3, raise_exc_info
+from tornado.util import PY3, raise_exc_info, TimeoutError
 
 try:
     try:
@@ -152,10 +152,6 @@ class BadYieldError(Exception):
 
 class ReturnValueIgnoredError(Exception):
     pass
-
-
-class TimeoutError(Exception):
-    """Exception raised by ``with_timeout``."""
 
 
 def _value_from_stopiteration(e):
@@ -871,10 +867,10 @@ def maybe_future(x):
 def with_timeout(timeout, future, quiet_exceptions=()):
     """Wraps a `.Future` (or other yieldable object) in a timeout.
 
-    Raises `TimeoutError` if the input future does not complete before
-    ``timeout``, which may be specified in any form allowed by
-    `.IOLoop.add_timeout` (i.e. a `datetime.timedelta` or an absolute time
-    relative to `.IOLoop.time`)
+    Raises `tornado.util.TimeoutError` if the input future does not
+    complete before ``timeout``, which may be specified in any form
+    allowed by `.IOLoop.add_timeout` (i.e. a `datetime.timedelta` or
+    an absolute time relative to `.IOLoop.time`)
 
     If the wrapped `.Future` fails after it has timed out, the exception
     will be logged unless it is of a type contained in ``quiet_exceptions``

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -624,14 +624,14 @@ def Task(func, *args, **kwargs):
 
 
 class YieldFuture(YieldPoint):
-    def __init__(self, future, io_loop=None):
+    def __init__(self, future):
         """Adapts a `.Future` to the `YieldPoint` interface.
 
-        .. versionchanged:: 4.1
-           The ``io_loop`` argument is deprecated.
+        .. versionchanged:: 5.0
+           The ``io_loop`` argument (deprecated since version 4.1) has been removed.
         """
         self.future = future
-        self.io_loop = io_loop or IOLoop.current()
+        self.io_loop = IOLoop.current()
 
     def start(self, runner):
         if not self.future.done():
@@ -868,7 +868,7 @@ def maybe_future(x):
         return fut
 
 
-def with_timeout(timeout, future, io_loop=None, quiet_exceptions=()):
+def with_timeout(timeout, future, quiet_exceptions=()):
     """Wraps a `.Future` (or other yieldable object) in a timeout.
 
     Raises `TimeoutError` if the input future does not complete before
@@ -902,8 +902,7 @@ def with_timeout(timeout, future, io_loop=None, quiet_exceptions=()):
     future = convert_yielded(future)
     result = Future()
     chain_future(future, result)
-    if io_loop is None:
-        io_loop = IOLoop.current()
+    io_loop = IOLoop.current()
 
     def error_callback(future):
         try:

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -359,6 +359,10 @@ class HTTP1Connection(httputil.HTTPConnection):
                 # Applications are discouraged from touching Transfer-Encoding,
                 # but if they do, leave it alone.
                 'Transfer-Encoding' not in headers)
+            # If connection to a 1.1 client will be closed, inform client
+            if (self._request_start_line.version == 'HTTP/1.1' and
+                self._disconnect_on_finish):
+                headers['Connection'] = 'close'
             # If a 1.0 client asked for keep-alive, add the header.
             if (self._request_start_line.version == 'HTTP/1.0' and
                 (self._request_headers.get('Connection', '').lower() ==
@@ -420,7 +424,7 @@ class HTTP1Connection(httputil.HTTPConnection):
     def write(self, chunk, callback=None):
         """Implements `.HTTPConnection.write`.
 
-        For backwards compatibility is is allowed but deprecated to
+        For backwards compatibility it is allowed but deprecated to
         skip `write_headers` and instead call `write()` with a
         pre-encoded header block.
         """

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -164,7 +164,6 @@ class HTTP1Connection(httputil.HTTPConnection):
                     header_data = yield gen.with_timeout(
                         self.stream.io_loop.time() + self.params.header_timeout,
                         header_future,
-                        io_loop=self.stream.io_loop,
                         quiet_exceptions=iostream.StreamClosedError)
                 except gen.TimeoutError:
                     self.close()
@@ -224,7 +223,7 @@ class HTTP1Connection(httputil.HTTPConnection):
                         try:
                             yield gen.with_timeout(
                                 self.stream.io_loop.time() + self._body_timeout,
-                                body_future, self.stream.io_loop,
+                                body_future,
                                 quiet_exceptions=iostream.StreamClosedError)
                         except gen.TimeoutError:
                             gen_log.info("Timeout reading body from %s",

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -250,6 +250,8 @@ class HTTP1Connection(httputil.HTTPConnection):
         except httputil.HTTPInputError as e:
             gen_log.info("Malformed HTTP message from %s: %s",
                          self.context, e)
+            if not self.is_client:
+                yield self.stream.write(b'HTTP/1.1 400 Bad Request\r\n\r\n')
             self.close()
             raise gen.Return(False)
         finally:

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -46,7 +46,7 @@ import weakref
 
 from tornado.concurrent import TracebackFuture
 from tornado.escape import utf8, native_str
-from tornado import httputil, stack_context
+from tornado import gen, httputil, stack_context
 from tornado.ioloop import IOLoop
 from tornado.util import Configurable
 
@@ -75,7 +75,10 @@ class HTTPClient(object):
         self._io_loop = IOLoop(make_current=False)
         if async_client_class is None:
             async_client_class = AsyncHTTPClient
-        self._async_client = async_client_class(self._io_loop, **kwargs)
+        # Create the client while our IOLoop is "current", without
+        # clobbering the thread's real current IOLoop (if any).
+        self._async_client = self._io_loop.run_sync(
+            gen.coroutine(lambda: async_client_class(**kwargs)))
         self._closed = False
 
     def __del__(self):
@@ -120,12 +123,12 @@ class AsyncHTTPClient(Configurable):
     The constructor for this class is magic in several respects: It
     actually creates an instance of an implementation-specific
     subclass, and instances are reused as a kind of pseudo-singleton
-    (one per `.IOLoop`).  The keyword argument ``force_instance=True``
-    can be used to suppress this singleton behavior.  Unless
-    ``force_instance=True`` is used, no arguments other than
-    ``io_loop`` should be passed to the `AsyncHTTPClient` constructor.
-    The implementation subclass as well as arguments to its
-    constructor can be set with the static method `configure()`
+    (one per `.IOLoop`). The keyword argument ``force_instance=True``
+    can be used to suppress this singleton behavior. Unless
+    ``force_instance=True`` is used, no arguments should be passed to
+    the `AsyncHTTPClient` constructor. The implementation subclass as
+    well as arguments to its constructor can be set with the static
+    method `configure()`
 
     All `AsyncHTTPClient` implementations support a ``defaults``
     keyword argument, which can be used to set default values for
@@ -137,8 +140,9 @@ class AsyncHTTPClient(Configurable):
         client = AsyncHTTPClient(force_instance=True,
             defaults=dict(user_agent="MyUserAgent"))
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
+
     """
     @classmethod
     def configurable_base(cls):
@@ -156,16 +160,15 @@ class AsyncHTTPClient(Configurable):
             setattr(cls, attr_name, weakref.WeakKeyDictionary())
         return getattr(cls, attr_name)
 
-    def __new__(cls, io_loop=None, force_instance=False, **kwargs):
-        io_loop = io_loop or IOLoop.current()
+    def __new__(cls, force_instance=False, **kwargs):
+        io_loop = IOLoop.current()
         if force_instance:
             instance_cache = None
         else:
             instance_cache = cls._async_clients()
         if instance_cache is not None and io_loop in instance_cache:
             return instance_cache[io_loop]
-        instance = super(AsyncHTTPClient, cls).__new__(cls, io_loop=io_loop,
-                                                       **kwargs)
+        instance = super(AsyncHTTPClient, cls).__new__(cls, **kwargs)
         # Make sure the instance knows which cache to remove itself from.
         # It can't simply call _async_clients() because we may be in
         # __new__(AsyncHTTPClient) but instance.__class__ may be
@@ -175,8 +178,8 @@ class AsyncHTTPClient(Configurable):
             instance_cache[instance.io_loop] = instance
         return instance
 
-    def initialize(self, io_loop, defaults=None):
-        self.io_loop = io_loop
+    def initialize(self, defaults=None):
+        self.io_loop = IOLoop.current()
         self.defaults = dict(HTTPRequest._DEFAULTS)
         if defaults is not None:
             self.defaults.update(defaults)

--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -134,6 +134,9 @@ class HTTPServer(TCPServer, Configurable,
 
     .. versionchanged:: 4.5
        Added the ``trusted_downstream`` argument.
+
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument has been removed.
     """
     def __init__(self, *args, **kwargs):
         # Ignore args to __init__; real initialization belongs in
@@ -143,7 +146,7 @@ class HTTPServer(TCPServer, Configurable,
         # completely)
         pass
 
-    def initialize(self, request_callback, no_keep_alive=False, io_loop=None,
+    def initialize(self, request_callback, no_keep_alive=False,
                    xheaders=False, ssl_options=None, protocol=None,
                    decompress_request=False,
                    chunk_size=None, max_header_size=None,
@@ -162,7 +165,7 @@ class HTTPServer(TCPServer, Configurable,
             max_body_size=max_body_size,
             body_timeout=body_timeout,
             no_keep_alive=no_keep_alive)
-        TCPServer.__init__(self, io_loop=io_loop, ssl_options=ssl_options,
+        TCPServer.__init__(self, ssl_options=ssl_options,
                            max_buffer_size=max_buffer_size,
                            read_chunk_size=chunk_size)
         self._connections = set()

--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -154,7 +154,6 @@ class HTTPServer(TCPServer, Configurable,
                    max_body_size=None, max_buffer_size=None,
                    trusted_downstream=None):
         self.request_callback = request_callback
-        self.no_keep_alive = no_keep_alive
         self.xheaders = xheaders
         self.protocol = protocol
         self.conn_params = HTTP1ConnectionParameters(

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -829,6 +829,8 @@ def parse_request_start_line(line):
     try:
         method, path, version = line.split(" ")
     except ValueError:
+        # https://tools.ietf.org/html/rfc7230#section-3.1.1
+        # invalid request-line SHOULD respond with a 400 (Bad Request)
         raise HTTPInputError("Malformed HTTP request line")
     if not re.match(r"^HTTP/1\.[0-9]$", version):
         raise HTTPInputError(

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -249,15 +249,7 @@ class IOLoop(Configurable):
 
     @classmethod
     def configurable_default(cls):
-        if hasattr(select, "epoll"):
-            from tornado.platform.epoll import EPollIOLoop
-            return EPollIOLoop
-        if hasattr(select, "kqueue"):
-            # Python 2.6+ on BSD or Mac
-            from tornado.platform.kqueue import KQueueIOLoop
-            return KQueueIOLoop
-        from tornado.platform.select import SelectIOLoop
-        return SelectIOLoop
+        return PollIOLoop
 
     def initialize(self, make_current=None):
         if make_current is None:
@@ -721,6 +713,22 @@ class PollIOLoop(IOLoop):
         self.add_handler(self._waker.fileno(),
                          lambda fd, events: self._waker.consume(),
                          self.READ)
+
+    @classmethod
+    def configurable_base(cls):
+        return PollIOLoop
+
+    @classmethod
+    def configurable_default(cls):
+        if hasattr(select, "epoll"):
+            from tornado.platform.epoll import EPollIOLoop
+            return EPollIOLoop
+        if hasattr(select, "kqueue"):
+            # Python 2.6+ on BSD or Mac
+            from tornado.platform.kqueue import KQueueIOLoop
+            return KQueueIOLoop
+        from tornado.platform.select import SelectIOLoop
+        return SelectIOLoop
 
     def close(self, all_fds=False):
         self._closing = True

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -1000,15 +1000,15 @@ class PeriodicCallback(object):
 
     `start` must be called after the `PeriodicCallback` is created.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
-    def __init__(self, callback, callback_time, io_loop=None):
+    def __init__(self, callback, callback_time):
         self.callback = callback
         if callback_time <= 0:
             raise ValueError("Periodic callback must have a positive callback_time")
         self.callback_time = callback_time
-        self.io_loop = io_loop or IOLoop.current()
+        self.io_loop = IOLoop.current()
         self._running = False
         self._timeout = None
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -48,7 +48,7 @@ from tornado.concurrent import TracebackFuture, is_future
 from tornado.log import app_log, gen_log
 from tornado.platform.auto import set_close_exec, Waker
 from tornado import stack_context
-from tornado.util import PY3, Configurable, errno_from_exception, timedelta_to_seconds
+from tornado.util import PY3, Configurable, errno_from_exception, timedelta_to_seconds, TimeoutError
 
 try:
     import signal
@@ -68,10 +68,6 @@ except ImportError:
 
 
 _POLL_TIMEOUT = 3600.0
-
-
-class TimeoutError(Exception):
-    pass
 
 
 class IOLoop(Configurable):
@@ -457,7 +453,7 @@ class IOLoop(Configurable):
 
         The keyword-only argument ``timeout`` may be used to set
         a maximum duration for the function.  If the timeout expires,
-        a `TimeoutError` is raised.
+        a `tornado.util.TimeoutError` is raised.
 
         This method is useful in conjunction with `tornado.gen.coroutine`
         to allow asynchronous calls in a ``main()`` function::

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -135,12 +135,10 @@ class BaseIOStream(object):
     Subclasses must implement `fileno`, `close_fd`, `write_to_fd`,
     `read_from_fd`, and optionally `get_fd_error`.
     """
-    def __init__(self, io_loop=None, max_buffer_size=None,
+    def __init__(self, max_buffer_size=None,
                  read_chunk_size=None, max_write_buffer_size=None):
         """`BaseIOStream` constructor.
 
-        :arg io_loop: The `.IOLoop` to use; defaults to `.IOLoop.current`.
-                      Deprecated since Tornado 4.1.
         :arg max_buffer_size: Maximum amount of incoming data to buffer;
             defaults to 100MB.
         :arg read_chunk_size: Amount of data to read at one time from the
@@ -151,8 +149,11 @@ class BaseIOStream(object):
         .. versionchanged:: 4.0
            Add the ``max_write_buffer_size`` parameter.  Changed default
            ``read_chunk_size`` to 64KB.
+        .. versionchanged:: 5.0
+           The ``io_loop`` argument (deprecated since version 4.1) has been
+           removed.
         """
-        self.io_loop = io_loop or ioloop.IOLoop.current()
+        self.io_loop = ioloop.IOLoop.current()
         self.max_buffer_size = max_buffer_size or 104857600
         # A chunk size that is too close to max_buffer_size can cause
         # spurious failures.
@@ -1190,8 +1191,7 @@ class IOStream(BaseIOStream):
         self._close_callback = None
 
         future = TracebackFuture()
-        ssl_stream = SSLIOStream(socket, ssl_options=ssl_options,
-                                 io_loop=self.io_loop)
+        ssl_stream = SSLIOStream(socket, ssl_options=ssl_options)
         # Wrap the original close callback so we can fail our Future as well.
         # If we had an "unwrap" counterpart to this method we would need
         # to restore the original callback after our Future resolves

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -99,7 +99,7 @@ class Condition(_TimeoutGarbageCollector):
         # Wait up to 1 second.
         yield condition.wait(timeout=datetime.timedelta(seconds=1))
 
-    The method raises `tornado.gen.TimeoutError` if there's no notification
+    The method raises `tornado.util.TimeoutError` if there's no notification
     before the deadline.
     """
 
@@ -220,7 +220,7 @@ class Event(object):
     def wait(self, timeout=None):
         """Block until the internal flag is true.
 
-        Returns a Future, which raises `tornado.gen.TimeoutError` after a
+        Returns a Future, which raises `tornado.util.TimeoutError` after a
         timeout.
         """
         if timeout is None:
@@ -480,7 +480,7 @@ class Lock(object):
     def acquire(self, timeout=None):
         """Attempt to lock. Returns a Future.
 
-        Returns a Future, which raises `tornado.gen.TimeoutError` after a
+        Returns a Future, which raises `tornado.util.TimeoutError` after a
         timeout.
         """
         return self._block.acquire(timeout)

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -270,6 +270,7 @@ def add_accept_handler(sock, callback):
                 if errno_from_exception(e) == errno.ECONNABORTED:
                     continue
                 raise
+            set_close_exec(connection.fileno())
             callback(connection, address)
     IOLoop.current().add_handler(sock, accept_handler, IOLoop.READ)
 

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -223,9 +223,10 @@ class OptionParser(object):
         override options set earlier on the command line, but can be overridden
         by later flags.
         """
-        if name in self._options:
+        normalized = self._normalize_name(name)
+        if normalized in self._options:
             raise Error("Option %r already defined in %s" %
-                        (name, self._options[name].file_name))
+                        (normalized, self._options[normalized].file_name))
         frame = sys._getframe(0)
         options_file = frame.f_code.co_filename
 
@@ -247,7 +248,6 @@ class OptionParser(object):
             group_name = group
         else:
             group_name = file_name
-        normalized = self._normalize_name(name)
         option = _Option(name, file_name=file_name,
                          default=default, type=type, help=help,
                          metavar=metavar, multiple=multiple,

--- a/tornado/platform/caresresolver.py
+++ b/tornado/platform/caresresolver.py
@@ -19,11 +19,11 @@ class CaresResolver(Resolver):
     the default for ``tornado.simple_httpclient``, but other libraries
     may default to ``AF_UNSPEC``.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
-    def initialize(self, io_loop=None):
-        self.io_loop = io_loop or IOLoop.current()
+    def initialize(self):
+        self.io_loop = IOLoop.current()
         self.channel = pycares.Channel(sock_state_cb=self._sock_state_cb)
         self.fds = {}
 

--- a/tornado/platform/common.py
+++ b/tornado/platform/common.py
@@ -32,10 +32,12 @@ class Waker(interface.Waker):
     and Jython.
     """
     def __init__(self):
+        from .auto import set_close_exec
         # Based on Zope select_trigger.py:
         # https://github.com/zopefoundation/Zope/blob/master/src/ZServer/medusa/thread/select_trigger.py
 
         self.writer = socket.socket()
+        set_close_exec(self.writer.fileno())
         # Disable buffering -- pulling the trigger sends 1 byte,
         # and we want that sent immediately, to wake up ASAP.
         self.writer.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
@@ -54,6 +56,7 @@ class Waker(interface.Waker):
             # http://mail.zope.org/pipermail/zope/2005-July/160433.html
             # for hideous details.
             a = socket.socket()
+            set_close_exec(a.fileno())
             a.bind(("127.0.0.1", 0))
             a.listen(1)
             connect_address = a.getsockname()  # assigned (host, port) pair
@@ -78,6 +81,7 @@ class Waker(interface.Waker):
                 a.close()
 
         self.reader, addr = a.accept()
+        set_close_exec(self.reader.fileno())
         self.reader.setblocking(0)
         self.writer.setblocking(0)
         a.close()

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -382,6 +382,8 @@ class _FD(object):
             self.handler(self.fileobj, tornado.ioloop.IOLoop.ERROR)
             self.lost = True
 
+    writeConnectionLost = readConnectionLost = connectionLost
+
     def logPrefix(self):
         return ''
 

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -112,7 +112,7 @@ class TornadoReactor(PosixReactorBase):
     instead of ``reactor.run()``.
 
     It is also possible to create a non-global reactor by calling
-    ``tornado.platform.twisted.TornadoReactor(io_loop)``.  However, if
+    ``tornado.platform.twisted.TornadoReactor()``.  However, if
     the `.IOLoop` and reactor are to be short-lived (such as those used in
     unit tests), additional cleanup may be required.  Specifically, it is
     recommended to call::
@@ -122,13 +122,11 @@ class TornadoReactor(PosixReactorBase):
 
     before closing the `.IOLoop`.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
-    def __init__(self, io_loop=None):
-        if not io_loop:
-            io_loop = tornado.ioloop.IOLoop.current()
-        self._io_loop = io_loop
+    def __init__(self):
+        self._io_loop = tornado.ioloop.IOLoop.current()
         self._readers = {}  # map of reader objects to fd
         self._writers = {}  # map of writer objects to fd
         self._fds = {}  # a map of fd to a (reader, writer) tuple
@@ -319,7 +317,9 @@ class _TestReactor(TornadoReactor):
     """
     def __init__(self):
         # always use a new ioloop
-        super(_TestReactor, self).__init__(IOLoop())
+        IOLoop(make_current=True)
+        super(_TestReactor, self).__init__()
+        IOLoop.clear_current()
 
     def listenTCP(self, port, factory, backlog=50, interface=''):
         # default to localhost to avoid firewall prompts on the mac
@@ -335,7 +335,7 @@ class _TestReactor(TornadoReactor):
             port, protocol, interface=interface, maxPacketSize=maxPacketSize)
 
 
-def install(io_loop=None):
+def install():
     """Install this package as the default Twisted reactor.
 
     ``install()`` must be called very early in the startup process,
@@ -346,13 +346,11 @@ def install(io_loop=None):
     in multi-process mode, and an external process manager such as
     ``supervisord`` is recommended instead.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
 
     """
-    if not io_loop:
-        io_loop = tornado.ioloop.IOLoop.current()
-    reactor = TornadoReactor(io_loop)
+    reactor = TornadoReactor()
     from twisted.internet.main import installReactor  # type: ignore
     installReactor(reactor)
     return reactor
@@ -526,14 +524,13 @@ class TwistedResolver(Resolver):
 
     Requires Twisted 12.1 or newer.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
-    def initialize(self, io_loop=None):
-        self.io_loop = io_loop or IOLoop.current()
+    def initialize(self):
         # partial copy of twisted.names.client.createResolver, which doesn't
         # allow for a reactor to be passed in.
-        self.reactor = tornado.platform.twisted.TornadoReactor(io_loop)
+        self.reactor = tornado.platform.twisted.TornadoReactor()
 
         host_resolver = twisted.names.hosts.Resolver('/etc/hosts')
         cache_resolver = twisted.names.cache.CacheResolver(reactor=self.reactor)

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -200,15 +200,14 @@ class Subprocess(object):
     * ``stdin``, ``stdout``, and ``stderr`` may have the value
       ``tornado.process.Subprocess.STREAM``, which will make the corresponding
       attribute of the resulting Subprocess a `.PipeIOStream`.
-    * A new keyword argument ``io_loop`` may be used to pass in an IOLoop.
 
     The ``Subprocess.STREAM`` option and the ``set_exit_callback`` and
     ``wait_for_exit`` methods do not work on Windows. There is
     therefore no reason to use this class instead of
     ``subprocess.Popen`` on that platform.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
 
     """
     STREAM = object()
@@ -217,7 +216,7 @@ class Subprocess(object):
     _waiting = {}  # type: ignore
 
     def __init__(self, *args, **kwargs):
-        self.io_loop = kwargs.pop('io_loop', None) or ioloop.IOLoop.current()
+        self.io_loop = ioloop.IOLoop.current()
         # All FDs we create should be closed on error; those in to_close
         # should be closed in the parent process on success.
         pipe_fds = []
@@ -227,19 +226,19 @@ class Subprocess(object):
             kwargs['stdin'] = in_r
             pipe_fds.extend((in_r, in_w))
             to_close.append(in_r)
-            self.stdin = PipeIOStream(in_w, io_loop=self.io_loop)
+            self.stdin = PipeIOStream(in_w)
         if kwargs.get('stdout') is Subprocess.STREAM:
             out_r, out_w = _pipe_cloexec()
             kwargs['stdout'] = out_w
             pipe_fds.extend((out_r, out_w))
             to_close.append(out_w)
-            self.stdout = PipeIOStream(out_r, io_loop=self.io_loop)
+            self.stdout = PipeIOStream(out_r)
         if kwargs.get('stderr') is Subprocess.STREAM:
             err_r, err_w = _pipe_cloexec()
             kwargs['stderr'] = err_w
             pipe_fds.extend((err_r, err_w))
             to_close.append(err_w)
-            self.stderr = PipeIOStream(err_r, io_loop=self.io_loop)
+            self.stderr = PipeIOStream(err_r)
         try:
             self.proc = subprocess.Popen(*args, **kwargs)
         except:
@@ -270,7 +269,7 @@ class Subprocess(object):
         signal handler is causing a problem.
         """
         self._exit_callback = stack_context.wrap(callback)
-        Subprocess.initialize(self.io_loop)
+        Subprocess.initialize()
         Subprocess._waiting[self.pid] = self
         Subprocess._try_cleanup_process(self.pid)
 
@@ -302,7 +301,7 @@ class Subprocess(object):
         return future
 
     @classmethod
-    def initialize(cls, io_loop=None):
+    def initialize(cls):
         """Initializes the ``SIGCHLD`` handler.
 
         The signal handler is run on an `.IOLoop` to avoid locking issues.
@@ -310,13 +309,13 @@ class Subprocess(object):
         same one used by individual Subprocess objects (as long as the
         ``IOLoops`` are each running in separate threads).
 
-        .. versionchanged:: 4.1
-           The ``io_loop`` argument is deprecated.
+        .. versionchanged:: 5.0
+           The ``io_loop`` argument (deprecated since version 4.1) has been
+           removed.
         """
         if cls._initialized:
             return
-        if io_loop is None:
-            io_loop = ioloop.IOLoop.current()
+        io_loop = ioloop.IOLoop.current()
         cls._old_sigchld = signal.signal(
             signal.SIGCHLD,
             lambda sig, frame: io_loop.add_callback_from_signal(cls._cleanup))

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -168,6 +168,11 @@ class Queue(object):
 
         Returns a Future, which raises `tornado.gen.TimeoutError` after a
         timeout.
+
+        ``timeout`` may be a number denoting a time (on the same
+        scale as `tornado.ioloop.IOLoop.time`, normally `time.time`), or a
+        `datetime.timedelta` object for a deadline relative to the
+        current time.
         """
         try:
             self.put_nowait(item)
@@ -200,6 +205,11 @@ class Queue(object):
 
         Returns a Future which resolves once an item is available, or raises
         `tornado.gen.TimeoutError` after a timeout.
+
+        ``timeout`` may be a number denoting a time (on the same
+        scale as `tornado.ioloop.IOLoop.time`, normally `time.time`), or a
+        `datetime.timedelta` object for a deadline relative to the
+        current time.
         """
         future = Future()
         try:

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -166,7 +166,7 @@ class Queue(object):
     def put(self, item, timeout=None):
         """Put an item into the queue, perhaps waiting until there is room.
 
-        Returns a Future, which raises `tornado.gen.TimeoutError` after a
+        Returns a Future, which raises `tornado.util.TimeoutError` after a
         timeout.
 
         ``timeout`` may be a number denoting a time (on the same
@@ -204,7 +204,7 @@ class Queue(object):
         """Remove and return an item from the queue.
 
         Returns a Future which resolves once an item is available, or raises
-        `tornado.gen.TimeoutError` after a timeout.
+        `tornado.util.TimeoutError` after a timeout.
 
         ``timeout`` may be a number denoting a time (on the same
         scale as `tornado.ioloop.IOLoop.time`, normally `time.time`), or a
@@ -258,7 +258,7 @@ class Queue(object):
     def join(self, timeout=None):
         """Block until all items in the queue are processed.
 
-        Returns a Future, which raises `tornado.gen.TimeoutError` after a
+        Returns a Future, which raises `tornado.util.TimeoutError` after a
         timeout.
         """
         return self._finished.wait(timeout)

--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -1,9 +1,12 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <stdint.h>
 
 static PyObject* websocket_mask(PyObject* self, PyObject* args) {
     const char* mask;
     Py_ssize_t mask_len;
+    uint32_t uint32_mask;
+    uint64_t uint64_mask;
     const char* data;
     Py_ssize_t data_len;
     Py_ssize_t i;
@@ -14,13 +17,35 @@ static PyObject* websocket_mask(PyObject* self, PyObject* args) {
         return NULL;
     }
 
+    uint32_mask = ((uint32_t*)mask)[0];
+
     result = PyBytes_FromStringAndSize(NULL, data_len);
     if (!result) {
         return NULL;
     }
     buf = PyBytes_AsString(result);
+
+    if (sizeof(size_t) >= 8) {
+        uint64_mask = uint32_mask;
+        uint64_mask = (uint64_mask << 32) | uint32_mask;
+
+        while (data_len >= 8) {
+            ((uint64_t*)buf)[0] = ((uint64_t*)data)[0] ^ uint64_mask;
+            data += 8;
+            buf += 8;
+            data_len -= 8;
+        }
+    }
+
+    while (data_len >= 4) {
+        ((uint32_t*)buf)[0] = ((uint32_t*)data)[0] ^ uint32_mask;
+        data += 4;
+        buf += 4;
+        data_len -= 4;
+    }
+
     for (i = 0; i < data_len; i++) {
-        buf[i] = data[i] ^ mask[i % 4];
+        buf[i] = data[i] ^ mask[i];
     }
 
     return result;

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -26,6 +26,7 @@ from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream
 from tornado import gen
 from tornado.netutil import Resolver
+from tornado.platform.auto import set_close_exec
 
 _INITIAL_CONNECT_TIMEOUT = 0.3
 
@@ -201,6 +202,7 @@ class TCPClient(object):
             # - 127.0.0.1 for IPv4
             # - ::1 for IPv6
         socket_obj = socket.socket(af)
+        set_close_exec(socket_obj.fileno())
         if source_port_bind or source_ip_bind:
             # If the user requires binding also to a specific IP/port.
             try:

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -155,7 +155,8 @@ class TCPClient(object):
 
     @gen.coroutine
     def connect(self, host, port, af=socket.AF_UNSPEC, ssl_options=None,
-                max_buffer_size=None, source_ip=None, source_port=None):
+                max_buffer_size=None, source_ip=None, source_port=None,
+                timeout=None):
         """Connect to the given host and port.
 
         Asynchronously returns an `.IOStream` (or `.SSLIOStream` if
@@ -173,19 +174,30 @@ class TCPClient(object):
         .. versionchanged:: 4.5
            Added the ``source_ip`` and ``source_port`` arguments.
         """
-        addrinfo = yield self.resolver.resolve(host, port, af)
+        if timeout:
+            addrinfo = yield gen.with_timeout(
+                timeout, self.resolver.resolve(host, port, af))
+        else:
+            addrinfo = yield self.resolver.resolve(host, port, af)
         connector = _Connector(
             addrinfo,
             functools.partial(self._create_stream, max_buffer_size,
                               source_ip=source_ip, source_port=source_port)
         )
-        af, addr, stream = yield connector.start()
+        if timeout:
+            af, addr, stream = yield gen.with_timeout(timeout, connector.start())
+        else:
+            af, addr, stream = yield connector.start()
         # TODO: For better performance we could cache the (af, addr)
         # information here and re-use it on subsequent connections to
         # the same host. (http://tools.ietf.org/html/rfc6555#section-4.2)
         if ssl_options is not None:
-            stream = yield stream.start_tls(False, ssl_options=ssl_options,
-                                            server_hostname=host)
+            if timeout:
+                stream = yield gen.with_timeout(timeout, stream.start_tls(
+                    False, ssl_options=ssl_options, server_hostname=host))
+            else:
+                stream = yield stream.start_tls(False, ssl_options=ssl_options,
+                                                server_hostname=host)
         raise gen.Return(stream)
 
     def _create_stream(self, max_buffer_size, af, addr, source_ip=None,

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -47,8 +47,8 @@ class _Connector(object):
     http://tools.ietf.org/html/rfc6555
 
     """
-    def __init__(self, addrinfo, io_loop, connect):
-        self.io_loop = io_loop
+    def __init__(self, addrinfo, connect):
+        self.io_loop = IOLoop.current()
         self.connect = connect
 
         self.future = Future()
@@ -137,16 +137,15 @@ class _Connector(object):
 class TCPClient(object):
     """A non-blocking TCP connection factory.
 
-    .. versionchanged:: 4.1
-       The ``io_loop`` argument is deprecated.
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
-    def __init__(self, resolver=None, io_loop=None):
-        self.io_loop = io_loop or IOLoop.current()
+    def __init__(self, resolver=None):
         if resolver is not None:
             self.resolver = resolver
             self._own_resolver = False
         else:
-            self.resolver = Resolver(io_loop=io_loop)
+            self.resolver = Resolver()
             self._own_resolver = True
 
     def close(self):
@@ -175,7 +174,7 @@ class TCPClient(object):
         """
         addrinfo = yield self.resolver.resolve(host, port, af)
         connector = _Connector(
-            addrinfo, self.io_loop,
+            addrinfo,
             functools.partial(self._create_stream, max_buffer_size,
                               source_ip=source_ip, source_port=source_port)
         )
@@ -212,7 +211,6 @@ class TCPClient(object):
                 raise
         try:
             stream = IOStream(socket_obj,
-                              io_loop=self.io_loop,
                               max_buffer_size=max_buffer_size)
         except socket.error as e:
             fu = Future()

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -102,10 +102,13 @@ class TCPServer(object):
 
     .. versionadded:: 3.1
        The ``max_buffer_size`` argument.
+
+    .. versionchanged:: 5.0
+       The ``io_loop`` argument has been removed.
     """
-    def __init__(self, io_loop=None, ssl_options=None, max_buffer_size=None,
+    def __init__(self, ssl_options=None, max_buffer_size=None,
                  read_chunk_size=None):
-        self.io_loop = io_loop
+        self.io_loop = IOLoop.current()
         self.ssl_options = ssl_options
         self._sockets = {}  # fd -> socket object
         self._pending_sockets = []
@@ -151,13 +154,9 @@ class TCPServer(object):
         method and `tornado.process.fork_processes` to provide greater
         control over the initialization of a multi-process server.
         """
-        if self.io_loop is None:
-            self.io_loop = IOLoop.current()
-
         for sock in sockets:
             self._sockets[sock.fileno()] = sock
-            add_accept_handler(sock, self._handle_connection,
-                               io_loop=self.io_loop)
+            add_accept_handler(sock, self._handle_connection)
 
     def add_socket(self, socket):
         """Singular version of `add_sockets`.  Takes a single socket object."""
@@ -284,11 +283,11 @@ class TCPServer(object):
                     raise
         try:
             if self.ssl_options is not None:
-                stream = SSLIOStream(connection, io_loop=self.io_loop,
+                stream = SSLIOStream(connection,
                                      max_buffer_size=self.max_buffer_size,
                                      read_chunk_size=self.read_chunk_size)
             else:
-                stream = IOStream(connection, io_loop=self.io_loop,
+                stream = IOStream(connection,
                                   max_buffer_size=self.max_buffer_size,
                                   read_chunk_size=self.read_chunk_size)
 

--- a/tornado/test/autoreload_test.py
+++ b/tornado/test/autoreload_test.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import, division, print_function
+import os
+import subprocess
+from subprocess import Popen
+import sys
+from tempfile import mkdtemp
+
+from tornado.test.util import unittest
+
+
+MAIN = """\
+import os
+import sys
+
+from tornado import autoreload
+
+# This import will fail if path is not set up correctly
+import testapp
+
+print('Starting')
+if 'TESTAPP_STARTED' not in os.environ:
+    os.environ['TESTAPP_STARTED'] = '1'
+    sys.stdout.flush()
+    autoreload._reload()
+"""
+
+
+class AutoreloadTest(unittest.TestCase):
+    def test_reload_module(self):
+        # Create temporary test application
+        path = mkdtemp()
+        os.mkdir(os.path.join(path, 'testapp'))
+        open(os.path.join(path, 'testapp/__init__.py'), 'w').close()
+        with open(os.path.join(path, 'testapp/__main__.py'), 'w') as f:
+            f.write(MAIN)
+
+        # Make sure the tornado module under test is available to the test
+        # application
+        pythonpath = os.getcwd()
+        if 'PYTHONPATH' in os.environ:
+            pythonpath += os.pathsep + os.environ['PYTHONPATH']
+
+        p = Popen(
+            [sys.executable, '-m', 'testapp'], stdout=subprocess.PIPE,
+            cwd=path, env=dict(os.environ, PYTHONPATH=pythonpath),
+            universal_newlines=True)
+        out = p.communicate()[0]
+        self.assertEqual(out, 'Starting\nStarting\n')

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -25,6 +25,7 @@ import traceback
 from tornado.concurrent import Future, return_future, ReturnValueIgnoredError, run_on_executor
 from tornado.escape import utf8, to_unicode
 from tornado import gen
+from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream
 from tornado.log import app_log
 from tornado import stack_context
@@ -217,9 +218,8 @@ class CapError(Exception):
 
 
 class BaseCapClient(object):
-    def __init__(self, port, io_loop):
+    def __init__(self, port):
         self.port = port
-        self.io_loop = io_loop
 
     def process_response(self, data):
         status, message = re.match('(.*)\t(.*)\n', to_unicode(data)).groups()
@@ -233,7 +233,7 @@ class ManualCapClient(BaseCapClient):
     def capitalize(self, request_data, callback=None):
         logging.info("capitalize")
         self.request_data = request_data
-        self.stream = IOStream(socket.socket(), io_loop=self.io_loop)
+        self.stream = IOStream(socket.socket())
         self.stream.connect(('127.0.0.1', self.port),
                             callback=self.handle_connect)
         self.future = Future()
@@ -261,7 +261,7 @@ class DecoratorCapClient(BaseCapClient):
     def capitalize(self, request_data, callback):
         logging.info("capitalize")
         self.request_data = request_data
-        self.stream = IOStream(socket.socket(), io_loop=self.io_loop)
+        self.stream = IOStream(socket.socket())
         self.stream.connect(('127.0.0.1', self.port),
                             callback=self.handle_connect)
         self.callback = callback
@@ -282,7 +282,7 @@ class GeneratorCapClient(BaseCapClient):
     @gen.engine
     def capitalize(self, request_data, callback):
         logging.info('capitalize')
-        stream = IOStream(socket.socket(), io_loop=self.io_loop)
+        stream = IOStream(socket.socket())
         logging.info('connecting')
         yield gen.Task(stream.connect, ('127.0.0.1', self.port))
         stream.write(utf8(request_data + '\n'))
@@ -296,10 +296,10 @@ class GeneratorCapClient(BaseCapClient):
 class ClientTestMixin(object):
     def setUp(self):
         super(ClientTestMixin, self).setUp()  # type: ignore
-        self.server = CapServer(io_loop=self.io_loop)
+        self.server = CapServer()
         sock, port = bind_unused_port()
         self.server.add_sockets([sock])
-        self.client = self.client_class(io_loop=self.io_loop, port=port)
+        self.client = self.client_class(port=port)
 
     def tearDown(self):
         self.server.stop()
@@ -362,74 +362,41 @@ class RunOnExecutorTest(AsyncTestCase):
     @gen_test
     def test_no_calling(self):
         class Object(object):
-            def __init__(self, io_loop):
-                self.io_loop = io_loop
+            def __init__(self):
                 self.executor = futures.thread.ThreadPoolExecutor(1)
 
             @run_on_executor
             def f(self):
                 return 42
 
-        o = Object(io_loop=self.io_loop)
+        o = Object()
         answer = yield o.f()
         self.assertEqual(answer, 42)
 
     @gen_test
     def test_call_with_no_args(self):
         class Object(object):
-            def __init__(self, io_loop):
-                self.io_loop = io_loop
+            def __init__(self):
                 self.executor = futures.thread.ThreadPoolExecutor(1)
 
             @run_on_executor()
             def f(self):
                 return 42
 
-        o = Object(io_loop=self.io_loop)
-        answer = yield o.f()
-        self.assertEqual(answer, 42)
-
-    @gen_test
-    def test_call_with_io_loop(self):
-        class Object(object):
-            def __init__(self, io_loop):
-                self._io_loop = io_loop
-                self.executor = futures.thread.ThreadPoolExecutor(1)
-
-            @run_on_executor(io_loop='_io_loop')
-            def f(self):
-                return 42
-
-        o = Object(io_loop=self.io_loop)
+        o = Object()
         answer = yield o.f()
         self.assertEqual(answer, 42)
 
     @gen_test
     def test_call_with_executor(self):
         class Object(object):
-            def __init__(self, io_loop):
-                self.io_loop = io_loop
+            def __init__(self):
                 self.__executor = futures.thread.ThreadPoolExecutor(1)
 
             @run_on_executor(executor='_Object__executor')
             def f(self):
                 return 42
 
-        o = Object(io_loop=self.io_loop)
-        answer = yield o.f()
-        self.assertEqual(answer, 42)
-
-    @gen_test
-    def test_call_with_both(self):
-        class Object(object):
-            def __init__(self, io_loop):
-                self._io_loop = io_loop
-                self.__executor = futures.thread.ThreadPoolExecutor(1)
-
-            @run_on_executor(io_loop='_io_loop', executor='_Object__executor')
-            def f(self):
-                return 42
-
-        o = Object(io_loop=self.io_loop)
+        o = Object()
         answer = yield o.f()
         self.assertEqual(answer, 42)

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -24,8 +24,7 @@ if pycurl is not None:
 @unittest.skipIf(pycurl is None, "pycurl module not present")
 class CurlHTTPClientCommonTestCase(httpclient_test.HTTPClientCommonTestCase):
     def get_http_client(self):
-        client = CurlAsyncHTTPClient(io_loop=self.io_loop,
-                                     defaults=dict(allow_ipv6=False))
+        client = CurlAsyncHTTPClient(defaults=dict(allow_ipv6=False))
         # make sure AsyncHTTPClient magic doesn't give us the wrong class
         self.assertTrue(isinstance(client, CurlAsyncHTTPClient))
         return client
@@ -94,7 +93,7 @@ class CurlHTTPClientTestCase(AsyncHTTPTestCase):
         ])
 
     def create_client(self, **kwargs):
-        return CurlAsyncHTTPClient(self.io_loop, force_instance=True,
+        return CurlAsyncHTTPClient(force_instance=True,
                                    defaults=dict(allow_ipv6=False),
                                    **kwargs)
 

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1096,8 +1096,7 @@ class GenTaskHandler(RequestHandler):
     @asynchronous
     @gen.engine
     def get(self):
-        io_loop = self.request.connection.stream.io_loop
-        client = AsyncHTTPClient(io_loop=io_loop)
+        client = AsyncHTTPClient()
         response = yield gen.Task(client.fetch, self.get_argument('url'))
         response.rethrow()
         self.finish(b"got response: " + response.body)
@@ -1250,7 +1249,7 @@ class WithTimeoutTest(AsyncTestCase):
         self.io_loop.add_timeout(datetime.timedelta(seconds=0.1),
                                  lambda: future.set_result('asdf'))
         result = yield gen.with_timeout(datetime.timedelta(seconds=3600),
-                                        future, io_loop=self.io_loop)
+                                        future)
         self.assertEqual(result, 'asdf')
 
     @gen_test
@@ -1261,14 +1260,14 @@ class WithTimeoutTest(AsyncTestCase):
             lambda: future.set_exception(ZeroDivisionError()))
         with self.assertRaises(ZeroDivisionError):
             yield gen.with_timeout(datetime.timedelta(seconds=3600),
-                                   future, io_loop=self.io_loop)
+                                   future)
 
     @gen_test
     def test_already_resolved(self):
         future = Future()
         future.set_result('asdf')
         result = yield gen.with_timeout(datetime.timedelta(seconds=3600),
-                                        future, io_loop=self.io_loop)
+                                        future)
         self.assertEqual(result, 'asdf')
 
     @unittest.skipIf(futures is None, 'futures module not present')

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -582,16 +582,11 @@ class HTTPResponseTestCase(unittest.TestCase):
 
 class SyncHTTPClientTest(unittest.TestCase):
     def setUp(self):
-        if IOLoop.configured_class().__name__ in ('TwistedIOLoop',
-                                                  'AsyncIOMainLoop'):
+        if IOLoop.configured_class().__name__ == 'TwistedIOLoop':
             # TwistedIOLoop only supports the global reactor, so we can't have
             # separate IOLoops for client and server threads.
-            # AsyncIOMainLoop doesn't work with the default policy
-            # (although it could with some tweaks to this test and a
-            # policy that created loops for non-main threads).
             raise unittest.SkipTest(
-                'Sync HTTPClient not compatible with TwistedIOLoop or '
-                'AsyncIOMainLoop')
+                'Sync HTTPClient not compatible with TwistedIOLoop')
         self.server_ioloop = IOLoop()
 
         @gen.coroutine

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -728,6 +728,7 @@ class KeepAliveTest(AsyncHTTPTestCase):
         self.stream.read_until_close(callback=self.stop)
         data = self.wait()
         self.assertTrue(not data)
+        self.assertEqual(self.headers['Connection'], 'close')
         self.close()
 
     # keepalive is supported for http 1.0 too, but it's opt-in

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -408,12 +408,13 @@ class HTTPServerRawTest(AsyncHTTPTestCase):
         self.wait()
 
     def test_malformed_first_line_response(self):
-        self.stream.write(b'asdf\r\n\r\n')
-        read_stream_body(self.stream, self.stop)
-        start_line, headers, response = self.wait()
-        self.assertEqual('HTTP/1.1', start_line.version)
-        self.assertEqual(400, start_line.code)
-        self.assertEqual('Bad Request', start_line.reason)
+        with ExpectLog(gen_log, '.*Malformed HTTP request line'):
+            self.stream.write(b'asdf\r\n\r\n')
+            read_stream_body(self.stream, self.stop)
+            start_line, headers, response = self.wait()
+            self.assertEqual('HTTP/1.1', start_line.version)
+            self.assertEqual(400, start_line.code)
+            self.assertEqual('Bad Request', start_line.reason)
 
     def test_malformed_first_line_log(self):
         with ExpectLog(gen_log, '.*Malformed HTTP request line'):

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -256,7 +256,7 @@ class HTTPConnectionTest(AsyncHTTPTestCase):
         # Run through a 100-continue interaction by hand:
         # When given Expect: 100-continue, we get a 100 response after the
         # headers, and then the real response after the body.
-        stream = IOStream(socket.socket(), io_loop=self.io_loop)
+        stream = IOStream(socket.socket())
         stream.connect(("127.0.0.1", self.get_http_port()), callback=self.stop)
         self.wait()
         stream.write(b"\r\n".join([b"POST /hello HTTP/1.1",
@@ -597,9 +597,9 @@ class UnixSocketTest(AsyncTestCase):
         self.sockfile = os.path.join(self.tmpdir, "test.sock")
         sock = netutil.bind_unix_socket(self.sockfile)
         app = Application([("/hello", HelloWorldRequestHandler)])
-        self.server = HTTPServer(app, io_loop=self.io_loop)
+        self.server = HTTPServer(app)
         self.server.add_socket(sock)
-        self.stream = IOStream(socket.socket(socket.AF_UNIX), io_loop=self.io_loop)
+        self.stream = IOStream(socket.socket(socket.AF_UNIX))
         self.stream.connect(self.sockfile, self.stop)
         self.wait()
 
@@ -681,7 +681,7 @@ class KeepAliveTest(AsyncHTTPTestCase):
 
     # The next few methods are a crude manual http client
     def connect(self):
-        self.stream = IOStream(socket.socket(), io_loop=self.io_loop)
+        self.stream = IOStream(socket.socket())
         self.stream.connect(('127.0.0.1', self.get_http_port()), self.stop)
         self.wait()
 
@@ -842,7 +842,7 @@ class StreamingChunkSizeTest(AsyncHTTPTestCase):
     def get_http_client(self):
         # body_producer doesn't work on curl_httpclient, so override the
         # configured AsyncHTTPClient implementation.
-        return SimpleAsyncHTTPClient(io_loop=self.io_loop)
+        return SimpleAsyncHTTPClient()
 
     def get_httpserver_options(self):
         return dict(chunk_size=self.CHUNK_SIZE, decompress_request=True)
@@ -1025,7 +1025,7 @@ class BodyLimitsTest(AsyncHTTPTestCase):
     def get_http_client(self):
         # body_producer doesn't work on curl_httpclient, so override the
         # configured AsyncHTTPClient implementation.
-        return SimpleAsyncHTTPClient(io_loop=self.io_loop)
+        return SimpleAsyncHTTPClient()
 
     def test_small_body(self):
         response = self.fetch('/buffered', method='PUT', body=b'a' * 4096)

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -29,18 +29,19 @@ from io import BytesIO
 
 def read_stream_body(stream, callback):
     """Reads an HTTP response from `stream` and runs callback with its
-    headers and body."""
+    start_line, headers and body."""
     chunks = []
 
     class Delegate(HTTPMessageDelegate):
         def headers_received(self, start_line, headers):
             self.headers = headers
+            self.start_line = start_line
 
         def data_received(self, chunk):
             chunks.append(chunk)
 
         def finish(self):
-            callback((self.headers, b''.join(chunks)))
+            callback((self.start_line, self.headers, b''.join(chunks)))
     conn = HTTP1Connection(stream, True)
     conn.read_response(Delegate())
 
@@ -217,7 +218,7 @@ class HTTPConnectionTest(AsyncHTTPTestCase):
                              [utf8("Content-Length: %d" % len(body))]) +
                 newline + newline + body)
             read_stream_body(stream, self.stop)
-            headers, body = self.wait()
+            start_line, headers, body = self.wait()
             return body
 
     def test_multipart_form(self):
@@ -406,7 +407,15 @@ class HTTPServerRawTest(AsyncHTTPTestCase):
         self.io_loop.add_timeout(datetime.timedelta(seconds=0.001), self.stop)
         self.wait()
 
-    def test_malformed_first_line(self):
+    def test_malformed_first_line_response(self):
+        self.stream.write(b'asdf\r\n\r\n')
+        read_stream_body(self.stream, self.stop)
+        start_line, headers, response = self.wait()
+        self.assertEqual('HTTP/1.1', start_line.version)
+        self.assertEqual(400, start_line.code)
+        self.assertEqual('Bad Request', start_line.reason)
+
+    def test_malformed_first_line_log(self):
         with ExpectLog(gen_log, '.*Malformed HTTP request line'):
             self.stream.write(b'asdf\r\n\r\n')
             # TODO: need an async version of ExpectLog so we don't need
@@ -438,7 +447,7 @@ bar
 
 """.replace(b"\n", b"\r\n"))
         read_stream_body(self.stream, self.stop)
-        headers, response = self.wait()
+        start_line, headers, response = self.wait()
         self.assertEqual(json_decode(response), {u'foo': [u'bar']})
 
     def test_chunked_request_uppercase(self):
@@ -457,7 +466,7 @@ bar
 
 """.replace(b"\n", b"\r\n"))
         read_stream_body(self.stream, self.stop)
-        headers, response = self.wait()
+        start_line, headers, response = self.wait()
         self.assertEqual(json_decode(response), {u'foo': [u'bar']})
 
     def test_invalid_content_length(self):
@@ -627,7 +636,7 @@ class UnixSocketTest(AsyncTestCase):
             self.stream.write(b"garbage\r\n\r\n")
             self.stream.read_until_close(self.stop)
             response = self.wait()
-        self.assertEqual(response, b"")
+        self.assertEqual(response, b"HTTP/1.1 400 Bad Request\r\n\r\n")
 
 
 class KeepAliveTest(AsyncHTTPTestCase):
@@ -1036,24 +1045,26 @@ class BodyLimitsTest(AsyncHTTPTestCase):
     def test_large_body_buffered(self):
         with ExpectLog(gen_log, '.*Content-Length too long'):
             response = self.fetch('/buffered', method='PUT', body=b'a' * 10240)
-        self.assertEqual(response.code, 599)
+        self.assertEqual(response.code, 400)
 
     def test_large_body_buffered_chunked(self):
         with ExpectLog(gen_log, '.*chunked body too large'):
             response = self.fetch('/buffered', method='PUT',
                                   body_producer=lambda write: write(b'a' * 10240))
-        self.assertEqual(response.code, 599)
+        # this test is flaky on windows; accept 400 (expected) or 599
+        self.assertIn(response.code, [400, 599])
 
     def test_large_body_streaming(self):
         with ExpectLog(gen_log, '.*Content-Length too long'):
             response = self.fetch('/streaming', method='PUT', body=b'a' * 10240)
-        self.assertEqual(response.code, 599)
+        self.assertEqual(response.code, 400)
 
     def test_large_body_streaming_chunked(self):
         with ExpectLog(gen_log, '.*chunked body too large'):
             response = self.fetch('/streaming', method='PUT',
                                   body_producer=lambda write: write(b'a' * 10240))
-        self.assertEqual(response.code, 599)
+        # this test is flaky on windows; accept 400 (expected) or 599
+        self.assertIn(response.code, [400, 599])
 
     def test_large_body_streaming_override(self):
         response = self.fetch('/streaming?expected_size=10240', method='PUT',
@@ -1090,14 +1101,14 @@ class BodyLimitsTest(AsyncHTTPTestCase):
             stream.write(b'PUT /streaming?expected_size=10240 HTTP/1.1\r\n'
                          b'Content-Length: 10240\r\n\r\n')
             stream.write(b'a' * 10240)
-            headers, response = yield gen.Task(read_stream_body, stream)
+            start_line, headers, response = yield gen.Task(read_stream_body, stream)
             self.assertEqual(response, b'10240')
             # Without the ?expected_size parameter, we get the old default value
             stream.write(b'PUT /streaming HTTP/1.1\r\n'
                          b'Content-Length: 10240\r\n\r\n')
             with ExpectLog(gen_log, '.*Content-Length too long'):
                 data = yield stream.read_until_close()
-            self.assertEqual(data, b'')
+            self.assertEqual(data, b'HTTP/1.1 400 Bad Request\r\n\r\n')
         finally:
             stream.close()
 

--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -45,3 +45,9 @@ class ImportTest(unittest.TestCase):
             pass
         else:
             import tornado.curl_httpclient
+
+    def test_import_aliases(self):
+        # Ensure we don't delete formerly-documented aliases accidentally.
+        import tornado.ioloop, tornado.gen, tornado.util
+        self.assertIs(tornado.ioloop.TimeoutError, tornado.util.TimeoutError)
+        self.assertIs(tornado.gen.TimeoutError, tornado.util.TimeoutError)

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -185,8 +185,7 @@ class TestIOStreamMixin(object):
         def connect_callback():
             streams[1] = client_stream
             self.stop()
-        netutil.add_accept_handler(listener, accept_callback,
-                                   io_loop=self.io_loop)
+        netutil.add_accept_handler(listener, accept_callback)
         client_stream = self._make_client_iostream(socket.socket(), **kwargs)
         client_stream.connect(('127.0.0.1', port),
                               callback=connect_callback)
@@ -227,7 +226,7 @@ class TestIOStreamMixin(object):
         # epoll IOLoop in this respect)
         cleanup_func, port = refusing_port()
         self.addCleanup(cleanup_func)
-        stream = IOStream(socket.socket(), self.io_loop)
+        stream = IOStream(socket.socket())
         self.connect_called = False
 
         def connect_callback():
@@ -255,7 +254,7 @@ class TestIOStreamMixin(object):
         # so we mock it instead. If IOStream changes to call a Resolver
         # before sock.connect, the mock target will need to change too.
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        stream = IOStream(s, io_loop=self.io_loop)
+        stream = IOStream(s)
         stream.set_close_callback(self.stop)
         with mock.patch('socket.socket.connect',
                         side_effect=socket.gaierror(errno.EIO, 'boom')):
@@ -845,12 +844,12 @@ class TestIOStreamMixin(object):
 
 class TestIOStreamWebHTTP(TestIOStreamWebMixin, AsyncHTTPTestCase):
     def _make_client_iostream(self):
-        return IOStream(socket.socket(), io_loop=self.io_loop)
+        return IOStream(socket.socket())
 
 
 class TestIOStreamWebHTTPS(TestIOStreamWebMixin, AsyncHTTPSTestCase):
     def _make_client_iostream(self):
-        return SSLIOStream(socket.socket(), io_loop=self.io_loop,
+        return SSLIOStream(socket.socket(),
                            ssl_options=dict(cert_reqs=ssl.CERT_NONE))
 
 
@@ -868,10 +867,10 @@ class TestIOStreamSSL(TestIOStreamMixin, AsyncTestCase):
                                      server_side=True,
                                      do_handshake_on_connect=False,
                                      **_server_ssl_options())
-        return SSLIOStream(connection, io_loop=self.io_loop, **kwargs)
+        return SSLIOStream(connection, **kwargs)
 
     def _make_client_iostream(self, connection, **kwargs):
-        return SSLIOStream(connection, io_loop=self.io_loop,
+        return SSLIOStream(connection,
                            ssl_options=dict(cert_reqs=ssl.CERT_NONE),
                            **kwargs)
 
@@ -889,12 +888,11 @@ class TestIOStreamSSLContext(TestIOStreamMixin, AsyncTestCase):
         connection = ssl_wrap_socket(connection, context,
                                      server_side=True,
                                      do_handshake_on_connect=False)
-        return SSLIOStream(connection, io_loop=self.io_loop, **kwargs)
+        return SSLIOStream(connection, **kwargs)
 
     def _make_client_iostream(self, connection, **kwargs):
         context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        return SSLIOStream(connection, io_loop=self.io_loop,
-                           ssl_options=context, **kwargs)
+        return SSLIOStream(connection, ssl_options=context, **kwargs)
 
 
 class TestIOStreamStartTLS(AsyncTestCase):
@@ -1100,8 +1098,8 @@ class TestPipeIOStream(AsyncTestCase):
     def test_pipe_iostream(self):
         r, w = os.pipe()
 
-        rs = PipeIOStream(r, io_loop=self.io_loop)
-        ws = PipeIOStream(w, io_loop=self.io_loop)
+        rs = PipeIOStream(r)
+        ws = PipeIOStream(w)
 
         ws.write(b"hel")
         ws.write(b"lo world")
@@ -1125,8 +1123,8 @@ class TestPipeIOStream(AsyncTestCase):
     def test_pipe_iostream_big_write(self):
         r, w = os.pipe()
 
-        rs = PipeIOStream(r, io_loop=self.io_loop)
-        ws = PipeIOStream(w, io_loop=self.io_loop)
+        rs = PipeIOStream(r)
+        ws = PipeIOStream(w)
 
         NUM_BYTES = 1048576
 

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -78,7 +78,7 @@ def _failing_getaddrinfo(*args):
 class BlockingResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(BlockingResolverTest, self).setUp()
-        self.resolver = BlockingResolver(io_loop=self.io_loop)
+        self.resolver = BlockingResolver()
 
 
 # getaddrinfo-based tests need mocking to reliably generate errors;
@@ -87,7 +87,7 @@ class BlockingResolverTest(AsyncTestCase, _ResolverTestMixin):
 class BlockingResolverErrorTest(AsyncTestCase, _ResolverErrorTestMixin):
     def setUp(self):
         super(BlockingResolverErrorTest, self).setUp()
-        self.resolver = BlockingResolver(io_loop=self.io_loop)
+        self.resolver = BlockingResolver()
         self.real_getaddrinfo = socket.getaddrinfo
         socket.getaddrinfo = _failing_getaddrinfo
 
@@ -101,7 +101,7 @@ class BlockingResolverErrorTest(AsyncTestCase, _ResolverErrorTestMixin):
 class ThreadedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(ThreadedResolverTest, self).setUp()
-        self.resolver = ThreadedResolver(io_loop=self.io_loop)
+        self.resolver = ThreadedResolver()
 
     def tearDown(self):
         self.resolver.close()
@@ -111,7 +111,7 @@ class ThreadedResolverTest(AsyncTestCase, _ResolverTestMixin):
 class ThreadedResolverErrorTest(AsyncTestCase, _ResolverErrorTestMixin):
     def setUp(self):
         super(ThreadedResolverErrorTest, self).setUp()
-        self.resolver = BlockingResolver(io_loop=self.io_loop)
+        self.resolver = BlockingResolver()
         self.real_getaddrinfo = socket.getaddrinfo
         socket.getaddrinfo = _failing_getaddrinfo
 
@@ -158,7 +158,7 @@ class ThreadedResolverImportTest(unittest.TestCase):
 class CaresResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(CaresResolverTest, self).setUp()
-        self.resolver = CaresResolver(io_loop=self.io_loop)
+        self.resolver = CaresResolver()
 
 
 # TwistedResolver produces consistent errors in our test cases so we
@@ -170,7 +170,7 @@ class TwistedResolverTest(AsyncTestCase, _ResolverTestMixin,
                           _ResolverErrorTestMixin):
     def setUp(self):
         super(TwistedResolverTest, self).setUp()
-        self.resolver = TwistedResolver(io_loop=self.io_loop)
+        self.resolver = TwistedResolver()
 
 
 class IsValidIPTest(unittest.TestCase):

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -7,7 +7,7 @@ import sys
 
 from tornado.options import OptionParser, Error
 from tornado.util import basestring_type, PY3
-from tornado.test.util import unittest
+from tornado.test.util import unittest, subTest
 
 if PY3:
     from io import StringIO
@@ -231,6 +231,24 @@ class OptionsTest(unittest.TestCase):
             options.define('foo')
         self.assertRegexpMatches(str(cm.exception),
                                  'Option.*foo.*already defined')
+
+    def test_error_redefine_underscore(self):
+        # Ensure that the dash/underscore normalization doesn't
+        # interfere with the redefinition error.
+        tests = [
+            ('foo-bar', 'foo-bar'),
+            ('foo_bar', 'foo_bar'),
+            ('foo-bar', 'foo_bar'),
+            ('foo_bar', 'foo-bar'),
+            ]
+        for a, b in tests:
+            with subTest(self, a=a, b=b):
+                options = OptionParser()
+                options.define(a)
+                with self.assertRaises(Error) as cm:
+                    options.define(b)
+                self.assertRegexpMatches(str(cm.exception),
+                                         'Option.*foo.bar.*already defined')
 
     def test_dash_underscore_cli(self):
         # Dashes and underscores should be interchangeable.

--- a/tornado/test/process_test.py
+++ b/tornado/test/process_test.py
@@ -147,8 +147,7 @@ class SubprocessTest(AsyncTestCase):
                                     "LayeredTwistedIOLoop")
         subproc = Subprocess([sys.executable, '-u', '-i'],
                              stdin=Subprocess.STREAM,
-                             stdout=Subprocess.STREAM, stderr=subprocess.STDOUT,
-                             io_loop=self.io_loop)
+                             stdout=Subprocess.STREAM, stderr=subprocess.STDOUT)
         self.addCleanup(lambda: (subproc.proc.terminate(), subproc.proc.wait()))
         subproc.stdout.read_until(b'>>> ', self.stop)
         self.wait()
@@ -168,8 +167,7 @@ class SubprocessTest(AsyncTestCase):
         # Close the parent's stdin handle and see that the child recognizes it.
         subproc = Subprocess([sys.executable, '-u', '-i'],
                              stdin=Subprocess.STREAM,
-                             stdout=Subprocess.STREAM, stderr=subprocess.STDOUT,
-                             io_loop=self.io_loop)
+                             stdout=Subprocess.STREAM, stderr=subprocess.STDOUT)
         self.addCleanup(lambda: (subproc.proc.terminate(), subproc.proc.wait()))
         subproc.stdout.read_until(b'>>> ', self.stop)
         self.wait()
@@ -184,8 +182,7 @@ class SubprocessTest(AsyncTestCase):
         skip_if_twisted()
         subproc = Subprocess([sys.executable, '-u', '-c',
                               r"import sys; sys.stderr.write('hello\n')"],
-                             stderr=Subprocess.STREAM,
-                             io_loop=self.io_loop)
+                             stderr=Subprocess.STREAM)
         self.addCleanup(lambda: (subproc.proc.terminate(), subproc.proc.wait()))
         subproc.stderr.read_until(b'\n', self.stop)
         data = self.wait()
@@ -194,10 +191,9 @@ class SubprocessTest(AsyncTestCase):
     def test_sigchild(self):
         # Twisted's SIGCHLD handler and Subprocess's conflict with each other.
         skip_if_twisted()
-        Subprocess.initialize(io_loop=self.io_loop)
+        Subprocess.initialize()
         self.addCleanup(Subprocess.uninitialize)
-        subproc = Subprocess([sys.executable, '-c', 'pass'],
-                             io_loop=self.io_loop)
+        subproc = Subprocess([sys.executable, '-c', 'pass'])
         subproc.set_exit_callback(self.stop)
         ret = self.wait()
         self.assertEqual(ret, 0)
@@ -215,12 +211,11 @@ class SubprocessTest(AsyncTestCase):
 
     def test_sigchild_signal(self):
         skip_if_twisted()
-        Subprocess.initialize(io_loop=self.io_loop)
+        Subprocess.initialize()
         self.addCleanup(Subprocess.uninitialize)
         subproc = Subprocess([sys.executable, '-c',
                               'import time; time.sleep(30)'],
-                             stdout=Subprocess.STREAM,
-                             io_loop=self.io_loop)
+                             stdout=Subprocess.STREAM)
         subproc.set_exit_callback(self.stop)
         os.kill(subproc.pid, signal.SIGTERM)
         try:

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -25,6 +25,7 @@ TEST_MODULES = [
     'tornado.util.doctests',
     'tornado.test.asyncio_test',
     'tornado.test.auth_test',
+    'tornado.test.autoreload_test',
     'tornado.test.concurrent_test',
     'tornado.test.curl_httpclient_test',
     'tornado.test.escape_test',

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -80,13 +80,15 @@ class LogCounter(logging.Filter):
     def __init__(self, *args, **kwargs):
         # Can't use super() because logging.Filter is an old-style class in py26
         logging.Filter.__init__(self, *args, **kwargs)
-        self.warning_count = self.error_count = 0
+        self.info_count = self.warning_count = self.error_count = 0
 
     def filter(self, record):
         if record.levelno >= logging.ERROR:
             self.error_count += 1
         elif record.levelno >= logging.WARNING:
             self.warning_count += 1
+        elif record.levelno >= logging.INFO:
+            self.info_count += 1
         return True
 
 
@@ -177,12 +179,15 @@ def main():
     try:
         tornado.testing.main(**kwargs)
     finally:
-        # The tests should run clean; consider it a failure if they logged
-        # any warnings or errors. We'd like to ban info logs too, but
-        # we can't count them cleanly due to interactions with LogTrapTestCase.
-        if log_counter.warning_count > 0 or log_counter.error_count > 0:
-            logging.error("logged %d warnings and %d errors",
-                          log_counter.warning_count, log_counter.error_count)
+        # The tests should run clean; consider it a failure if they
+        # logged anything at info level or above (except for the one
+        # allowed info message "PASS")
+        if (log_counter.info_count > 1 or
+            log_counter.warning_count > 0 or
+            log_counter.error_count > 0):
+            logging.error("logged %d infos, %d warnings, and %d errors",
+                          log_counter.info_count, log_counter.warning_count,
+                          log_counter.error_count)
             sys.exit(1)
 
 

--- a/tornado/test/stack_context_test.py
+++ b/tornado/test/stack_context_test.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 from tornado import gen
+from tornado.ioloop import IOLoop
 from tornado.log import app_log
 from tornado.stack_context import (StackContext, wrap, NullContext, StackContextInconsistentError,
                                    ExceptionStackContext, run_with_stack_context, _state)
@@ -14,22 +15,21 @@ import logging
 
 
 class TestRequestHandler(RequestHandler):
-    def __init__(self, app, request, io_loop):
+    def __init__(self, app, request):
         super(TestRequestHandler, self).__init__(app, request)
-        self.io_loop = io_loop
 
     @asynchronous
     def get(self):
         logging.debug('in get()')
         # call self.part2 without a self.async_callback wrapper.  Its
         # exception should still get thrown
-        self.io_loop.add_callback(self.part2)
+        IOLoop.current().add_callback(self.part2)
 
     def part2(self):
         logging.debug('in part2()')
         # Go through a third layer to make sure that contexts once restored
         # are again passed on to future callbacks
-        self.io_loop.add_callback(self.part3)
+        IOLoop.current().add_callback(self.part3)
 
     def part3(self):
         logging.debug('in part3()')
@@ -44,8 +44,7 @@ class TestRequestHandler(RequestHandler):
 
 class HTTPStackContextTest(AsyncHTTPTestCase):
     def get_app(self):
-        return Application([('/', TestRequestHandler,
-                             dict(io_loop=self.io_loop))])
+        return Application([('/', TestRequestHandler)])
 
     def test_stack_context(self):
         with ExpectLog(app_log, "Uncaught exception GET /"):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -168,7 +168,7 @@ class TCPClientTest(AsyncTestCase):
                 return Future()  # never completes
         with self.assertRaises(TimeoutError):
             yield TCPClient(resolver=TimeoutResolver()).connect(
-                '8.8.8.8', 12345, self.io_loop.time() + timeout)
+                '8.8.8.8', 12345, timeout=self.io_loop.time() + timeout)
 
 
 class TestConnectorSplit(unittest.TestCase):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -218,7 +218,7 @@ class ConnectorTest(AsyncTestCase):
             future.set_exception(IOError())
 
     def start_connect(self, addrinfo):
-        conn = _Connector(addrinfo, self.io_loop, self.create_stream)
+        conn = _Connector(addrinfo, self.create_stream)
         # Give it a huge timeout; we'll trigger timeouts manually.
         future = conn.start(3600)
         return conn, future

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -4,8 +4,9 @@ from __future__ import absolute_import, division, print_function
 
 from tornado import gen, ioloop
 from tornado.log import app_log
-from tornado.testing import AsyncTestCase, gen_test, ExpectLog
 from tornado.test.util import unittest, skipBefore35, exec_test
+from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, gen_test, ExpectLog
+from tornado.web import Application
 import contextlib
 import os
 import traceback
@@ -73,6 +74,40 @@ class AsyncTestCaseTest(AsyncTestCase):
             with self.assertRaises(Exception) as cm:
                 self.wait()
         self.assertEqual(str(cm.exception), "error one")
+
+
+class AsyncHTTPTestCaseTest(AsyncHTTPTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(AsyncHTTPTestCaseTest, cls).setUpClass()
+        # An unused port is bound so we can make requests upon it without
+        # impacting a real local web server.
+        cls.external_sock, cls.external_port = bind_unused_port()
+
+    def get_app(self):
+        return Application()
+
+    def test_fetch_segment(self):
+        path = '/path'
+        response = self.fetch(path)
+        self.assertEqual(response.request.url, self.get_url(path))
+
+    def test_fetch_full_http_url(self):
+        path = 'http://localhost:%d/path' % self.external_port
+
+        response = self.fetch(path, request_timeout=0.1)
+        self.assertEqual(response.request.url, path)
+
+    def test_fetch_full_https_url(self):
+        path = 'https://localhost:%d/path' % self.external_port
+
+        response = self.fetch(path, request_timeout=0.1)
+        self.assertEqual(response.request.url, path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.external_sock.close()
+        super(AsyncHTTPTestCaseTest, cls).tearDownClass()
 
 
 class AsyncTestCaseWrapperTest(unittest.TestCase):

--- a/tornado/test/util.py
+++ b/tornado/test/util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import contextlib
 import os
 import platform
 import socket
@@ -94,3 +95,15 @@ def is_coverage_running():
         except AttributeError:
             return False
     return mod.startswith('coverage')
+
+
+def subTest(test, *args, **kwargs):
+    """Compatibility shim for unittest.TestCase.subTest.
+
+    Usage: ``with tornado.test.util.subTest(self, x=x):``
+    """
+    try:
+        subTest = test.subTest  # py34+
+    except AttributeError:
+        subTest = contextlib.contextmanager(lambda *a, **kw: (yield))
+    return subTest(*args, **kwargs)

--- a/tornado/test/util_test.py
+++ b/tornado/test/util_test.py
@@ -58,12 +58,35 @@ class TestConfig2(TestConfigurable):
         self.pos_arg = pos_arg
 
 
+class TestConfig3(TestConfigurable):
+    # TestConfig3 is a configuration option that is itself configurable.
+    @classmethod
+    def configurable_base(cls):
+        return TestConfig3
+
+    @classmethod
+    def configurable_default(cls):
+        return TestConfig3A
+
+
+class TestConfig3A(TestConfig3):
+    def initialize(self, a=None):
+        self.a = a
+
+
+class TestConfig3B(TestConfig3):
+    def initialize(self, b=None):
+        self.b = b
+
+
 class ConfigurableTest(unittest.TestCase):
     def setUp(self):
         self.saved = TestConfigurable._save_configuration()
+        self.saved3 = TestConfig3._save_configuration()
 
     def tearDown(self):
         TestConfigurable._restore_configuration(self.saved)
+        TestConfig3._restore_configuration(self.saved3)
 
     def checkSubclasses(self):
         # no matter how the class is configured, it should always be
@@ -130,6 +153,39 @@ class ConfigurableTest(unittest.TestCase):
         # args bound in configure don't apply when using the subclass directly
         obj = TestConfig2()
         self.assertIs(obj.b, None)
+
+    def test_config_multi_level(self):
+        TestConfigurable.configure(TestConfig3, a=1)
+        obj = TestConfigurable()
+        self.assertIsInstance(obj, TestConfig3A)
+        self.assertEqual(obj.a, 1)
+
+        TestConfigurable.configure(TestConfig3)
+        TestConfig3.configure(TestConfig3B, b=2)
+        obj = TestConfigurable()
+        self.assertIsInstance(obj, TestConfig3B)
+        self.assertEqual(obj.b, 2)
+
+    def test_config_inner_level(self):
+        # The inner level can be used even when the outer level
+        # doesn't point to it.
+        obj = TestConfig3()
+        self.assertIsInstance(obj, TestConfig3A)
+
+        TestConfig3.configure(TestConfig3B)
+        obj = TestConfig3()
+        self.assertIsInstance(obj, TestConfig3B)
+
+        # Configuring the base doesn't configure the inner.
+        obj = TestConfigurable()
+        self.assertIsInstance(obj, TestConfig1)
+        TestConfigurable.configure(TestConfig2)
+
+        obj = TestConfigurable()
+        self.assertIsInstance(obj, TestConfig2)
+
+        obj = TestConfig3()
+        self.assertIsInstance(obj, TestConfig3B)
 
 
 class UnicodeLiteralTest(unittest.TestCase):

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -917,6 +917,10 @@ class ErrorResponseTest(WebTestCase):
             self.assertEqual(response.code, 503)
             self.assertTrue(b"503: Service Unavailable" in response.body)
 
+            response = self.fetch("/default?status=435")
+            self.assertEqual(response.code, 435)
+            self.assertTrue(b"435: Unknown" in response.body)
+
     def test_write_error(self):
         with ExpectLog(app_log, "Uncaught exception"):
             response = self.fetch("/write_error")
@@ -1489,9 +1493,9 @@ class StatusReasonTest(SimpleHandlerTestCase):
         response = self.fetch("/?code=682&reason=Bar")
         self.assertEqual(response.code, 682)
         self.assertEqual(response.reason, "Bar")
-        with ExpectLog(app_log, 'Uncaught exception'):
-            response = self.fetch("/?code=682")
-        self.assertEqual(response.code, 500)
+        response = self.fetch("/?code=682")
+        self.assertEqual(response.code, 682)
+        self.assertEqual(response.reason, "Unknown")
 
 
 @wsgi_safe

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -379,7 +379,7 @@ class ConnectionCloseTest(WebTestCase):
     def test_connection_close(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         s.connect(("127.0.0.1", self.get_http_port()))
-        self.stream = IOStream(s, io_loop=self.io_loop)
+        self.stream = IOStream(s)
         self.stream.write(b"GET / HTTP/1.0\r\n\r\n")
         self.wait()
 
@@ -1481,7 +1481,7 @@ class StatusReasonTest(SimpleHandlerTestCase):
 
     def get_http_client(self):
         # simple_httpclient only: curl doesn't expose the reason string
-        return SimpleAsyncHTTPClient(io_loop=self.io_loop)
+        return SimpleAsyncHTTPClient()
 
     def test_status(self):
         response = self.fetch("/?code=304")
@@ -1520,7 +1520,7 @@ class RaiseWithReasonTest(SimpleHandlerTestCase):
 
     def get_http_client(self):
         # simple_httpclient only: curl doesn't expose the reason string
-        return SimpleAsyncHTTPClient(io_loop=self.io_loop)
+        return SimpleAsyncHTTPClient()
 
     def test_raise_with_reason(self):
         response = self.fetch("/")
@@ -2115,7 +2115,7 @@ class StreamingRequestBodyTest(WebTestCase):
         # Use a raw connection so we can control the sending of data.
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         s.connect(("127.0.0.1", self.get_http_port()))
-        stream = IOStream(s, io_loop=self.io_loop)
+        stream = IOStream(s)
         stream.write(b"GET " + url + b" HTTP/1.1\r\n")
         if connection_close:
             stream.write(b"Connection: close\r\n")
@@ -2211,7 +2211,7 @@ class BaseStreamingRequestFlowControlTest(object):
 
     def get_http_client(self):
         # simple_httpclient only: curl doesn't support body_producer.
-        return SimpleAsyncHTTPClient(io_loop=self.io_loop)
+        return SimpleAsyncHTTPClient()
 
     # Test all the slightly different code paths for fixed, chunked, etc bodies.
     def test_flow_control_fixed_body(self):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -211,7 +211,7 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_websocket_callbacks(self):
         websocket_connect(
             'ws://127.0.0.1:%d/echo' % self.get_http_port(),
-            io_loop=self.io_loop, callback=self.stop)
+            callback=self.stop)
         ws = self.wait().result()
         ws.write_message('hello')
         ws.read_message(self.stop)
@@ -273,7 +273,6 @@ class WebSocketTest(WebSocketBaseTestCase):
             with ExpectLog(gen_log, ".*"):
                 yield websocket_connect(
                     'ws://127.0.0.1:%d/' % port,
-                    io_loop=self.io_loop,
                     connect_timeout=3600)
 
     @gen_test
@@ -372,8 +371,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         url = 'ws://127.0.0.1:%d/echo' % port
         headers = {'Origin': 'http://127.0.0.1:%d' % port}
 
-        ws = yield websocket_connect(HTTPRequest(url, headers=headers),
-                                     io_loop=self.io_loop)
+        ws = yield websocket_connect(HTTPRequest(url, headers=headers))
         ws.write_message('hello')
         response = yield ws.read_message()
         self.assertEqual(response, 'hello')
@@ -386,8 +384,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         url = 'ws://127.0.0.1:%d/echo' % port
         headers = {'Origin': 'http://127.0.0.1:%d/something' % port}
 
-        ws = yield websocket_connect(HTTPRequest(url, headers=headers),
-                                     io_loop=self.io_loop)
+        ws = yield websocket_connect(HTTPRequest(url, headers=headers))
         ws.write_message('hello')
         response = yield ws.read_message()
         self.assertEqual(response, 'hello')
@@ -401,8 +398,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         headers = {'Origin': '127.0.0.1:%d' % port}
 
         with self.assertRaises(HTTPError) as cm:
-            yield websocket_connect(HTTPRequest(url, headers=headers),
-                                    io_loop=self.io_loop)
+            yield websocket_connect(HTTPRequest(url, headers=headers))
         self.assertEqual(cm.exception.code, 403)
 
     @gen_test
@@ -415,8 +411,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         headers = {'Origin': 'http://somewhereelse.com'}
 
         with self.assertRaises(HTTPError) as cm:
-            yield websocket_connect(HTTPRequest(url, headers=headers),
-                                    io_loop=self.io_loop)
+            yield websocket_connect(HTTPRequest(url, headers=headers))
 
         self.assertEqual(cm.exception.code, 403)
 
@@ -430,8 +425,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         headers = {'Origin': 'http://subtenant.localhost'}
 
         with self.assertRaises(HTTPError) as cm:
-            yield websocket_connect(HTTPRequest(url, headers=headers),
-                                    io_loop=self.io_loop)
+            yield websocket_connect(HTTPRequest(url, headers=headers))
 
         self.assertEqual(cm.exception.code, 403)
 

--- a/tornado/test/windows_test.py
+++ b/tornado/test/windows_test.py
@@ -21,7 +21,5 @@ class WindowsTest(unittest.TestCase):
         r, w = os.pipe()
         self.addCleanup(functools.partial(os.close, r))
         self.addCleanup(functools.partial(os.close, w))
-        with self.assertRaises(WindowsError) as cm:
+        with self.assertRaises(WindowsError):
             set_close_exec(r)
-        ERROR_INVALID_HANDLE = 6
-        self.assertEqual(cm.exception.winerror, ERROR_INVALID_HANDLE)

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -395,14 +395,20 @@ class AsyncHTTPTestCase(AsyncTestCase):
         raise NotImplementedError()
 
     def fetch(self, path, **kwargs):
-        """Convenience method to synchronously fetch a url.
+        """Convenience method to synchronously fetch a URL.
 
         The given path will be appended to the local server's host and
         port.  Any additional kwargs will be passed directly to
         `.AsyncHTTPClient.fetch` (and so could be used to pass
         ``method="POST"``, ``body="..."``, etc).
+
+        If the path begins with http:// or https://, it will be treated as a
+        full URL and will be fetched as-is.
         """
-        self.http_client.fetch(self.get_url(path), self.stop, **kwargs)
+        if path.lower().startswith(('http://', 'https://')):
+            self.http_client.fetch(path, self.stop, **kwargs)
+        else:
+            self.http_client.fetch(self.get_url(path), self.stop, **kwargs)
         return self.wait()
 
     def get_httpserver_options(self):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -458,7 +458,7 @@ def gen_test(func=None, timeout=None):
         class MyTest(AsyncHTTPTestCase):
             @gen_test
             def test_something(self):
-                response = yield gen.Task(self.fetch('/'))
+                response = yield self.http_client.fetch(self.get_url('/'))
 
     By default, ``@gen_test`` times out after 5 seconds. The timeout may be
     overridden globally with the ``ASYNC_TEST_TIMEOUT`` environment variable,
@@ -467,7 +467,11 @@ def gen_test(func=None, timeout=None):
         class MyTest(AsyncHTTPTestCase):
             @gen_test(timeout=10)
             def test_something_slow(self):
-                response = yield gen.Task(self.fetch('/'))
+                response = yield self.http_client.fetch(self.get_url('/'))
+
+    Note that ``@gen_test`` is incompatible with `AsyncTestCase.stop`,
+    `AsyncTestCase.wait`, and `AsyncHTTPTestCase.fetch`. Use ``yield
+    self.http_client.fetch(self.get_url())`` as shown above instead.
 
     .. versionadded:: 3.1
        The ``timeout`` argument and ``ASYNC_TEST_TIMEOUT`` environment
@@ -476,6 +480,7 @@ def gen_test(func=None, timeout=None):
     .. versionchanged:: 4.0
        The wrapper now passes along ``*args, **kwargs`` so it can be used
        on functions with arguments.
+
     """
     if timeout is None:
         timeout = get_async_test_timeout()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -73,24 +73,6 @@ else:
     except ImportError:
         import unittest  # type: ignore
 
-_next_port = 10000
-
-
-def get_unused_port():
-    """Returns a (hopefully) unused port number.
-
-    This function does not guarantee that the port it returns is available,
-    only that a series of get_unused_port calls in a single process return
-    distinct ports.
-
-    .. deprecated::
-       Use bind_unused_port instead, which is guaranteed to find an unused port.
-    """
-    global _next_port
-    port = _next_port
-    _next_port = _next_port + 1
-    return port
-
 
 def bind_unused_port(reuse_port=False):
     """Binds a server socket to an available port on localhost.
@@ -166,8 +148,7 @@ class AsyncTestCase(unittest.TestCase):
     callbacks should call ``self.stop()`` to signal completion.
 
     By default, a new `.IOLoop` is constructed for each test and is available
-    as ``self.io_loop``.  This `.IOLoop` should be used in the construction of
-    HTTP clients/servers, etc.  If the code being tested requires a
+    as ``self.io_loop``.  If the code being tested requires a
     global `.IOLoop`, subclasses should override `get_new_ioloop` to return it.
 
     The `.IOLoop`'s ``start`` and ``stop`` methods should not be
@@ -182,7 +163,7 @@ class AsyncTestCase(unittest.TestCase):
         class MyTestCase(AsyncTestCase):
             @tornado.testing.gen_test
             def test_http_fetch(self):
-                client = AsyncHTTPClient(self.io_loop)
+                client = AsyncHTTPClient()
                 response = yield client.fetch("http://www.tornadoweb.org")
                 # Test contents of response
                 self.assertIn("FriendFeed", response.body)
@@ -190,7 +171,7 @@ class AsyncTestCase(unittest.TestCase):
         # This test uses argument passing between self.stop and self.wait.
         class MyTestCase2(AsyncTestCase):
             def test_http_fetch(self):
-                client = AsyncHTTPClient(self.io_loop)
+                client = AsyncHTTPClient()
                 client.fetch("http://www.tornadoweb.org/", self.stop)
                 response = self.wait()
                 # Test contents of response
@@ -199,7 +180,7 @@ class AsyncTestCase(unittest.TestCase):
         # This test uses an explicit callback-based style.
         class MyTestCase3(AsyncTestCase):
             def test_http_fetch(self):
-                client = AsyncHTTPClient(self.io_loop)
+                client = AsyncHTTPClient()
                 client.fetch("http://www.tornadoweb.org/", self.handle_fetch)
                 self.wait()
 
@@ -382,11 +363,10 @@ class AsyncHTTPTestCase(AsyncTestCase):
         self.http_server.add_sockets([sock])
 
     def get_http_client(self):
-        return AsyncHTTPClient(io_loop=self.io_loop)
+        return AsyncHTTPClient()
 
     def get_http_server(self):
-        return HTTPServer(self._app, io_loop=self.io_loop,
-                          **self.get_httpserver_options())
+        return HTTPServer(self._app, **self.get_httpserver_options())
 
     def get_app(self):
         """Should be overridden by subclasses to return a
@@ -448,7 +428,7 @@ class AsyncHTTPSTestCase(AsyncHTTPTestCase):
     Interface is generally the same as `AsyncHTTPTestCase`.
     """
     def get_http_client(self):
-        return AsyncHTTPClient(io_loop=self.io_loop, force_instance=True,
+        return AsyncHTTPClient(force_instance=True,
                                defaults=dict(validate_cert=False))
 
     def get_httpserver_options(self):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -216,13 +216,11 @@ class AsyncTestCase(unittest.TestCase):
         # Clean up Subprocess, so it can be used again with a new ioloop.
         Subprocess.uninitialize()
         self.io_loop.clear_current()
-        if (not IOLoop.initialized() or
-                self.io_loop is not IOLoop.instance()):
-            # Try to clean up any file descriptors left open in the ioloop.
-            # This avoids leaks, especially when tests are run repeatedly
-            # in the same process with autoreload (because curl does not
-            # set FD_CLOEXEC on its file descriptors)
-            self.io_loop.close(all_fds=True)
+        # Try to clean up any file descriptors left open in the ioloop.
+        # This avoids leaks, especially when tests are run repeatedly
+        # in the same process with autoreload (because curl does not
+        # set FD_CLOEXEC on its file descriptors)
+        self.io_loop.close(all_fds=True)
         super(AsyncTestCase, self).tearDown()
         # In case an exception escaped or the StackContext caught an exception
         # when there wasn't a wait() to re-raise it, do so here.
@@ -416,9 +414,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
         self.http_server.stop()
         self.io_loop.run_sync(self.http_server.close_all_connections,
                               timeout=get_async_test_timeout())
-        if (not IOLoop.initialized() or
-                self.http_client.io_loop is not IOLoop.instance()):
-            self.http_client.close()
+        self.http_client.close()
         super(AsyncHTTPTestCase, self).tearDown()
 
 

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -84,6 +84,16 @@ except ImportError:
     is_finalizing = _get_emulated_is_finalizing()
 
 
+class TimeoutError(Exception):
+    """Exception raised by `.with_timeout` and `.IOLoop.run_sync`.
+
+    .. versionchanged:: 5.0:
+       Unified ``tornado.gen.TimeoutError`` and
+       ``tornado.ioloop.TimeoutError`` as ``tornado.util.TimeoutError``.
+       Both former names remain as aliases.
+    """
+
+
 class ObjectDict(_ObjectDictBase):
     """Makes a dictionary behave like an object, with attribute-style access.
     """

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -286,6 +286,9 @@ class Configurable(object):
         else:
             impl = cls
         init_kwargs.update(kwargs)
+        if impl.configurable_base() is not base:
+            # The impl class is itself configurable, so recurse.
+            return impl(*args, **init_kwargs)
         instance = super(Configurable, cls).__new__(impl)
         # initialize vs __init__ chosen for compatibility with AsyncHTTPClient
         # singleton magic.  If we get rid of that we can switch to __init__
@@ -343,7 +346,10 @@ class Configurable(object):
         # type: () -> type
         """Returns the currently configured class."""
         base = cls.configurable_base()
-        if cls.__impl_class is None:
+        # Manually mangle the private name to see whether this base
+        # has been configured (and not another base higher in the
+        # hierarchy).
+        if base.__dict__.get('_Configurable__impl_class') is None:
             base.__impl_class = cls.configurable_default()
         return base.__impl_class
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -319,10 +319,7 @@ class RequestHandler(object):
         if reason is not None:
             self._reason = escape.native_str(reason)
         else:
-            try:
-                self._reason = httputil.responses[status_code]
-            except KeyError:
-                raise ValueError("unknown status code %d" % status_code)
+            self._reason = httputil.responses.get(status_code, "Unknown")
 
     def get_status(self):
         """Returns the status code for our response."""
@@ -1561,11 +1558,7 @@ class RequestHandler(object):
             # send a response.
             return
         if isinstance(e, HTTPError):
-            if e.status_code not in httputil.responses and not e.reason:
-                gen_log.error("Bad HTTP status code: %d", e.status_code)
-                self.send_error(500, exc_info=sys.exc_info())
-            else:
-                self.send_error(e.status_code, exc_info=sys.exc_info())
+            self.send_error(e.status_code, exc_info=sys.exc_info())
         else:
             self.send_error(500, exc_info=sys.exc_info())
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -518,18 +518,28 @@ class RequestHandler(object):
         return self.request.cookies
 
     def get_cookie(self, name, default=None):
-        """Gets the value of the cookie with the given name, else default."""
+        """Returns the value of the request cookie with the given name.
+
+        If the named cookie is not present, returns ``default``.
+
+        This method only returns cookies that were present in the request.
+        It does not see the outgoing cookies set by `set_cookie` in this
+        handler.
+        """
         if self.request.cookies is not None and name in self.request.cookies:
             return self.request.cookies[name].value
         return default
 
     def set_cookie(self, name, value, domain=None, expires=None, path="/",
                    expires_days=None, **kwargs):
-        """Sets the given cookie name/value with the given options.
+        """Sets an outgoing cookie name/value with the given options.
 
-        Additional keyword arguments are set on the Cookie.Morsel
+        Newly-set cookies are not immediately visible via `get_cookie`;
+        they are not present until the next request.
+
+        Additional keyword arguments are set on the cookies.Morsel
         directly.
-        See https://docs.python.org/2/library/cookie.html#Cookie.Morsel
+        See https://docs.python.org/3/library/http.cookies.html#http.cookies.Morsel
         for available attributes.
         """
         # The cookie library only accepts type str, in both python 2 and 3
@@ -571,6 +581,9 @@ class RequestHandler(object):
         path and domain to clear a cookie as were used when that cookie
         was set (but there is no way to find out on the server side
         which values were used for a given cookie).
+
+        Similar to `set_cookie`, the effect of this method will not be
+        seen until the following request.
         """
         expires = datetime.datetime.utcnow() - datetime.timedelta(days=365)
         self.set_cookie(name, value="", path=path, expires=expires,
@@ -581,6 +594,9 @@ class RequestHandler(object):
 
         See `clear_cookie` for more information on the path and domain
         parameters.
+
+        Similar to `set_cookie`, the effect of this method will not be
+        seen until the following request.
 
         .. versionchanged:: 3.2
 
@@ -605,6 +621,9 @@ class RequestHandler(object):
 
         Secure cookies may contain arbitrary byte values, not just unicode
         strings (unlike regular cookies)
+
+        Similar to `set_cookie`, the effect of this method will not be
+        seen until the following request.
 
         .. versionchanged:: 3.2.1
 
@@ -644,6 +663,10 @@ class RequestHandler(object):
 
         The decoded cookie value is returned as a byte string (unlike
         `get_cookie`).
+
+        Similar to `get_cookie`, this method only returns cookies that
+        were present in the request. It does not see outgoing cookies set by
+        `set_secure_cookie` in this handler.
 
         .. versionchanged:: 3.2.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ envlist =
         {py2,py3}-select,
         {py2,py3}-full-twisted,
         py2-twistedlayered,
-        {py3,py33}-full-asyncio,
+        py3-full-poll,
         py2-full-trollius,
 
         # Alternate Resolvers.
@@ -84,7 +84,6 @@ deps =
      {py2,py27,pypy,py3,pypy3}-full: mock
      # singledispatch became standard in py34.
      {py2,py27,pypy,py3,py33}-full: singledispatch
-     py33-asyncio: asyncio
      trollius: trollius
      py2-monotonic: monotonic
      sphinx: sphinx
@@ -120,13 +119,14 @@ commands =
          # implementations; this flag controls which client all the
          # other tests use.
          curl: --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient \
+         poll: --ioloop=tornado.ioloop.PollIOLoop \
          select: --ioloop=tornado.platform.select.SelectIOLoop \
          twisted: --ioloop=tornado.platform.twisted.TwistedIOLoop \
          twistedlayered: --ioloop=tornado.test.twisted_test.LayeredTwistedIOLoop --resolver=tornado.platform.twisted.TwistedResolver \
-         {asyncio,trollius}: --ioloop=tornado.platform.asyncio.AsyncIOLoop \
+         trollius: --ioloop=tornado.platform.asyncio.AsyncIOLoop \
          caresresolver: --resolver=tornado.platform.caresresolver.CaresResolver \
          threadedresolver: --resolver=tornado.netutil.ThreadedResolver \
-         monotonic: --ioloop_time_monotonic \
+         monotonic: --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic \
          # Test with a non-english locale to uncover str/bytes mixing issues.
          locale: --locale=zh_TW \
          {posargs:}


### PR DESCRIPTION
It has been a while and I am back to solve the issue!

The TCP connection timeout is under the stack of TCP/IP, so we cannot simulate it. Maybe using tools like `iptables` to drop the packets is good idea, but it is platform dependent, so we can only mock it.