### PR TITLE
Fix file upload demo on Python 2.

### DIFF
--- a/demos/file_upload/file_uploader.py
+++ b/demos/file_upload/file_uploader.py
@@ -9,6 +9,7 @@ single file without encoding.
 See also file_receiver.py in this directory, a server that receives uploads.
 """
 
+from __future__ import print_function
 import mimetypes
 import os
 import sys


### PR DESCRIPTION
If no filenames are specified then [the demo prints to standard error](/tornadoweb/tornado/blob/26e5779a50b466f8e2a5bf14808c96ebea2a4eef/demos/file_upload/file_uploader.py#L111), but it uses a syntax only compatible with Python 3 unless the print function is imported from `__future__`.