### PR TITLE
make http clients implement the context manager protocol

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -81,6 +81,12 @@ class HTTPClient(object):
     def __del__(self):
         self.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
     def close(self):
         """Closes the HTTPClient, freeing any resources used."""
         if not self._closed:
@@ -174,6 +180,12 @@ class AsyncHTTPClient(Configurable):
         if instance_cache is not None:
             instance_cache[instance.io_loop] = instance
         return instance
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
 
     def initialize(self, io_loop, defaults=None):
         self.io_loop = io_loop

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -536,6 +536,15 @@ X-XSS-Protection: 1;
         response.rethrow()
         self.assertEqual(response.headers["Foo"], native_str(u"\u00e9"))
 
+    def test_async_context_manager(self):
+        with self.http_client:
+            response = self.fetch("/hello")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers["Content-Type"], "text/plain")
+        self.assertEqual(response.body, b"Hello world!")
+        self.assertEqual(int(response.request_time), 0)
+        self.assert_(self.http_client._closed)
+
 
 class RequestProxyTest(unittest.TestCase):
     def test_request_set(self):
@@ -631,6 +640,12 @@ class SyncHTTPClientTest(unittest.TestCase):
         with self.assertRaises(HTTPError) as assertion:
             self.http_client.fetch(self.get_url('/notfound'))
         self.assertEqual(assertion.exception.code, 404)
+
+    def test_sync_context_manager(self):
+        with HTTPClient() as client:
+            response = self.http_client.fetch(self.get_url('/'))
+        self.assertEqual(b'Hello world!', response.body)
+        self.assert_(client._closed)
 
 
 class HTTPRequestTestCase(unittest.TestCase):


### PR DESCRIPTION
This lets you use HTTPClient and AsyncHTTPClient as context managers. The `__exit__` method closes the underlying client.