### PR TITLE
fix Windows test_set_close_exec

### DIFF
--- a/tornado/test/windows_test.py
+++ b/tornado/test/windows_test.py
@@ -24,4 +24,6 @@ class WindowsTest(unittest.TestCase):
         with self.assertRaises(WindowsError) as cm:
             set_close_exec(r)
         ERROR_INVALID_HANDLE = 6
-        self.assertEqual(cm.exception.winerror, ERROR_INVALID_HANDLE)
+        ERROR_INVALID_PARAMETER = 87
+        errors = (ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER)
+        self.assertIn(cm.exception.winerror, errors)


### PR DESCRIPTION
On my platform (Windows 7, 64bit, Python 2.7) set_close_exec fails with ERROR_INVALID_PARAMETER.

    FAIL: test_set_close_exec (tornado.test.windows_test.WindowsTest)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "C:\Data\Extern\tornaduv\.tox\py27-deps\lib\site-packages\tornado\test\windows_test.py", line 27, in test_set_close_exec
        self.assertEqual(cm.exception.winerror, ERROR_INVALID_HANDLE)
    AssertionError: 87 != 6

Maybe we shouldn't check the error code at all. Windows is really fickle regaring error codes.