### PR TITLE
ioloop: Redefine instance() in terms of current()

### DIFF
--- a/docs/ioloop.rst
+++ b/docs/ioloop.rst
@@ -13,14 +13,15 @@
 
    .. automethod:: IOLoop.current
    .. automethod:: IOLoop.make_current
-   .. automethod:: IOLoop.instance
-   .. automethod:: IOLoop.initialized
-   .. automethod:: IOLoop.install
-   .. automethod:: IOLoop.clear_instance
+   .. automethod:: IOLoop.clear_current
    .. automethod:: IOLoop.start
    .. automethod:: IOLoop.stop
    .. automethod:: IOLoop.run_sync
    .. automethod:: IOLoop.close
+   .. automethod:: IOLoop.instance
+   .. automethod:: IOLoop.initialized
+   .. automethod:: IOLoop.install
+   .. automethod:: IOLoop.clear_instance
 
    I/O events
    ^^^^^^^^^^

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -216,13 +216,11 @@ class AsyncTestCase(unittest.TestCase):
         # Clean up Subprocess, so it can be used again with a new ioloop.
         Subprocess.uninitialize()
         self.io_loop.clear_current()
-        if (not IOLoop.initialized() or
-                self.io_loop is not IOLoop.instance()):
-            # Try to clean up any file descriptors left open in the ioloop.
-            # This avoids leaks, especially when tests are run repeatedly
-            # in the same process with autoreload (because curl does not
-            # set FD_CLOEXEC on its file descriptors)
-            self.io_loop.close(all_fds=True)
+        # Try to clean up any file descriptors left open in the ioloop.
+        # This avoids leaks, especially when tests are run repeatedly
+        # in the same process with autoreload (because curl does not
+        # set FD_CLOEXEC on its file descriptors)
+        self.io_loop.close(all_fds=True)
         super(AsyncTestCase, self).tearDown()
         # In case an exception escaped or the StackContext caught an exception
         # when there wasn't a wait() to re-raise it, do so here.
@@ -416,9 +414,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
         self.http_server.stop()
         self.io_loop.run_sync(self.http_server.close_all_connections,
                               timeout=get_async_test_timeout())
-        if (not IOLoop.initialized() or
-                self.http_client.io_loop is not IOLoop.instance()):
-            self.http_client.close()
+        self.http_client.close()
         super(AsyncHTTPTestCase, self).tearDown()
 
 


### PR DESCRIPTION
This aligns us more closely with asyncio, which only has a single
get_event_loop() function. Most uses of instance() are simply a
holdover from before current() was introduced and are not actually
relying on its slightly different behavior, so we redefine it (and the
related methods install(), initialized(), and clear_instance()) in
terms of current().