### PR TITLE
Implement IOLoop.run_in_executor

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -43,6 +43,7 @@ import threading
 import time
 import traceback
 import math
+from multiprocessing import cpu_count
 
 from tornado.concurrent import TracebackFuture, is_future, Future, chain_future
 from tornado.log import app_log, gen_log
@@ -644,7 +645,7 @@ class IOLoop(Configurable):
 
         if executor is None:
             if not hasattr(self, '_executor'):
-                self._executor = ThreadPoolExecutor()
+                self._executor = ThreadPoolExecutor(max_workers=(cpu_count() * 5))
             executor = self._executor
 
         future = executor.submit(func, *args)

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -648,12 +648,9 @@ class IOLoop(Configurable):
 
         future = executor.submit(func, *args)
         self.add_future(future, lambda future: future.result())
-        if sys.version_info >= (3, 5):
-            future_ = Future()
-            chain_future(future, future_)
-            return future_
-        else:
-            return future
+        future_ = Future()
+        chain_future(future, future_)
+        return future_
 
     def set_default_executor(self, executor):
         """Sets the default executor to use with :meth:`run_in_executor`."""

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -58,10 +58,8 @@ except ImportError:
 
 try:
     from concurrent.futures import ThreadPoolExecutor
-    _concurrent_futures_found = True
 except ImportError:
     ThreadPoolExecutor = None
-    _concurrent_futures_found = False
 
 if PY3:
     import _thread as thread
@@ -639,7 +637,7 @@ class IOLoop(Configurable):
         Use `functools.partial` to pass keyword arguments to `func`.
 
         """
-        if not _concurrent_futures_found:
+        if ThreadPoolExecutor is None:
             raise RuntimeError(
                 "concurrent.futures is required to use IOLoop.run_in_executor")
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -801,6 +801,8 @@ class PollIOLoop(IOLoop):
         self._impl.close()
         self._callbacks = None
         self._timeouts = None
+        if hasattr(self, '_executor'):
+            self._executor.shutdown()
 
     def add_handler(self, fd, handler, events):
         fd, obj = self.split_fd(fd)

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -43,7 +43,6 @@ import threading
 import time
 import traceback
 import math
-from multiprocessing import cpu_count
 
 from tornado.concurrent import TracebackFuture, is_future, Future, chain_future
 from tornado.log import app_log, gen_log
@@ -643,6 +642,7 @@ class IOLoop(Configurable):
 
         if executor is None:
             if not hasattr(self, '_executor'):
+                from tornado.process import cpu_count
                 self._executor = ThreadPoolExecutor(max_workers=(cpu_count() * 5))
             executor = self._executor
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -44,7 +44,7 @@ import time
 import traceback
 import math
 
-from tornado.concurrent import TracebackFuture, is_future, Future, chain_future
+from tornado.concurrent import TracebackFuture, is_future
 from tornado.log import app_log, gen_log
 from tornado.platform.auto import set_close_exec, Waker
 from tornado import stack_context
@@ -646,11 +646,7 @@ class IOLoop(Configurable):
                 self._executor = ThreadPoolExecutor(max_workers=(cpu_count() * 5))
             executor = self._executor
 
-        future = executor.submit(func, *args)
-        self.add_future(future, lambda future: future.result())
-        future_ = Future()
-        chain_future(future, future_)
-        return future_
+        return executor.submit(func, *args)
 
     def set_default_executor(self, executor):
         """Sets the default executor to use with :meth:`run_in_executor`."""

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -591,7 +591,8 @@ class TestIOLoopFutures(AsyncTestCase):
 
         def callback(self_event, other_event):
             self_event.set()
-            other_event.wait()
+            time.sleep(0.01)
+            self.assertTrue(other_event.is_set())
             return self_event
 
         res = yield [
@@ -608,6 +609,8 @@ class TestIOLoopFutures(AsyncTestCase):
 
         def callback(self_event, other_event):
             self_event.set()
+            time.sleep(0.01)
+            self.assertTrue(other_event.is_set())
             other_event.wait()
             return self_event
 

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -614,7 +614,7 @@ class TestIOLoopFutures(AsyncTestCase):
         class MyExecutor(futures.ThreadPoolExecutor):
             pass
 
-        executor = MyExecutor()
+        executor = MyExecutor(max_workers=1)
         IOLoop.current().set_default_executor(executor)
         self.assertIsInstance(IOLoop.current()._executor, MyExecutor)
 

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -602,12 +602,13 @@ class TestIOLoopFutures(AsyncTestCase):
         def func(arg1, arg2):
             return arg1 + arg2
 
+        namespace = exec_test(globals(), locals(), """
         async def main():
             arg1, arg2 = random.random(), random.random()
             res = await IOLoop.current().run_in_executor(None, func, arg1, arg2)
             self.assertEqual(arg1 + arg2, res)
-
-        IOLoop.current().run_sync(main)
+        """)
+        IOLoop.current().run_sync(namespace['main'])
 
     def test_set_default_executor(self):
         class MyExecutor(futures.ThreadPoolExecutor):


### PR DESCRIPTION
Addresses #1982: implements an API mimicking `run_in_executor` from `asyncio`. This uses the same strategy as `asyncio`, namely using `chain_future` to map `concurrent.futures.Future` onto an awaitable `Future`.

Some questions:

- Do we need to do something else to properly handle exceptions here?
- What additional tests should be added?
- Would it make sense to always return the chained future instead of checking the Python version?