### PR TITLE
ioloop: Make asyncio the default when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,12 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python -bb $TARGET; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.netutil.ThreadedResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --resolver=tornado.platform.twisted.TwistedResolver; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic; fi
     #- if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python $TARGET --ioloop_time_monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then ../nodeps/bin/python -m tornado.test.runtests; fi
     # make coverage reports for Codecov to find
     - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then coverage xml; fi

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -582,16 +582,11 @@ class HTTPResponseTestCase(unittest.TestCase):
 
 class SyncHTTPClientTest(unittest.TestCase):
     def setUp(self):
-        if IOLoop.configured_class().__name__ in ('TwistedIOLoop',
-                                                  'AsyncIOMainLoop'):
+        if IOLoop.configured_class().__name__ == 'TwistedIOLoop':
             # TwistedIOLoop only supports the global reactor, so we can't have
             # separate IOLoops for client and server threads.
-            # AsyncIOMainLoop doesn't work with the default policy
-            # (although it could with some tweaks to this test and a
-            # policy that created loops for non-main threads).
             raise unittest.SkipTest(
-                'Sync HTTPClient not compatible with TwistedIOLoop or '
-                'AsyncIOMainLoop')
+                'Sync HTTPClient not compatible with TwistedIOLoop')
         self.server_ioloop = IOLoop()
 
         @gen.coroutine

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -6,11 +6,13 @@ import contextlib
 import datetime
 import functools
 import socket
+import subprocess
 import sys
 import threading
 import time
 import types
 
+from tornado.escape import native_str
 from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError, PollIOLoop, PeriodicCallback
 from tornado.log import app_log
@@ -23,6 +25,16 @@ try:
     from concurrent import futures
 except ImportError:
     futures = None
+
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
+
+try:
+    import twisted
+except ImportError:
+    twisted = None
 
 
 class FakeTimeSelect(_Select):
@@ -675,6 +687,52 @@ class TestPeriodicCallback(unittest.TestCase):
         pc.start()
         self.io_loop.start()
         self.assertEqual(calls, expected)
+
+
+class TestIOLoopConfiguration(unittest.TestCase):
+    def run_python(self, *statements):
+        statements = [
+            'from tornado.ioloop import IOLoop, PollIOLoop',
+            'classname = lambda x: x.__class__.__name__',
+        ] + list(statements)
+        args = [sys.executable, '-c', '; '.join(statements)]
+        return native_str(subprocess.check_output(args)).strip()
+
+    def test_default(self):
+        # The default is a subclass of PollIOLoop
+        is_poll = self.run_python(
+            'print(isinstance(IOLoop.current(), PollIOLoop))')
+        self.assertEqual(is_poll, 'True')
+
+    def test_explicit_select(self):
+        # SelectIOLoop can always be configured explicitly.
+        default_class = self.run_python(
+            'IOLoop.configure("tornado.platform.select.SelectIOLoop")',
+            'print(classname(IOLoop.current()))')
+        self.assertEqual(default_class, 'SelectIOLoop')
+
+    @unittest.skipIf(asyncio is None, "asyncio module not present")
+    def test_asyncio(self):
+        cls = self.run_python(
+            'IOLoop.configure("tornado.platform.asyncio.AsyncIOLoop")',
+            'print(classname(IOLoop.current()))')
+        self.assertEqual(cls, 'AsyncIOLoop')
+
+    @unittest.skipIf(asyncio is None, "asyncio module not present")
+    def test_asyncio_main(self):
+        cls = self.run_python(
+            'from tornado.platform.asyncio import AsyncIOMainLoop',
+            'AsyncIOMainLoop().install()',
+            'print(classname(IOLoop.current()))')
+        self.assertEqual(cls, 'AsyncIOMainLoop')
+
+    @unittest.skipIf(twisted is None, "twisted module not present")
+    def test_twisted(self):
+        cls = self.run_python(
+            'from tornado.platform.twisted import TwistedIOLoop',
+            'TwistedIOLoop().install()',
+            'print(classname(IOLoop.current()))')
+        self.assertEqual(cls, 'TwistedIOLoop')
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ envlist =
         {py2,py3}-select,
         {py2,py3}-full-twisted,
         py2-twistedlayered,
-        {py3,py33}-full-asyncio,
+        py3-full-poll,
         py2-full-trollius,
 
         # Alternate Resolvers.
@@ -84,7 +84,6 @@ deps =
      {py2,py27,pypy,py3,pypy3}-full: mock
      # singledispatch became standard in py34.
      {py2,py27,pypy,py3,py33}-full: singledispatch
-     py33-asyncio: asyncio
      trollius: trollius
      py2-monotonic: monotonic
      sphinx: sphinx
@@ -120,13 +119,14 @@ commands =
          # implementations; this flag controls which client all the
          # other tests use.
          curl: --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient \
+         poll: --ioloop=tornado.ioloop.PollIOLoop \
          select: --ioloop=tornado.platform.select.SelectIOLoop \
          twisted: --ioloop=tornado.platform.twisted.TwistedIOLoop \
          twistedlayered: --ioloop=tornado.test.twisted_test.LayeredTwistedIOLoop --resolver=tornado.platform.twisted.TwistedResolver \
-         {asyncio,trollius}: --ioloop=tornado.platform.asyncio.AsyncIOLoop \
+         trollius: --ioloop=tornado.platform.asyncio.AsyncIOLoop \
          caresresolver: --resolver=tornado.platform.caresresolver.CaresResolver \
          threadedresolver: --resolver=tornado.netutil.ThreadedResolver \
-         monotonic: --ioloop_time_monotonic \
+         monotonic: --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic \
          # Test with a non-english locale to uncover str/bytes mixing issues.
          locale: --locale=zh_TW \
          {posargs:}


### PR DESCRIPTION
In addition to changing the configurable default, add a special case
in IOLoop.current() so that the current IOLoop will be backed by
the main asyncio event loop.