### PR TITLE
concurrent: Use asyncio.Future when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
     - pypy3.5-5.7.1-beta
 
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install futures mock monotonic trollius; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install futures mock monotonic; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then travis_retry pip install futures mock; fi
     # TODO(bdarnell): pycares tests are currently disabled on travis due to ipv6 issues.
     #- if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install pycares; fi
@@ -67,7 +67,6 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.netutil.ThreadedResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --resolver=tornado.platform.twisted.TwistedResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic; fi
     #- if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,18 +59,17 @@ script:
     # run it with nightly cpython.
     - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then export TARGET="-m coverage run $TARGET"; fi
     - python $TARGET
-    - python $TARGET --ioloop=tornado.platform.select.SelectIOLoop
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.select.SelectIOLoop; fi
     - python -O $TARGET
     - LANG=C python $TARGET
     - LANG=en_US.utf-8 python $TARGET
     - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python -bb $TARGET; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.netutil.ThreadedResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --httpclient=tornado.curl_httpclient.CurlAsyncHTTPClient; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 || $TRAVIS_PYTHON_VERSION == 3.5 || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.twisted.TwistedIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.platform.asyncio.AsyncIOLoop; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --resolver=tornado.platform.twisted.TwistedResolver; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python $TARGET --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic; fi
     #- if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then python $TARGET --resolver=tornado.platform.caresresolver.CaresResolver; fi
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then ../nodeps/bin/python -m tornado.test.runtests; fi
     # make coverage reports for Codecov to find

--- a/docs/concurrent.rst
+++ b/docs/concurrent.rst
@@ -17,10 +17,8 @@
 
     .. automethod:: Future.result
     .. automethod:: Future.exception
-    .. automethod:: Future.exc_info
     .. automethod:: Future.add_done_callback
     .. automethod:: Future.done
-    .. automethod:: Future.running
     .. automethod:: Future.cancel
     .. automethod:: Future.cancelled
 
@@ -29,4 +27,3 @@
 
     .. automethod:: Future.set_result
     .. automethod:: Future.set_exception
-    .. automethod:: Future.set_exc_info

--- a/docs/concurrent.rst
+++ b/docs/concurrent.rst
@@ -8,7 +8,7 @@
 
 .. automodule:: tornado.concurrent
     :members:
-    :exclude-members: Future, TracebackFuture
+    :exclude-members: Future
 
     .. autoclass:: Future
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,9 +39,6 @@ coverage_ignore_modules = [
     ]
 # I wish this could go in a per-module file...
 coverage_ignore_classes = [
-    # tornado.concurrent
-    "TracebackFuture",
-
     # tornado.gen
     "Runner",
 

--- a/docs/guide/security.rst
+++ b/docs/guide/security.rst
@@ -3,6 +3,7 @@ Authentication and security
 
 .. testsetup::
 
+   import tornado.auth
    import tornado.web
 
 Cookies and secure cookies

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -75,7 +75,7 @@ import hmac
 import time
 import uuid
 
-from tornado.concurrent import TracebackFuture, return_future, chain_future
+from tornado.concurrent import TracebackFuture, return_future, chain_future, future_set_exc_info
 from tornado import gen
 from tornado import httpclient
 from tornado import escape
@@ -127,7 +127,7 @@ def _auth_return_future(f):
             if future.done():
                 return False
             else:
-                future.set_exc_info((typ, value, tb))
+                future_set_exc_info(future, (typ, value, tb))
                 return True
         with ExceptionStackContext(handle_exception):
             f(*args, **kwargs)

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -75,7 +75,7 @@ import hmac
 import time
 import uuid
 
-from tornado.concurrent import TracebackFuture, return_future, chain_future, future_set_exc_info
+from tornado.concurrent import Future, return_future, chain_future, future_set_exc_info
 from tornado import gen
 from tornado import httpclient
 from tornado import escape
@@ -117,7 +117,7 @@ def _auth_return_future(f):
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        future = TracebackFuture()
+        future = Future()
         callback, args, kwargs = replacer.replace(future, args, kwargs)
         if callback is not None:
             future.add_done_callback(

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -498,7 +498,7 @@ def return_future(f):
                     callback()
                 else:
                     callback(future.result())
-            future.add_done_callback(wrap(run_callback))
+            future_add_done_callback(future, wrap(run_callback))
         return future
     return wrapper
 
@@ -520,7 +520,7 @@ def chain_future(a, b):
             b.set_exception(a.exception())
         else:
             b.set_result(a.result())
-    a.add_done_callback(copy)
+    future_add_done_callback(a, copy)
 
 
 def future_set_exc_info(future, exc_info):
@@ -537,3 +537,18 @@ def future_set_exc_info(future, exc_info):
     else:
         # asyncio.Future
         future.set_exception(exc_info[1])
+
+
+def future_add_done_callback(future, callback):
+    """Arrange to call ``callback`` when ``future`` is complete.
+
+    ``callback`` is invoked with one argument, the ``future``.
+
+    If ``future`` is already done, ``callback`` is invoked immediately.
+    This may differ from the behavior of `.Future.add_done_callback`,
+    which makes no such guarantee.
+    """
+    if future.done():
+        callback(future)
+    else:
+        future.add_done_callback(callback)

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -508,6 +508,8 @@ def chain_future(a, b):
 
     The result (success or failure) of ``a`` will be copied to ``b``, unless
     ``b`` has already been completed or cancelled by the time ``a`` finishes.
+
+    Accepts both Tornado/asyncio `Future` objects and `concurrent.futures.Future`.
     """
     def copy(future):
         assert future is a
@@ -520,7 +522,12 @@ def chain_future(a, b):
             b.set_exception(a.exception())
         else:
             b.set_result(a.result())
-    future_add_done_callback(a, copy)
+    if isinstance(a, Future):
+        future_add_done_callback(a, copy)
+    else:
+        # concurrent.futures.Future
+        from tornado.ioloop import IOLoop
+        IOLoop.current().add_future(a, copy)
 
 
 def future_set_exc_info(future, exc_info):

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -146,8 +146,6 @@ class Future(object):
     and ``set_exc_info`` are supported to capture tracebacks in Python 2.
     The traceback is automatically available in Python 3, but in the
     Python 2 futures backport this information is discarded.
-    This functionality was previously available in a separate class
-    ``TracebackFuture``, which is now a deprecated alias for this class.
 
     .. versionchanged:: 4.0
        `tornado.concurrent.Future` is always a thread-unsafe ``Future``
@@ -164,6 +162,10 @@ class Future(object):
        where it results in undesired logging it may be necessary to
        suppress the logging by ensuring that the exception is observed:
        ``f.add_done_callback(lambda f: f.exception())``.
+
+    .. versionchanged:: 5.0
+       This class was previoiusly available under the name ``TracebackFuture``.
+       This name, which was deprecated since version 4.0, has been removed.
     """
     def __init__(self):
         self._done = False
@@ -344,8 +346,6 @@ class Future(object):
                           self, ''.join(tb).rstrip())
 
 
-TracebackFuture = Future
-
 if futures is None:
     FUTURES = Future  # type: typing.Union[type, typing.Tuple[type, ...]]
 else:
@@ -358,7 +358,7 @@ def is_future(x):
 
 class DummyExecutor(object):
     def submit(self, fn, *args, **kwargs):
-        future = TracebackFuture()
+        future = Future()
         try:
             future.set_result(fn(*args, **kwargs))
         except Exception:
@@ -460,7 +460,7 @@ def return_future(f):
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        future = TracebackFuture()
+        future = Future()
         callback, args, kwargs = replacer.replace(
             lambda value=_NO_RESULT: future.set_result(value),
             args, kwargs)

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -85,7 +85,7 @@ import textwrap
 import types
 import weakref
 
-from tornado.concurrent import Future, TracebackFuture, is_future, chain_future, future_set_exc_info
+from tornado.concurrent import Future, is_future, chain_future, future_set_exc_info
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 from tornado import stack_context
@@ -277,7 +277,7 @@ def _make_coroutine_wrapper(func, replace_callback):
 
     @functools.wraps(wrapped)
     def wrapper(*args, **kwargs):
-        future = TracebackFuture()
+        future = Future()
 
         if replace_callback and 'callback' in kwargs:
             callback = kwargs.pop('callback')
@@ -302,7 +302,7 @@ def _make_coroutine_wrapper(func, replace_callback):
                     orig_stack_contexts = stack_context._state.contexts
                     yielded = next(result)
                     if stack_context._state.contexts is not orig_stack_contexts:
-                        yielded = TracebackFuture()
+                        yielded = Future()
                         yielded.set_exception(
                             stack_context.StackContextInconsistentError(
                                 'stack_context inconsistency (probably caused '
@@ -456,7 +456,7 @@ class WaitIterator(object):
         Note that this `.Future` will not be the same object as any of
         the inputs.
         """
-        self._running_future = TracebackFuture()
+        self._running_future = Future()
 
         if self._finished:
             self._return_result(self._finished.popleft())
@@ -973,7 +973,7 @@ class Runner(object):
     Maintains information about pending callbacks and their results.
 
     The results of the generator are stored in ``result_future`` (a
-    `.TracebackFuture`)
+    `.Future`)
     """
     def __init__(self, gen, result_future, first_yielded):
         self.gen = gen
@@ -1104,7 +1104,7 @@ class Runner(object):
         if isinstance(yielded, YieldPoint):
             # YieldPoints are too closely coupled to the Runner to go
             # through the generic convert_yielded mechanism.
-            self.future = TracebackFuture()
+            self.future = Future()
 
             def start_yield_point():
                 try:

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from tornado.concurrent import Future
+from tornado.concurrent import Future, future_add_done_callback
 from tornado.escape import native_str, utf8
 from tornado import gen
 from tornado import httputil
@@ -470,7 +470,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         if self._pending_write is None:
             self._finish_request(None)
         else:
-            self._pending_write.add_done_callback(self._finish_request)
+            future_add_done_callback(self._pending_write, self._finish_request)
 
     def _on_write_complete(self, future):
         exc = future.exception()

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -44,7 +44,7 @@ import functools
 import time
 import weakref
 
-from tornado.concurrent import TracebackFuture
+from tornado.concurrent import Future
 from tornado.escape import utf8, native_str
 from tornado import gen, httputil, stack_context
 from tornado.ioloop import IOLoop
@@ -238,7 +238,7 @@ class AsyncHTTPClient(Configurable):
         # where normal dicts get converted to HTTPHeaders objects.
         request.headers = httputil.HTTPHeaders(request.headers)
         request = _RequestProxy(request, self.defaults)
-        future = TracebackFuture()
+        future = Future()
         if callback is not None:
             callback = stack_context.wrap(callback)
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -44,7 +44,7 @@ import time
 import traceback
 import math
 
-from tornado.concurrent import TracebackFuture, is_future, chain_future
+from tornado.concurrent import TracebackFuture, is_future, chain_future, future_set_exc_info
 from tornado.log import app_log, gen_log
 from tornado.platform.auto import set_close_exec, Waker
 from tornado import stack_context
@@ -482,7 +482,7 @@ class IOLoop(Configurable):
                     result = convert_yielded(result)
             except Exception:
                 future_cell[0] = TracebackFuture()
-                future_cell[0].set_exc_info(sys.exc_info())
+                future_set_exc_info(future_cell[0], sys.exc_info())
             else:
                 if is_future(result):
                     future_cell[0] = result

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -44,7 +44,7 @@ import time
 import traceback
 import math
 
-from tornado.concurrent import TracebackFuture, is_future, chain_future, future_set_exc_info
+from tornado.concurrent import Future, is_future, chain_future, future_set_exc_info
 from tornado.log import app_log, gen_log
 from tornado.platform.auto import set_close_exec, Waker
 from tornado import stack_context
@@ -481,13 +481,13 @@ class IOLoop(Configurable):
                     from tornado.gen import convert_yielded
                     result = convert_yielded(result)
             except Exception:
-                future_cell[0] = TracebackFuture()
+                future_cell[0] = Future()
                 future_set_exc_info(future_cell[0], sys.exc_info())
             else:
                 if is_future(result):
                     future_cell[0] = result
                 else:
-                    future_cell[0] = TracebackFuture()
+                    future_cell[0] = Future()
                     future_cell[0].set_result(result)
             self.add_future(future_cell[0], lambda future: self.stop())
         self.add_callback(run)
@@ -658,7 +658,7 @@ class IOLoop(Configurable):
         c_future = executor.submit(func, *args)
         # Concurrent Futures are not usable with await. Wrap this in a
         # Tornado Future instead, using self.add_future for thread-safety.
-        t_future = TracebackFuture()
+        t_future = Future()
         self.add_future(c_future, lambda f: chain_future(f, t_future))
         return t_future
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -44,7 +44,7 @@ import time
 import traceback
 import math
 
-from tornado.concurrent import Future, is_future, chain_future, future_set_exc_info
+from tornado.concurrent import Future, is_future, chain_future, future_set_exc_info, future_add_done_callback
 from tornado.log import app_log, gen_log
 from tornado.platform.auto import set_close_exec, Waker
 from tornado import stack_context
@@ -636,8 +636,8 @@ class IOLoop(Configurable):
         """
         assert is_future(future)
         callback = stack_context.wrap(callback)
-        future.add_done_callback(
-            lambda future: self.add_callback(callback, future))
+        future_add_done_callback(future,
+                           lambda future: self.add_callback(callback, future))
 
     def run_in_executor(self, executor, func, *args):
         """Runs a function in a ``concurrent.futures.Executor``. If

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -34,7 +34,7 @@ import socket
 import sys
 import re
 
-from tornado.concurrent import TracebackFuture
+from tornado.concurrent import Future
 from tornado import ioloop
 from tornado.log import gen_log, app_log
 from tornado.netutil import ssl_wrap_socket, _client_ssl_defaults, _server_ssl_defaults
@@ -395,7 +395,7 @@ class BaseIOStream(object):
             self._write_callback = stack_context.wrap(callback)
             future = None
         else:
-            future = TracebackFuture()
+            future = Future()
             future.add_done_callback(lambda f: f.exception())
             self._write_futures.append((self._total_write_index, future))
         if not self._connecting:
@@ -671,7 +671,7 @@ class BaseIOStream(object):
         if callback is not None:
             self._read_callback = stack_context.wrap(callback)
         else:
-            self._read_future = TracebackFuture()
+            self._read_future = Future()
         return self._read_future
 
     def _run_read_callback(self, size, streaming):
@@ -1091,7 +1091,7 @@ class IOStream(BaseIOStream):
             self._connect_callback = stack_context.wrap(callback)
             future = None
         else:
-            future = self._connect_future = TracebackFuture()
+            future = self._connect_future = Future()
         try:
             self.socket.connect(address)
         except socket.error as e:
@@ -1169,7 +1169,7 @@ class IOStream(BaseIOStream):
         orig_close_callback = self._close_callback
         self._close_callback = None
 
-        future = TracebackFuture()
+        future = Future()
         ssl_stream = SSLIOStream(socket, ssl_options=ssl_options)
         # Wrap the original close callback so we can fail our Future as well.
         # If we had an "unwrap" counterpart to this method we would need
@@ -1425,7 +1425,7 @@ class SSLIOStream(IOStream):
             self._ssl_connect_callback = stack_context.wrap(callback)
             future = None
         else:
-            future = self._ssl_connect_future = TracebackFuture()
+            future = self._ssl_connect_future = Future()
         if not self._ssl_accepting:
             self._run_ssl_connect_callback()
         return future

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -463,6 +463,7 @@ class BaseIOStream(object):
                 self._ssl_connect_future = None
             for future in futures:
                 future.set_exception(StreamClosedError(real_error=self.error))
+                future.exception()
             if self._close_callback is not None:
                 cb = self._close_callback
                 self._close_callback = None

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -105,14 +105,21 @@ class BaseAsyncIOLoop(IOLoop):
     def start(self):
         old_current = IOLoop.current(instance=False)
         try:
+            old_asyncio = asyncio.get_event_loop()
+        except RuntimeError:
+            old_asyncio = None
+        try:
             self._setup_logging()
             self.make_current()
+            # This is automatic in 3.5, but must be done manually in 3.4.
+            asyncio.set_event_loop(self.asyncio_loop)
             self.asyncio_loop.run_forever()
         finally:
             if old_current is None:
                 IOLoop.clear_current()
             else:
                 old_current.make_current()
+            asyncio.set_event_loop(old_asyncio)
 
     def stop(self):
         self.asyncio_loop.stop()
@@ -186,10 +193,12 @@ def to_tornado_future(asyncio_future):
     """Convert an `asyncio.Future` to a `tornado.concurrent.Future`.
 
     .. versionadded:: 4.1
+
+    .. deprecated:: 5.0
+       Tornado ``Futures`` have been merged with `asyncio.Future`,
+       so this method is now a no-op.
     """
-    tf = tornado.concurrent.Future()
-    tornado.concurrent.chain_future(asyncio_future, tf)
-    return tf
+    return asyncio_future
 
 
 def to_asyncio_future(tornado_future):
@@ -200,12 +209,9 @@ def to_asyncio_future(tornado_future):
     .. versionchanged:: 4.3
        Now accepts any yieldable object, not just
        `tornado.concurrent.Future`.
+
+    .. deprecated:: 5.0
+       Tornado ``Futures`` have been merged with `asyncio.Future`,
+       so this method is now equivalent to `tornado.gen.convert_yielded`.
     """
-    tornado_future = convert_yielded(tornado_future)
-    af = asyncio.Future()
-    tornado.concurrent.chain_future(tornado_future, af)
-    return af
-
-
-if hasattr(convert_yielded, 'register'):
-    convert_yielded.register(asyncio.Future, to_tornado_future)  # type: ignore
+    return convert_yielded(tornado_future)

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -26,17 +26,7 @@ from tornado.gen import convert_yielded
 from tornado.ioloop import IOLoop
 from tornado import stack_context
 
-try:
-    # Import the real asyncio module for py33+ first.  Older versions of the
-    # trollius backport also use this name.
-    import asyncio  # type: ignore
-except ImportError as e:
-    # Asyncio itself isn't available; see if trollius is (backport to py26+).
-    try:
-        import trollius as asyncio  # type: ignore
-    except ImportError:
-        # Re-raise the original asyncio error, not the trollius one.
-        raise e
+import asyncio
 
 
 class BaseAsyncIOLoop(IOLoop):

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -42,7 +42,7 @@ import twisted.names.resolve  # type: ignore
 
 from zope.interface import implementer  # type: ignore
 
-from tornado.concurrent import Future
+from tornado.concurrent import Future, future_set_exc_info
 from tornado.escape import utf8
 from tornado import gen
 import tornado.ioloop
@@ -585,6 +585,6 @@ if hasattr(gen.convert_yielded, 'register'):
                 # Should never happen, but just in case
                 raise Exception("errback called without error")
             except:
-                f.set_exc_info(sys.exc_info())
+                future_set_exc_info(f, sys.exc_info())
         d.addCallbacks(f.set_result, errback)
         return f

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -317,6 +317,7 @@ class _TestReactor(TornadoReactor):
     """
     def __init__(self):
         # always use a new ioloop
+        IOLoop.clear_current()
         IOLoop(make_current=True)
         super(_TestReactor, self).__init__()
         IOLoop.clear_current()

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -47,7 +47,8 @@ class QueueFull(Exception):
 def _set_timeout(future, timeout):
     if timeout:
         def on_timeout():
-            future.set_exception(gen.TimeoutError())
+            if not future.done():
+                future.set_exception(gen.TimeoutError())
         io_loop = ioloop.IOLoop.current()
         timeout_handle = io_loop.add_timeout(timeout, on_timeout)
         future.add_done_callback(

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -24,7 +24,7 @@ import time
 import numbers
 import datetime
 
-from tornado.concurrent import Future
+from tornado.concurrent import Future, future_add_done_callback
 from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream
 from tornado import gen
@@ -105,8 +105,8 @@ class _Connector(object):
             return
         stream, future = self.connect(af, addr)
         self.streams.add(stream)
-        future.add_done_callback(functools.partial(self.on_connect_done,
-                                                   addrs, af, addr))
+        future_add_done_callback(future, functools.partial(self.on_connect_done,
+                                                     addrs, af, addr))
 
     def on_connect_done(self, addrs, af, addr, future):
         self.remaining -= 1

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -105,10 +105,11 @@ class AsyncIOLoopTest(AsyncTestCase):
             42)
 
         # Asyncio only supports coroutines that yield asyncio-compatible
-        # Futures.
-        with self.assertRaises(RuntimeError):
+        # Futures (which our Future is since 5.0).
+        self.assertEqual(
             asyncio.get_event_loop().run_until_complete(
-                native_coroutine_without_adapter())
+                native_coroutine_without_adapter()),
+            42)
         self.assertEqual(
             asyncio.get_event_loop().run_until_complete(
                 native_coroutine_with_adapter()),

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -176,6 +176,13 @@ class ReturnFutureTest(AsyncTestCase):
 
     @gen_test
     def test_uncaught_exception_log(self):
+        if IOLoop.configured_class().__name__.endswith('AsyncIOLoop'):
+            # Install an exception handler that mirrors our
+            # non-asyncio logging behavior.
+            def exc_handler(loop, context):
+                app_log.error('%s: %s', context['message'],
+                              type(context.get('exception')))
+            self.io_loop.asyncio_loop.set_exception_handler(exc_handler)
         @gen.coroutine
         def f():
             yield gen.moment

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -5,8 +5,9 @@ from hashlib import md5
 
 from tornado.escape import utf8
 from tornado.httpclient import HTTPRequest
+from tornado.locks import Event
 from tornado.stack_context import ExceptionStackContext
-from tornado.testing import AsyncHTTPTestCase
+from tornado.testing import AsyncHTTPTestCase, gen_test
 from tornado.test import httpclient_test
 from tornado.test.util import unittest
 from tornado.web import Application, RequestHandler
@@ -97,19 +98,20 @@ class CurlHTTPClientTestCase(AsyncHTTPTestCase):
                                    defaults=dict(allow_ipv6=False),
                                    **kwargs)
 
+    @gen_test
     def test_prepare_curl_callback_stack_context(self):
         exc_info = []
+        error_event = Event()
 
         def error_handler(typ, value, tb):
             exc_info.append((typ, value, tb))
-            self.stop()
+            error_event.set()
             return True
 
         with ExceptionStackContext(error_handler):
-            request = HTTPRequest(self.get_url('/'),
+            request = HTTPRequest(self.get_url('/custom_reason'),
                                   prepare_curl_callback=lambda curl: 1 / 0)
-        self.http_client.fetch(request, callback=self.stop)
-        self.wait()
+        yield [error_event.wait(), self.http_client.fetch(request)]
         self.assertEqual(1, len(exc_info))
         self.assertIs(exc_info[0][0], ZeroDivisionError)
 

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1016,6 +1016,8 @@ class GenCoroutineTest(AsyncTestCase):
         self.finished = True
 
     @skipNotCPython
+    @unittest.skipIf((3,) < sys.version_info < (3,6),
+                     "asyncio.Future has reference cycles")
     def test_coroutine_refcounting(self):
         # On CPython, tasks and their arguments should be released immediately
         # without waiting for garbage collection.

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -41,6 +41,7 @@ def read_stream_body(stream, callback):
             chunks.append(chunk)
 
         def finish(self):
+            conn.detach()
             callback((self.start_line, self.headers, b''.join(chunks)))
     conn = HTTP1Connection(stream, True)
     conn.read_response(Delegate())
@@ -614,6 +615,7 @@ class UnixSocketTest(AsyncTestCase):
 
     def tearDown(self):
         self.stream.close()
+        self.io_loop.run_sync(self.server.close_all_connections)
         self.server.stop()
         shutil.rmtree(self.tmpdir)
         super(UnixSocketTest, self).tearDown()

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -799,6 +799,8 @@ class TestIOLoopConfiguration(unittest.TestCase):
                 'print(isinstance(IOLoop.current(), PollIOLoop))')
             self.assertEqual(is_poll, 'True')
 
+    @unittest.skipIf(asyncio is not None,
+                     "IOLoop configuration not available")
     def test_explicit_select(self):
         # SelectIOLoop can always be configured explicitly.
         default_class = self.run_python(

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -121,6 +121,13 @@ def main():
     # Twisted 15.0.0 triggers some warnings on py3 with -bb.
     warnings.filterwarnings("ignore", category=BytesWarning,
                             module=r"twisted\..*")
+    if (3,) < sys.version_info < (3, 6):
+        # Prior to 3.6, async ResourceWarnings were rather noisy
+        # and even
+        # `python3.4 -W error -c 'import asyncio; asyncio.get_event_loop()'`
+        # would generate a warning.
+        warnings.filterwarnings("ignore", category=ResourceWarning,
+                                module=r"asyncio\..*")
 
     logging.getLogger("tornado.access").setLevel(logging.CRITICAL)
 

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -230,6 +230,9 @@ class ConnectorTest(AsyncTestCase):
         else:
             self.streams.pop(addr)
             future.set_exception(IOError())
+        # Run the loop to allow callbacks to be run.
+        self.io_loop.add_callback(self.stop)
+        self.wait()
 
     def assert_connector_streams_closed(self, conn):
         for stream in conn.streams:

--- a/tornado/test/tcpserver_test.py
+++ b/tornado/test/tcpserver_test.py
@@ -19,7 +19,7 @@ class TCPServerTest(AsyncTestCase):
         class TestServer(TCPServer):
             @gen.coroutine
             def handle_stream(self, stream, address):
-                yield gen.moment
+                yield stream.read_bytes(len(b'hello'))
                 stream.close()
                 1 / 0
 
@@ -32,6 +32,7 @@ class TCPServerTest(AsyncTestCase):
             client = IOStream(socket.socket())
             with ExpectLog(app_log, "Exception in callback"):
                 yield client.connect(('localhost', port))
+                yield client.write(b'hello')
                 yield client.read_until_close()
                 yield gen.moment
         finally:

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -68,6 +68,10 @@ if PY3:
 else:
     import thread
 
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
 
 skipIfNoTwisted = unittest.skipUnless(have_twisted,
                                       "twisted module not present")
@@ -501,6 +505,14 @@ class CompatibilityTests(unittest.TestCase):
 
 @skipIfNoTwisted
 class ConvertDeferredTest(unittest.TestCase):
+    def setUp(self):
+        if asyncio is not None:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+
+    def tearDown(self):
+        if asyncio is not None:
+            asyncio.set_event_loop(None)
+
     def test_success(self):
         @inlineCallbacks
         def fn():

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -94,6 +94,7 @@ def restore_signal_handlers(saved):
 class ReactorTestCase(unittest.TestCase):
     def setUp(self):
         self._saved_signals = save_signal_handlers()
+        IOLoop.clear_current()
         self._io_loop = IOLoop(make_current=True)
         self._reactor = TornadoReactor()
         IOLoop.clear_current()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -48,6 +48,12 @@ else:
     from cStringIO import StringIO
 
 try:
+    import asyncio
+except ImportError:
+    asyncio = None
+
+
+try:
     from collections.abc import Generator as GeneratorType  # type: ignore
 except ImportError:
     from types import GeneratorType  # type: ignore
@@ -211,6 +217,9 @@ class AsyncTestCase(unittest.TestCase):
         super(AsyncTestCase, self).setUp()
         self.io_loop = self.get_new_ioloop()
         self.io_loop.make_current()
+        if hasattr(self.io_loop, 'asyncio_loop'):
+            # Ensure that asyncio's current event loop matches ours.
+            asyncio.set_event_loop(self.io_loop.asyncio_loop)
 
     def tearDown(self):
         # Clean up Subprocess, so it can be used again with a new ioloop.
@@ -222,6 +231,8 @@ class AsyncTestCase(unittest.TestCase):
         # set FD_CLOEXEC on its file descriptors)
         self.io_loop.close(all_fds=True)
         super(AsyncTestCase, self).tearDown()
+        if hasattr(self.io_loop, 'asyncio_loop'):
+            asyncio.set_event_loop(None)
         # In case an exception escaped or the StackContext caught an exception
         # when there wasn't a wait() to re-raise it, do so here.
         # This is our last chance to raise an exception in a way that the

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -28,7 +28,7 @@ import tornado.escape
 import tornado.web
 import zlib
 
-from tornado.concurrent import TracebackFuture
+from tornado.concurrent import Future
 from tornado.escape import utf8, native_str, to_unicode
 from tornado import gen, httpclient, httputil
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -1052,7 +1052,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
                  compression_options=None, ping_interval=None, ping_timeout=None,
                  max_message_size=None):
         self.compression_options = compression_options
-        self.connect_future = TracebackFuture()
+        self.connect_future = Future()
         self.protocol = None
         self.read_future = None
         self.read_queue = collections.deque()
@@ -1158,7 +1158,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         ready.
         """
         assert self.read_future is None
-        future = TracebackFuture()
+        future = Future()
         if self.read_queue:
             future.set_result(self.read_queue.popleft())
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,9 @@ envlist =
         {py2,py3}-curl,
 
         # Alternate IOLoops.
-        {py2,py3}-select,
-        {py2,py3}-full-twisted,
+        py2-select,
+        py2-full-twisted,
         py2-twistedlayered,
-        py3-full-poll,
         py2-full-trollius,
 
         # Alternate Resolvers.

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ envlist =
         py2-select,
         py2-full-twisted,
         py2-twistedlayered,
-        py2-full-trollius,
 
         # Alternate Resolvers.
         {py2,py3}-full-{threadedresolver},
@@ -80,7 +79,6 @@ deps =
      {py2,py27,pypy,pypy3}-full: mock
      # singledispatch became standard in py34.
      {py2,py27,pypy}-full: singledispatch
-     trollius: trollius
      py2-monotonic: monotonic
      sphinx: sphinx
      sphinx: sphinx_rtd_theme
@@ -119,7 +117,6 @@ commands =
          select: --ioloop=tornado.platform.select.SelectIOLoop \
          twisted: --ioloop=tornado.platform.twisted.TwistedIOLoop \
          twistedlayered: --ioloop=tornado.test.twisted_test.LayeredTwistedIOLoop --resolver=tornado.platform.twisted.TwistedResolver \
-         trollius: --ioloop=tornado.platform.asyncio.AsyncIOLoop \
          caresresolver: --resolver=tornado.platform.caresresolver.CaresResolver \
          threadedresolver: --resolver=tornado.netutil.ThreadedResolver \
          monotonic: --ioloop=tornado.ioloop.PollIOLoop --ioloop_time_monotonic \


### PR DESCRIPTION
Tornado's Future class is now an alias for asyncio.Future on python 3.4+.

- Removed TracebackFuture alias
- Introduced new functions future_set_exc_info and future_add_done_callback to cover some differences between the implementations
- Tweaked tests due to changes in callback timing (asyncio futures always schedule their callbacks on the next IOLoop iteration)
- Ensure all tests have valid asyncio event loops (asyncio.Future requires one *at creation time*)