### PR TITLE
Add IOLoop.is_running()

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -496,6 +496,16 @@ class IOLoop(Configurable):
             raise TimeoutError('Operation timed out after %s seconds' % timeout)
         return future_cell[0].result()
 
+    def is_running(self):
+        """Return True if this `IOLoop` is currently running.
+
+        An `IOLoop` is running if its `start()` method has been called
+        and has not yet returned.
+
+        .. versionadded:: 5.0
+        """
+        raise NotImplementedError
+
     def time(self):
         """Returns the current time according to the `IOLoop`'s clock.
 
@@ -956,6 +966,7 @@ class PollIOLoop(IOLoop):
 
         finally:
             # reset the stopped flag so another start/stop pair can be issued
+            self._running = False
             self._stopped = False
             if self._blocking_signal_threshold is not None:
                 signal.setitimer(signal.ITIMER_REAL, 0, 0)
@@ -967,6 +978,9 @@ class PollIOLoop(IOLoop):
         self._running = False
         self._stopped = True
         self._waker.wake()
+
+    def is_running(self):
+        return self._running
 
     def time(self):
         return self.time_func()

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -128,6 +128,9 @@ class BaseAsyncIOLoop(IOLoop):
     def stop(self):
         self.asyncio_loop.stop()
 
+    def is_running(self):
+        return self.asyncio_loop.is_running()
+
     def call_at(self, when, callback, *args, **kwargs):
         # asyncio.call_at supports *args but not **kwargs, so bind them here.
         # We do not synchronize self.time and asyncio_loop.time, so

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -485,6 +485,9 @@ class TwistedIOLoop(tornado.ioloop.IOLoop):
     def stop(self):
         self.reactor.crash()
 
+    def is_running(self):
+        return self.reactor.running
+
     def add_timeout(self, deadline, callback, *args, **kwargs):
         # This method could be simplified (since tornado 4.0) by
         # overriding call_at instead of add_timeout, but we leave it

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -38,6 +38,20 @@ class AsyncIOLoopTest(AsyncTestCase):
         asyncio.get_event_loop().call_soon(self.stop)
         self.wait()
 
+    def test_is_running(self):
+        loop = self.io_loop
+        was_running = [None]
+
+        def cb():
+            was_running[0] = loop.is_running()
+
+        loop.add_callback(cb)
+        loop.add_callback(loop.stop)
+        self.assertFalse(loop.is_running())
+        loop.start()
+        self.assertTrue(was_running[0])
+        self.assertFalse(loop.is_running())
+
     @gen_test
     def test_asyncio_future(self):
         # Test that we can yield an asyncio future from a tornado coroutine.

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -39,18 +39,25 @@ class AsyncIOLoopTest(AsyncTestCase):
         self.wait()
 
     def test_is_running(self):
-        loop = self.io_loop
         was_running = [None]
 
         def cb():
-            was_running[0] = loop.is_running()
+            was_running[0] = self.io_loop.is_running()
 
-        loop.add_callback(cb)
-        loop.add_callback(loop.stop)
-        self.assertFalse(loop.is_running())
-        loop.start()
+        self.io_loop.add_callback(cb)
+        self.io_loop.add_callback(self.io_loop.stop)
+        self.assertFalse(self.io_loop.is_running())
+        self.io_loop.start()
         self.assertTrue(was_running[0])
-        self.assertFalse(loop.is_running())
+        self.assertFalse(self.io_loop.is_running())
+
+        was_running = [None]
+        asyncio.get_event_loop().call_soon(cb)
+        asyncio.get_event_loop().call_soon(asyncio.get_event_loop().stop)
+        self.assertFalse(self.io_loop.is_running())
+        asyncio.get_event_loop().run_forever()
+        self.assertTrue(was_running[0])
+        self.assertFalse(self.io_loop.is_running())
 
     @gen_test
     def test_asyncio_future(self):

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -177,13 +177,10 @@ class TestIOLoop(AsyncTestCase):
         # This also happens to be the first test where we run an IOLoop in
         # a non-main thread.
         other_ioloop = IOLoop()
-        self.assertFalse(other_ioloop.is_running())
         thread = threading.Thread(target=other_ioloop.start)
         thread.start()
-        self.assertTrue(other_ioloop.is_running())
         other_ioloop.add_callback_from_signal(other_ioloop.stop)
         thread.join()
-        self.assertFalse(other_ioloop.is_running())
         other_ioloop.close()
 
     def test_add_callback_while_closing(self):

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -34,7 +34,7 @@ from tornado.httpclient import AsyncHTTPClient
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop, PollIOLoop
 from tornado.platform.auto import set_close_exec
-from tornado.testing import bind_unused_port
+from tornado.testing import AsyncTestCase, bind_unused_port
 from tornado.test.util import unittest
 from tornado.util import import_object, PY3
 from tornado.web import RequestHandler, Application
@@ -218,6 +218,35 @@ class ReactorCallInThread(ReactorTestCase):
     def testCallInThread(self):
         self._reactor.callWhenRunning(self._whenRunningCallback)
         self._reactor.run()
+
+
+@skipIfNoTwisted
+class TwistedIOLoopTest(AsyncTestCase):
+    def setUp(self):
+        super(TwistedIOLoopTest, self).setUp()
+        self._saved_signals = save_signal_handlers()
+
+    def tearDown(self):
+        restore_signal_handlers(self._saved_signals)
+        super(TwistedIOLoopTest, self).tearDown()
+
+    def get_new_ioloop(self):
+        io_loop = TwistedIOLoop()
+        return io_loop
+
+    def test_is_running(self):
+        loop = self.io_loop
+        was_running = [None]
+
+        def cb():
+            was_running[0] = loop.is_running()
+
+        loop.add_callback(cb)
+        loop.add_callback(loop.stop)
+        self.assertFalse(loop.is_running())
+        loop.start()
+        self.assertTrue(was_running[0])
+        self.assertFalse(loop.is_running())
 
 
 if have_twisted:


### PR DESCRIPTION
This provides a public API to replace the private `_running` flag specific to PollIOLoop.
Also mirrors equivalent APIs provided by asyncio and Twisted.