### PR TITLE
Tcpclient connect timeout

### DIFF
--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -137,7 +137,8 @@ class _Connector(object):
 
     def on_timeout(self):
         self.timeout = None
-        self.try_connect(iter(self.secondary_addrs))
+        if not self.future.done():
+            self.try_connect(iter(self.secondary_addrs))
 
     def clear_timeout(self):
         if self.timeout is not None:

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -20,6 +20,9 @@ from __future__ import absolute_import, division, print_function
 
 import functools
 import socket
+import time
+import numbers
+import datetime
 
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
@@ -27,6 +30,8 @@ from tornado.iostream import IOStream
 from tornado import gen
 from tornado.netutil import Resolver
 from tornado.platform.auto import set_close_exec
+from tornado.gen import TimeoutError
+from tornado.util import timedelta_to_seconds
 
 _INITIAL_CONNECT_TIMEOUT = 0.3
 
@@ -54,6 +59,7 @@ class _Connector(object):
 
         self.future = Future()
         self.timeout = None
+        self.connect_timeout = None
         self.last_error = None
         self.remaining = len(addrinfo)
         self.primary_addrs, self.secondary_addrs = self.split(addrinfo)
@@ -78,9 +84,11 @@ class _Connector(object):
                 secondary.append((af, addr))
         return primary, secondary
 
-    def start(self, timeout=_INITIAL_CONNECT_TIMEOUT):
+    def start(self, timeout=_INITIAL_CONNECT_TIMEOUT, connect_timeout=None):
         self.try_connect(iter(self.primary_addrs))
-        self.set_timout(timeout)
+        self.set_timeout(timeout)
+        if connect_timeout is not None:
+            self.set_connect_timeout(connect_timeout)
         return self.future
 
     def try_connect(self, addrs):
@@ -116,13 +124,14 @@ class _Connector(object):
                 self.on_timeout()
             return
         self.clear_timeout()
+        self.clear_connect_timeout()
         if self.future.done():
             # This is a late arrival; just drop it.
             stream.close()
         else:
             self.future.set_result((af, addr, stream))
 
-    def set_timout(self, timeout):
+    def set_timeout(self, timeout):
         self.timeout = self.io_loop.add_timeout(self.io_loop.time() + timeout,
                                                 self.on_timeout)
 
@@ -133,6 +142,18 @@ class _Connector(object):
     def clear_timeout(self):
         if self.timeout is not None:
             self.io_loop.remove_timeout(self.timeout)
+
+    def set_connect_timeout(self, connect_timeout):
+        self.connect_timeout = self.io_loop.add_timeout(
+            connect_timeout, self.on_connect_timeout)
+
+    def on_connect_timeout(self):
+        if not self.future.done():
+            self.future.set_exception(TimeoutError())
+
+    def clear_connect_timeout(self):
+        if self.connect_timeout is not None:
+            self.io_loop.remove_timeout(self.connect_timeout)
 
 
 class TCPClient(object):
@@ -155,7 +176,8 @@ class TCPClient(object):
 
     @gen.coroutine
     def connect(self, host, port, af=socket.AF_UNSPEC, ssl_options=None,
-                max_buffer_size=None, source_ip=None, source_port=None):
+                max_buffer_size=None, source_ip=None, source_port=None,
+                timeout=None):
         """Connect to the given host and port.
 
         Asynchronously returns an `.IOStream` (or `.SSLIOStream` if
@@ -167,25 +189,45 @@ class TCPClient(object):
         use a specific interface, it has to be handled outside
         of Tornado as this depends very much on the platform.
 
+        Raises `TimeoutError` if the input future does not complete before
+        ``timeout``, which may be specified in any form allowed by
+        `.IOLoop.add_timeout` (i.e. a `datetime.timedelta` or an absolute time
+        relative to `.IOLoop.time`)
+
         Similarly, when the user requires a certain source port, it can
         be specified using the ``source_port`` arg.
 
         .. versionchanged:: 4.5
            Added the ``source_ip`` and ``source_port`` arguments.
         """
-        addrinfo = yield self.resolver.resolve(host, port, af)
+        if timeout is not None:
+            if isinstance(timeout, numbers.Real):
+                timeout = time.time() + timeout
+            elif isinstance(timeout, datetime.timedelta):
+                timeout = time.time() + timedelta_to_seconds(timeout)
+            else:
+                raise TypeError("Unsupported timeout %r" % timeout)
+        if timeout is not None:
+            addrinfo = yield gen.with_timeout(
+                timeout, self.resolver.resolve(host, port, af))
+        else:
+            addrinfo = yield self.resolver.resolve(host, port, af)
         connector = _Connector(
             addrinfo,
             functools.partial(self._create_stream, max_buffer_size,
                               source_ip=source_ip, source_port=source_port)
         )
-        af, addr, stream = yield connector.start()
+        af, addr, stream = yield connector.start(connect_timeout=timeout)
         # TODO: For better performance we could cache the (af, addr)
         # information here and re-use it on subsequent connections to
         # the same host. (http://tools.ietf.org/html/rfc6555#section-4.2)
         if ssl_options is not None:
-            stream = yield stream.start_tls(False, ssl_options=ssl_options,
-                                            server_hostname=host)
+            if timeout is not None:
+                stream = yield gen.with_timeout(timeout, stream.start_tls(
+                    False, ssl_options=ssl_options, server_hostname=host))
+            else:
+                stream = yield stream.start_tls(False, ssl_options=ssl_options,
+                                                server_hostname=host)
         raise gen.Return(stream)
 
     def _create_stream(self, max_buffer_size, af, addr, source_ip=None,

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -162,17 +162,18 @@ class TCPClientTest(AsyncTestCase):
     @skipOnTravis
     @gen_test
     def test_connect_timeout(self):
-        timeout = 0.02
-        timeout_min = self.io_loop.time() + 0.01
-        timeout_max = self.io_loop.time() + 0.03
+        timeout = 0.05
+        timeout_min, timeout_max = 0.04, 0.10
 
         class TimeoutResolver(Resolver):
             def resolve(self, *args, **kwargs):
                 return Future()  # never completes
+        start_time = self.io_loop.time()
         with self.assertRaises(TimeoutError):
             yield TCPClient(resolver=TimeoutResolver()).connect(
                 '8.8.8.8', 12345, timeout=timeout)
-        self.assertTrue(timeout_min < self.io_loop.time() < timeout_max)
+        end_time = self.io_loop.time()
+        self.assertTrue(timeout_min < end_time - start_time < timeout_max)
 
 
 class TestConnectorSplit(unittest.TestCase):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -330,7 +330,7 @@ class ConnectorTest(AsyncTestCase):
         self.resolve_connect(AF1, 'b', False)
         self.assertRaises(IOError, future.result)
 
-    def test_one_family_connect_timeout(self):
+    def test_one_family_timeout_after_connect_timeout(self):
         conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
         self.assert_pending((AF1, 'a'))
         conn.on_connect_timeout()
@@ -338,6 +338,7 @@ class ConnectorTest(AsyncTestCase):
         # should explicitly pop the connect_future.
         self.connect_futures.pop((AF1, 'a'))
         self.assertTrue(self.streams.pop('a').closed)
+        conn.on_timeout()
         # if the future is set with TimeoutError, we will not iterate next
         # possible address.
         self.assert_pending()

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -328,45 +328,63 @@ class ConnectorTest(AsyncTestCase):
         self.resolve_connect(AF1, 'b', False)
         self.assertRaises(IOError, future.result)
 
-    def test_timeout_after_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a')])
-        self.assert_pending((AF1, 'a'))
-        conn.on_connect_timeout()
-        conn.on_timeout()
-        self.assertRaises(TimeoutError, future.result)
-
-    def test_timeout_before_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a')])
-        self.assert_pending((AF1, 'a'))
-        conn.on_timeout()
-        conn.on_connect_timeout()
-        self.assertRaises(TimeoutError, future.result)
-
-    def test_failure_before_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a')])
-        self.assert_pending((AF1, 'a'))
-        self.resolve_connect(AF1, 'a', False)
-        conn.on_connect_timeout()
-        self.assertRaises(IOError, future.result)
-
-    def test_failure_after_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a')])
-        self.assert_pending((AF1, 'a'))
-        conn.on_connect_timeout()
-        self.resolve_connect(AF1, 'a', False)
-        self.assertRaises(TimeoutError, future.result)
-
-    def test_success_before_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a')])
+    def test_one_family_success_before_connect_timeout(self):
+        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
         self.assert_pending((AF1, 'a'))
         self.resolve_connect(AF1, 'a', True)
         conn.on_connect_timeout()
+        self.assert_pending()
         self.assertEqual(future.result(), (AF1, 'a', self.streams['a']))
 
-    def test_success_after_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a')])
+    def test_one_family_success_after_connect_timeout(self):
+        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
         self.assert_pending((AF1, 'a'))
         conn.on_connect_timeout()
         self.resolve_connect(AF1, 'a', True)
         self.assertTrue(self.streams.pop('a').closed)
+        self.assertRaises(TimeoutError, future.result)
+
+    def test_one_family_second_try_failure_before_connect_timeout(self):
+        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
+        self.assert_pending((AF1, 'a'))
+        self.resolve_connect(AF1, 'a', False)
+        self.assert_pending((AF1, 'b'))
+        self.resolve_connect(AF1, 'b', False)
+        conn.on_connect_timeout()
+        self.assertRaises(IOError, future.result)
+
+    def test_one_family_second_try_failure_after_connect_timeout(self):
+        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
+        self.assert_pending((AF1, 'a'))
+        self.resolve_connect(AF1, 'a', False)
+        conn.on_connect_timeout()
+        self.assert_pending((AF1, 'b'))
+        self.resolve_connect(AF1, 'b', False)
+        self.assertRaises(TimeoutError, future.result)
+
+    def test_two_family_timeout_before_connect_timeout(self):
+        conn, future = self.start_connect(self.addrinfo)
+        self.assert_pending((AF1, 'a'))
+        conn.on_timeout()
+        self.assert_pending((AF1, 'a'), (AF2, 'c'))
+        conn.on_connect_timeout()
+        self.assert_pending((AF1, 'a'), (AF2, 'c'))
+        self.resolve_connect(AF1, 'a', True)
+        self.assertTrue(self.streams.pop('a').closed)
+        self.resolve_connect(AF2, 'c', True)
+        self.assertTrue(self.streams.pop('c').closed)
+        self.assert_pending()
+        self.assertRaises(TimeoutError, future.result)
+
+    def test_two_family_timeout_after_connect_timeout(self):
+        conn, future = self.start_connect(self.addrinfo)
+        self.assert_pending((AF1, 'a'))
+        conn.on_connect_timeout()
+        conn.on_timeout()
+        # if the future is set with TimeoutError, we do not trigger
+        # secondary address.
+        self.assert_pending((AF1, 'a'))
+        self.resolve_connect(AF1, 'a', True)
+        self.assertTrue(self.streams.pop('a').closed)
+        self.assert_pending()
         self.assertRaises(TimeoutError, future.result)

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -341,7 +341,18 @@ class ConnectorTest(AsyncTestCase):
         self.assert_pending((AF1, 'a'))
         conn.on_connect_timeout()
         self.resolve_connect(AF1, 'a', True)
+        # the later success stream will be closed after connect timeout.
         self.assertTrue(self.streams.pop('a').closed)
+        self.assertRaises(TimeoutError, future.result)
+
+    def test_one_family_first_try_failure_after_connect_timeout(self):
+        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
+        self.assert_pending((AF1, 'a'))
+        conn.on_connect_timeout()
+        self.resolve_connect(AF1, 'a', False)
+        # if the future is set with TimeoutError, we will not iterate next
+        # possible address.
+        self.assert_pending()
         self.assertRaises(TimeoutError, future.result)
 
     def test_one_family_second_try_failure_before_connect_timeout(self):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -159,21 +159,16 @@ class TCPClientTest(AsyncTestCase):
                           '127.0.0.1',
                           source_port=1)
 
-    @skipOnTravis
     @gen_test
     def test_connect_timeout(self):
         timeout = 0.05
-        timeout_min, timeout_max = 0.04, 0.10
 
         class TimeoutResolver(Resolver):
             def resolve(self, *args, **kwargs):
                 return Future()  # never completes
-        start_time = self.io_loop.time()
         with self.assertRaises(TimeoutError):
             yield TCPClient(resolver=TimeoutResolver()).connect(
-                '8.8.8.8', 12345, timeout=timeout)
-        end_time = self.io_loop.time()
-        self.assertTrue(timeout_min < end_time - start_time < timeout_max)
+                '1.2.3.4', 12345, timeout=timeout)
 
 
 class TestConnectorSplit(unittest.TestCase):
@@ -219,9 +214,11 @@ class ConnectorTest(AsyncTestCase):
         super(ConnectorTest, self).tearDown()
 
     def create_stream(self, af, addr):
+        stream = ConnectorTest.FakeStream()
+        self.streams[addr] = stream
         future = Future()
         self.connect_futures[(af, addr)] = future
-        return future
+        return stream, future
 
     def assert_pending(self, *keys):
         self.assertEqual(sorted(self.connect_futures.keys()), sorted(keys))
@@ -229,10 +226,14 @@ class ConnectorTest(AsyncTestCase):
     def resolve_connect(self, af, addr, success):
         future = self.connect_futures.pop((af, addr))
         if success:
-            self.streams[addr] = ConnectorTest.FakeStream()
             future.set_result(self.streams[addr])
         else:
+            self.streams.pop(addr)
             future.set_exception(IOError())
+
+    def assert_connector_streams_closed(self, conn):
+        for stream in conn.streams:
+            self.assertTrue(stream.closed)
 
     def start_connect(self, addrinfo):
         conn = _Connector(addrinfo, self.create_stream)
@@ -329,31 +330,45 @@ class ConnectorTest(AsyncTestCase):
         self.resolve_connect(AF1, 'b', False)
         self.assertRaises(IOError, future.result)
 
+    def test_one_family_connect_timeout(self):
+        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
+        self.assert_pending((AF1, 'a'))
+        conn.on_connect_timeout()
+        # the connector will close all streams on connect timeout, we
+        # should explicitly pop the connect_future.
+        self.connect_futures.pop((AF1, 'a'))
+        self.assertTrue(self.streams.pop('a').closed)
+        # if the future is set with TimeoutError, we will not iterate next
+        # possible address.
+        self.assert_pending()
+        self.assertEqual(len(conn.streams), 1)
+        self.assert_connector_streams_closed(conn)
+        self.assertRaises(TimeoutError, future.result)
+
     def test_one_family_success_before_connect_timeout(self):
         conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
         self.assert_pending((AF1, 'a'))
         self.resolve_connect(AF1, 'a', True)
         conn.on_connect_timeout()
         self.assert_pending()
+        self.assertEqual(self.streams['a'].closed, False)
+        # success stream will be pop
+        self.assertEqual(len(conn.streams), 0)
+        # streams in connector should be closed after connect timeout
+        self.assert_connector_streams_closed(conn)
         self.assertEqual(future.result(), (AF1, 'a', self.streams['a']))
 
-    def test_one_family_success_after_connect_timeout(self):
+    def test_one_family_second_try_after_connect_timeout(self):
         conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
         self.assert_pending((AF1, 'a'))
-        conn.on_connect_timeout()
-        self.resolve_connect(AF1, 'a', True)
-        # the later success stream will be closed after connect timeout.
-        self.assertTrue(self.streams.pop('a').closed)
-        self.assertRaises(TimeoutError, future.result)
-
-    def test_one_family_first_try_failure_after_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
-        self.assert_pending((AF1, 'a'))
-        conn.on_connect_timeout()
         self.resolve_connect(AF1, 'a', False)
-        # if the future is set with TimeoutError, we will not iterate next
-        # possible address.
+        self.assert_pending((AF1, 'b'))
+        conn.on_connect_timeout()
+        self.connect_futures.pop((AF1, 'b'))
+        self.assertTrue(self.streams.pop('b').closed)
         self.assert_pending()
+        self.assertEqual(len(conn.streams), 2)
+        self.assert_connector_streams_closed(conn)
         self.assertRaises(TimeoutError, future.result)
 
     def test_one_family_second_try_failure_before_connect_timeout(self):
@@ -363,16 +378,10 @@ class ConnectorTest(AsyncTestCase):
         self.assert_pending((AF1, 'b'))
         self.resolve_connect(AF1, 'b', False)
         conn.on_connect_timeout()
+        self.assert_pending()
+        self.assertEqual(len(conn.streams), 2)
+        self.assert_connector_streams_closed(conn)
         self.assertRaises(IOError, future.result)
-
-    def test_one_family_second_try_failure_after_connect_timeout(self):
-        conn, future = self.start_connect([(AF1, 'a'), (AF1, 'b')])
-        self.assert_pending((AF1, 'a'))
-        self.resolve_connect(AF1, 'a', False)
-        conn.on_connect_timeout()
-        self.assert_pending((AF1, 'b'))
-        self.resolve_connect(AF1, 'b', False)
-        self.assertRaises(TimeoutError, future.result)
 
     def test_two_family_timeout_before_connect_timeout(self):
         conn, future = self.start_connect(self.addrinfo)
@@ -380,23 +389,40 @@ class ConnectorTest(AsyncTestCase):
         conn.on_timeout()
         self.assert_pending((AF1, 'a'), (AF2, 'c'))
         conn.on_connect_timeout()
-        self.assert_pending((AF1, 'a'), (AF2, 'c'))
-        self.resolve_connect(AF1, 'a', True)
+        self.connect_futures.pop((AF1, 'a'))
         self.assertTrue(self.streams.pop('a').closed)
-        self.resolve_connect(AF2, 'c', True)
+        self.connect_futures.pop((AF2, 'c'))
         self.assertTrue(self.streams.pop('c').closed)
         self.assert_pending()
+        self.assertEqual(len(conn.streams), 2)
+        self.assert_connector_streams_closed(conn)
         self.assertRaises(TimeoutError, future.result)
+
+    def test_two_family_success_after_timeout(self):
+        conn, future = self.start_connect(self.addrinfo)
+        self.assert_pending((AF1, 'a'))
+        conn.on_timeout()
+        self.assert_pending((AF1, 'a'), (AF2, 'c'))
+        self.resolve_connect(AF1, 'a', True)
+        # if one of streams succeed, connector will close all other streams
+        self.connect_futures.pop((AF2, 'c'))
+        self.assertTrue(self.streams.pop('c').closed)
+        self.assert_pending()
+        self.assertEqual(len(conn.streams), 1)
+        self.assert_connector_streams_closed(conn)
+        self.assertEqual(future.result(), (AF1, 'a', self.streams['a']))
 
     def test_two_family_timeout_after_connect_timeout(self):
         conn, future = self.start_connect(self.addrinfo)
         self.assert_pending((AF1, 'a'))
         conn.on_connect_timeout()
-        conn.on_timeout()
-        # if the future is set with TimeoutError, we do not trigger
-        # secondary address.
-        self.assert_pending((AF1, 'a'))
-        self.resolve_connect(AF1, 'a', True)
+        self.connect_futures.pop((AF1, 'a'))
         self.assertTrue(self.streams.pop('a').closed)
         self.assert_pending()
+        conn.on_timeout()
+        # if the future is set with TimeoutError, connector will not
+        # trigger secondary address.
+        self.assert_pending()
+        self.assertEqual(len(conn.streams), 1)
+        self.assert_connector_streams_closed(conn)
         self.assertRaises(TimeoutError, future.result)


### PR DESCRIPTION
Hi bdarnell, I fixed some issues you mentioned last time.
1) The `tcpclient` timeout parameter should be real numbers or `timedelta`.
2) Add precise timeout testing to `tcpclient`.
3) Pass timeout to `connector`. If the timeout is triggered, we will not iterate either next address or secondary address, and the later success stream will also be closed.