### PR TITLE
ioloop: add loop iteration callback

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -743,6 +743,7 @@ class PollIOLoop(IOLoop):
         self._pid = os.getpid()
         self._blocking_signal_threshold = None
         self._timeout_counter = itertools.count()
+        self._loop_iter_callback = None
 
         # Create a pipe that we send bogus data to when we want to wake
         # the I/O loop when it is idle
@@ -795,6 +796,9 @@ class PollIOLoop(IOLoop):
             self._impl.unregister(fd)
         except Exception:
             gen_log.debug("Error deleting fd from IOLoop", exc_info=True)
+
+    def set_loop_iter_callback(self, fn):
+        self._loop_iter_callback = fn
 
     def set_blocking_signal_threshold(self, seconds, action):
         if not hasattr(signal, "setitimer"):
@@ -919,6 +923,7 @@ class PollIOLoop(IOLoop):
 
                 try:
                     event_pairs = self._impl.poll(poll_timeout)
+                    event_pairs_count = len(event_pairs)
                 except Exception as e:
                     # Depending on python version and IOLoop implementation,
                     # different exception types may be thrown and there are
@@ -954,6 +959,8 @@ class PollIOLoop(IOLoop):
                         self.handle_callback_exception(self._handlers.get(fd))
                 fd_obj = handler_func = None
 
+                if self._loop_iter_callback:
+                    self._loop_iter_callback(ncallbacks, event_pairs_count)
         finally:
             # reset the stopped flag so another start/stop pair can be issued
             self._stopped = False


### PR DESCRIPTION
I wanted to try and build better metrics around _how_ long the `ioloop` is blocked in a few applications.

Specifically, I tried to do something like:

```python
def ioloop_blocked_callback(signal, frame, threshold_ms):
        metrics.incr('ioloop_blocked', tags={'duration': '{}ms'.format(threshold_ms)})

    for threshold in range(50, 2000, 50):
        tornado.ioloop.set_blocking_signal(threshold, functools.partial(ioloop_blocked, threshold_ms=threshold))
```
which led me to realized that we couldn't actually set more than one blocked threshold.

Digging in a bit further, I was thinking it might be generally useful to add a `hook` which allows us to run a callback on each iteration of the ioloop. Specifically, here, I'm curious about how long an iteration takes as well as how much work its doing. My assumption, is that its probably just as good to understand _how_ long iterations are taking because you could use it to help understand how saturated the `ioloop` is. For instance, if we're consistently returning a lot of event pairs, we know we're saturating the `ioloop`, right? 

I ended up implementing a `callback` with _this_ branch where I wrote metrics for the following code to try and pull out some of this context. Here's some pseudo code:

```python
  iter_start_ts = time.time()

    def iter_callback(ncallbacks, nevents):
        global iter_start_ts

        metrics.incr('io_loop_iteration.count')
        metrics.timing('io_loop_iteration.latency', time.time() - iter_start_ts)
        metrics.histogram('io_loop_iteration.callbacks', ncallbacks)
        metrics.histogram('io_loop_iteration.events', nevents)

        iter_start_ts = time.time()

    tornado.ioloop.IOLoop.instance().set_loop_iter_callback(iter_callback)
```

Maybe there's a better way to do something like this and get these metrics, which I'd totally be open to trying!

**PS** oops - I meant to open this PR on my own fork first!