### PR TITLE
remove redundant gen.coroutine

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -478,9 +478,8 @@ class WaitIterator(object):
         self.current_future = done
         self.current_index = self._unfinished.pop(done)
 
-    @coroutine
     def __aiter__(self):
-        raise Return(self)
+        return self
 
     def __anext__(self):
         if self.done():

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -263,7 +263,6 @@ class Queue(object):
         """
         return self._finished.wait(timeout)
 
-    @gen.coroutine
     def __aiter__(self):
         return _QueueIterator(self)
 


### PR DESCRIPTION
According  to [PEP 492](https://www.python.org/dev/peps/pep-0492/) 
The __aiter__  doesn't need to be awaitable, only __anext__ needs to. But in Tornado,  
`async ` for 
  is transformed into 
`   
 @coroutine
    def _wrap_awaitable(x):
        if hasattr(x, '__await__'):
            x = x.__await__()
        return (yield from x)
`
so  __anext__ just returns a Future() is also work.

Besides,  python above 3.4 or3.5 can use "async for", and it  can use "return" directly
