### PR TITLE
Alter Condition.wait() documentation.

### DIFF
--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -99,8 +99,7 @@ class Condition(_TimeoutGarbageCollector):
         # Wait up to 1 second.
         yield condition.wait(timeout=datetime.timedelta(seconds=1))
 
-    The method raises `tornado.util.TimeoutError` if there's no notification
-    before the deadline.
+    The method returns False if there's no notification before the deadline.
     """
 
     def __init__(self):


### PR DESCRIPTION
~~The [documentation](http://www.tornadoweb.org/en/stable/locks.html#tornado.locks.Condition) for condition is misleading.  In the class docs, it depicts the `wait` method to accept a timeout, and once the timeout has elapsed raise a `gen.TimeoutError` much like how `Event`, `Lock`, and `Semaphore` all raise.  However, the literal [method](http://www.tornadoweb.org/en/stable/locks.html#tornado.locks.Condition.wait) changes the classes defined behavior of wait to a unique action of setting the `Future` to `False`.~~

~~This PR aims to make `Condition` act more like it's `tornado.locks` brethren by setting the `gen.TimeoutError` exception when the timeout has elapsed.~~

**Edit:** Changed the PR to alter documentation to reflect the methods behavior, rather than alter the method to fit the documentation.