### PR TITLE
ensure AsyncIOLoop.stop wakes eventloop

### DIFF
--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -126,7 +126,7 @@ class BaseAsyncIOLoop(IOLoop):
                 old_current.make_current()
 
     def stop(self):
-        self.asyncio_loop.stop()
+        self.add_callback(self.asyncio_loop.stop)
 
     def call_at(self, when, callback, *args, **kwargs):
         # asyncio.call_at supports *args but not **kwargs, so bind them here.


### PR DESCRIPTION
base IOLoop triggers _waker.wake, which ensures the eventloop stops, so make AsyncIOLoop match.

use self.add_callback to trigger a similar wake if called from a signal handler / thread.

Without this, `IOLoop.current().stop()` called from a signal handler will not halt the eventloop until the next event to be handled.