### PR TITLE
Add SSL/SSH handshake timing to response properties (curl client)

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -261,6 +261,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             queue=info["curl_start_time"] - info["request"].start_time,
             namelookup=curl.getinfo(pycurl.NAMELOOKUP_TIME),
             connect=curl.getinfo(pycurl.CONNECT_TIME),
+            appconnect=curl.getinfo(pycurl.APPCONNECT_TIME),
             pretransfer=curl.getinfo(pycurl.PRETRANSFER_TIME),
             starttransfer=curl.getinfo(pycurl.STARTTRANSFER_TIME),
             total=curl.getinfo(pycurl.TOTAL_TIME),


### PR DESCRIPTION
This PR exposes the duration from the start until the SSL/SSH connect/handshake to the remote host timing (1).
libcurl/PycURL compatibility:
The option was added in libcurl 7.19.0, Tornado stable requires 7.22.0 or higher, PycURL requires 7.19.0 or higher.
runtest.sh is passing on my dev environment but happy to do more testing as need be.

(1) https://curl.haxx.se/libcurl/c/CURLINFO_APPCONNECT_TIME.html
 