### PR TITLE
Remove headers from HTTPServerRequest repr

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -467,8 +467,7 @@ class HTTPServerRequest(object):
     def __repr__(self):
         attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
         args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
-        return "%s(%s, headers=%s)" % (
-            self.__class__.__name__, args, dict(self.headers))
+        return "%s(%s)" % (self.__class__.__name__, args)
 
 
 class HTTPInputError(Exception):

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -418,6 +418,10 @@ class HTTPServerRequestTest(unittest.TestCase):
         requets = HTTPServerRequest(uri='/')
         self.assertIsInstance(requets.body, bytes)
 
+    def test_repr_does_not_contain_headers(self):
+        request = HTTPServerRequest(uri='/', headers={'Canary': 'Coal Mine'})
+        self.assertTrue('Canary' not in repr(request))
+
 
 class ParseRequestStartLineTest(unittest.TestCase):
     METHOD = "GET"


### PR DESCRIPTION
In tornadoweb/tornado#1112 it was decided to stop including headers in the request repr, since they are needlessly verbose and risk leaking user secrets into the application log.