### PR TITLE
Correctly clear and create a new ioloop during autoreload

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -135,9 +135,13 @@ def wait():
     to run the tests again after any source file changes (but see also
     the command-line interface in `main`)
     """
-    io_loop = ioloop.IOLoop()
-    start(io_loop)
-    io_loop.start()
+    # stop and clear the current io loop as we need a new one
+    ioloop.IOLoop().stop()
+    ioloop.IOLoop().clear_current()
+    # create a new ioloop (this will also set it as the current ioloop)
+    new_ioloop = ioloop.IOLoop().current(True)
+    start()
+    new_ioloop.start()
 
 
 def watch(filename):

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -135,13 +135,9 @@ def wait():
     to run the tests again after any source file changes (but see also
     the command-line interface in `main`)
     """
-    # stop and clear the current io loop as we need a new one
-    ioloop.IOLoop().stop()
-    ioloop.IOLoop().clear_current()
-    # create a new ioloop (this will also set it as the current ioloop)
-    new_ioloop = ioloop.IOLoop().current(True)
-    start()
-    new_ioloop.start()
+    io_loop = ioloop.IOLoop()
+    io_loop.add_callback(start)
+    io_loop.start()
 
 
 def watch(filename):


### PR DESCRIPTION
After the removal of the deprecated `io_loop` arguments from all functions, the autoreload module stopped working as the wait function's usage was missed in the refactor. This resulted in the start function receiving an `IOLoop` object as its only argument which it then used as the `check_time` argument resulting in errors further down the line when the `check_time` is expected to be an int. This PR fixes that problem allowing the autoreload script to work correctly.

To the see the original bug just run the autoreload module, for example: `python -m tornado.autoreload -m tornado.test`, modify a test file after the first run completes and you'll get something like this:

```
[I 170819 12:02:37 testing:679] PASS
[I 170819 12:02:37 autoreload:306] Script exited with status False
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/rogan/code/tornado/tornado/autoreload.py", line 340, in <module>
    main()
  File "/home/rogan/code/tornado/tornado/autoreload.py", line 334, in main
    wait()
  File "/home/rogan/code/tornado/tornado/autoreload.py", line 139, in wait
    start(io_loop)
  File "/home/rogan/code/tornado/tornado/autoreload.py", line 127, in start
    scheduler = ioloop.PeriodicCallback(callback, check_time)
  File "/home/rogan/code/tornado/tornado/ioloop.py", line 1053, in __init__
    if callback_time <= 0:
TypeError: '<=' not supported between instances of 'AsyncIOLoop' and 'int'
```