### PR TITLE
Allow custom loader callbacks in parse_config_file()

### DIFF
--- a/tornado/options.py
+++ b/tornado/options.py
@@ -97,6 +97,13 @@ from tornado import stack_context
 from tornado.util import basestring_type, exec_in
 
 
+def _load_python_file(path):
+    config = {'__file__': os.path.abspath(path)}
+    with open(path, 'rb') as f:
+        exec_in(native_str(f.read()), config, config)
+    return config
+
+
 class Error(Exception):
     """Exception raised by errors in the options module."""
     pass
@@ -298,12 +305,16 @@ class OptionParser(object):
 
         return remaining
 
-    def parse_config_file(self, path, final=True):
-        """Parses and loads the Python config file at the given path.
+    def parse_config_file(self, path, final=True, loader=_load_python_file):
+        """Parses and loads a config file at the given path.
 
         If ``final`` is ``False``, parse callbacks will not be run.
         This is useful for applications that wish to combine configurations
         from multiple sources.
+
+        ``loader`` should be a callback that accepts the file ``path`` to
+        load, and returns a config dictionary. The default callback execs
+        the file contents as Python, in a restricted environment.
 
         .. versionchanged:: 4.1
            Config files are now always interpreted as utf-8 instead of
@@ -313,13 +324,10 @@ class OptionParser(object):
            The special variable ``__file__`` is available inside config
            files, specifying the absolute path to the config file itself.
         """
-        config = {'__file__': os.path.abspath(path)}
-        with open(path, 'rb') as f:
-            exec_in(native_str(f.read()), config, config)
-        for name in config:
+        for name, val in loader(path).items():
             normalized = self._normalize_name(name)
             if normalized in self._options:
-                self._options[normalized].set(config[name])
+                self._options[normalized].set(val)
 
         if final:
             self.run_parse_callbacks()

--- a/tornado/test/options_test.json
+++ b/tornado/test/options_test.json
@@ -1,0 +1,5 @@
+{
+    "port": 443,
+    "username": "李康",
+    "foo_bar": "a"
+}

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -2,9 +2,11 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
+import json
 import os
 import sys
 
+from tornado.escape import to_unicode
 from tornado.options import OptionParser, Error
 from tornado.util import basestring_type, PY3
 from tornado.test.util import unittest, subTest
@@ -22,6 +24,12 @@ except ImportError:
         import mock  # type: ignore
     except ImportError:
         mock = None
+
+
+def load_json(path):
+    """Load a JSON file, and convert string keys/values to unicode."""
+    with open(path) as fileobj:
+        return json.load(fileobj)
 
 
 class OptionsTest(unittest.TestCase):
@@ -42,6 +50,16 @@ class OptionsTest(unittest.TestCase):
         self.assertEqual(options.port, 443)
         self.assertEqual(options.username, "李康")
         self.assertEqual(options.my_path, config_path)
+
+    def test_parse_config_file_custom_loader(self):
+        options = OptionParser()
+        options.define("port", default=80)
+        options.define("username", default='foo', type=basestring_type)
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   "options_test.json")
+        options.parse_config_file(config_path, loader=load_json)
+        self.assertEqual(options.port, 443)
+        self.assertEqual(options.username, to_unicode("李康"))
 
     def test_parse_callbacks(self):
         options = OptionParser()


### PR DESCRIPTION
This change is pretty straightforward: it allows users to pass a custom callback to `options.parse_config_file()` to load the config path in some custom way. I intend to use this on a personal project to load YAML configs. The test case I added loads a JSON config using the builtin Python `json` module, to avoid introducing new dependencies.