### PR TITLE
return 404 when routing delegate is not found

### DIFF
--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -242,6 +242,11 @@ class _RoutingDelegate(httputil.HTTPMessageDelegate):
             start_line=start_line, headers=headers)
 
         self.delegate = self.router.find_handler(request)
+        if self.delegate is None:
+            app_log.info("Delegate for %s %s request not found",
+                         start_line.method, start_line.path)
+            self.delegate = _DefaultMessageDelegate(self.request_conn)
+
         return self.delegate.headers_received(start_line, headers)
 
     def data_received(self, chunk):
@@ -252,6 +257,16 @@ class _RoutingDelegate(httputil.HTTPMessageDelegate):
 
     def on_connection_close(self):
         self.delegate.on_connection_close()
+
+
+class _DefaultMessageDelegate(httputil.HTTPMessageDelegate):
+    def __init__(self, connection):
+        self.connection = connection
+
+    def finish(self):
+        self.connection.write_headers(
+            httputil.ResponseStartLine("HTTP/1.1", 404, "Not Found"), httputil.HTTPHeaders())
+        self.connection.finish()
 
 
 class RuleRouter(Router):


### PR DESCRIPTION
fix for https://github.com/tornadoweb/tornado/issues/2141