### PR TITLE
file_upload demo: yield write() cb in body_producer

### DIFF
--- a/demos/file_upload/file_uploader.py
+++ b/demos/file_upload/file_uploader.py
@@ -34,13 +34,15 @@ def multipart_producer(boundary, filenames, write):
 
     for filename in filenames:
         filename_bytes = filename.encode()
-        yield write(b'--%s\r\n' % (boundary_bytes,))
-        yield write(b'Content-Disposition: form-data; name="%s"; filename="%s"\r\n' %
-                    (filename_bytes, filename_bytes))
-
         mtype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
-        yield write(b'Content-Type: %s\r\n' % (mtype.encode(),))
-        yield write(b'\r\n')
+        buf = (
+            (b'--%s\r\n' % boundary_bytes) +
+            (b'Content-Disposition: form-data; name="%s"; filename="%s"\r\n' %
+             (filename_bytes, filename_bytes)) +
+            (b'Content-Type: %s\r\n' % mtype.encode()) +
+            b'\r\n'
+        )
+        yield write(buf)
         with open(filename, 'rb') as f:
             while True:
                 # 16k at a time.
@@ -95,7 +97,6 @@ def put(filenames):
                                       method='PUT',
                                       headers=headers,
                                       body_producer=producer)
-    
         print(response)
 
 


### PR DESCRIPTION
The documentation for `tornado.httpclient.HTTPRequest` says:

> body_producer – Callable used for lazy/asynchronous request bodies. It is called with one argument, a write function, and should return a Future. It should call the write function with new data as it becomes available. The write function returns a Future which can be used for flow control.

In the simpler example in this demo, `raw_producer()`, there are no yields (or awaits) at all. It doesn't make much sense to use a `body_producer` callback if it generates and writes the whole body all at once without ever yielding, you might as well have just generated the whole body up front. In the more complex example, `multipart_producer()`, it looks like `yield gen.moment` was thrown in to allow some of the body to be sent before more of the body is produced, but that seems less elegant than just yielding `write()`.

It's possible I just don't understand the nuances, so consider this half-question half-proposal :)