### PR TITLE
Add support for parsing options from environment variables

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -17,6 +17,7 @@
 
    .. autofunction:: parse_command_line
    .. autofunction:: parse_config_file
+   .. autofunction:: parse_environment
    .. autofunction:: print_help(file=sys.stderr)
    .. autofunction:: add_parse_callback
    .. autoexception:: Error

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -208,8 +208,9 @@ class LogFormatter(logging.Formatter):
 def enable_pretty_logging(options=None, logger=None):
     """Turns on formatted logging output as configured.
 
-    This is called automatically by `tornado.options.parse_command_line`
-    and `tornado.options.parse_config_file`.
+    This is called automatically by `tornado.options.parse_command_line`,
+    `tornado.options.parse_config_file` and
+    `tornado.options.parse_environment`.
     """
     if options is None:
         import tornado.options


### PR DESCRIPTION
This is useful for 12factor-style applications: in development use the
command line, in production use environment variables. Having this
supported directly in Tornado makes things easier.

The application must explicitly call `options.parse_environment`; this
is not enabled by default.