### PR TITLE
[WIP] Fix #2147: mostly zero-copy reads and writes in IOStream

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -278,6 +278,8 @@ class StreamBuffer(object):
         return pattern.search(self._buffers[0][1])
 
 
+# FIXME: a decision must be made.  The StreamBuffer improves performance
+# for large reads but adds complication for read_until and read_until_regex.
 USE_STREAM_BUFFER_FOR_READS = True
 
 


### PR DESCRIPTION
Improves performance by 45% on the following benchmark: https://github.com/tornadoweb/tornado/issues/2147#issuecomment-329146253

Caveats:
* small reads and writes can be 10% slower
* `read_until` and `read_until_regex` can be 10 to 20% slower