### PR TITLE
[WIP] Fix #2147: mostly zero-copy writes and reads in IOStream

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -278,6 +278,8 @@ class StreamBuffer(object):
         return pattern.search(self._buffers[0][1])
 
 
+# FIXME: a decision must be made.  The StreamBuffer improves performance
+# for large reads but adds complication for read_until and read_until_regex.
 USE_STREAM_BUFFER_FOR_READS = True
 
 

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -584,7 +584,7 @@ class BaseIOStream(object):
             self._write_futures.append((self._total_write_index, future))
         if not self._connecting:
             self._handle_write()
-            if len(self._write_buffer):
+            if self._write_buffer:
                 self._add_io_state(self.io_loop.WRITE)
             self._maybe_add_error_listener()
         return future


### PR DESCRIPTION
Improves performance by 45% on the following benchmark: https://github.com/tornadoweb/tornado/issues/2147#issuecomment-329146253

Caveats:
* small reads and writes can be 10% slower
* `read_until` and `read_until_regex` can be 10 to 20% slower

If we implement the core of StreamBuffer in C, we can probably make performance even better.