### PR TITLE
Issue #2147: avoid copies on non-small writes

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -118,6 +118,10 @@ class StreamBufferFullError(Exception):
 
 
 class _StreamBuffer(object):
+    """
+    A specialized buffer that tries to avoid copies when large pieces
+    of data are encountered.
+    """
 
     def __init__(self):
         # A sequence of (False, bytearray) and (True, memoryview) objects
@@ -134,6 +138,9 @@ class _StreamBuffer(object):
     _large_buf_threshold = 2048
 
     def append(self, data):
+        """
+        Append the given piece of data (should be a buffer-compatible object).
+        """
         size = len(data)
         if size > self._large_buf_threshold:
             if not isinstance(data, memoryview):
@@ -153,6 +160,10 @@ class _StreamBuffer(object):
         self._size += size
 
     def peek(self, size):
+        """
+        Get a view over at most ``size`` bytes (possibly fewer) at the
+        current buffer position.
+        """
         assert size > 0
         try:
             is_memview, b = self._buffers[0]
@@ -166,6 +177,9 @@ class _StreamBuffer(object):
             return memoryview(b)[pos:pos + size]
 
     def advance(self, size):
+        """
+        Advance the current buffer position by ``size`` bytes.
+        """
         assert 0 < size <= self._size
         self._size -= size
         pos = self._first_pos

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -1188,7 +1188,7 @@ class TestStreamBuffer(unittest.TestCase):
         while expected:
             n = self.random.randrange(1, len(expected) + 1)
             expected = expected[n:]
-            buf.skip(n)
+            buf.advance(n)
             self.assertEqual(len(buf), len(expected))
             self.check_peek(buf, expected)
 
@@ -1214,9 +1214,9 @@ class TestStreamBuffer(unittest.TestCase):
         for i in range(9):
             buf.append(b'x')
         self.assertEqual(len(buf._buffers), 2)
-        buf.skip(10)
+        buf.advance(10)
         self.assertEqual(len(buf._buffers), 1)
-        buf.skip(8)
+        buf.advance(8)
         self.assertEqual(len(buf._buffers), 0)
         self.assertEqual(len(buf), 0)
 
@@ -1247,8 +1247,8 @@ class TestStreamBuffer(unittest.TestCase):
         self.assertEqual(len(buf._buffers), 4)
         buf.append(b'z')
         self.assertEqual(len(buf._buffers), 4)
-        buf.skip(33)
+        buf.advance(33)
         self.assertEqual(len(buf._buffers), 1)
-        buf.skip(2)
+        buf.advance(2)
         self.assertEqual(len(buf._buffers), 0)
         self.assertEqual(len(buf), 0)

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 from tornado.concurrent import Future
 from tornado import gen
 from tornado import netutil
-from tornado.iostream import IOStream, SSLIOStream, PipeIOStream, StreamClosedError
+from tornado.iostream import IOStream, SSLIOStream, PipeIOStream, StreamClosedError, _StreamBuffer
 from tornado.httputil import HTTPHeaders
 from tornado.log import gen_log, app_log
 from tornado.netutil import ssl_wrap_socket
@@ -12,9 +12,11 @@ from tornado.testing import AsyncHTTPTestCase, AsyncHTTPSTestCase, AsyncTestCase
 from tornado.test.util import unittest, skipIfNonUnix, refusing_port, skipPypy3V58
 from tornado.web import RequestHandler, Application
 import errno
+import io
 import logging
 import os
 import platform
+import random
 import socket
 import ssl
 import sys
@@ -1139,3 +1141,117 @@ class TestPipeIOStream(AsyncTestCase):
 
         ws.close()
         rs.close()
+
+
+class TestStreamBuffer(unittest.TestCase):
+    """
+    Unit tests for the private _StreamBuffer class.
+    """
+
+    def setUp(self):
+        self.random = random.Random(42)
+
+    def to_bytes(self, b):
+        if isinstance(b, (bytes, bytearray)):
+            return bytes(b)
+        elif isinstance(b, memoryview):
+            return b.tobytes()   # For py2
+        else:
+            raise TypeError(b)
+
+    def make_streambuffer(self, large_buf_threshold=10):
+        buf = _StreamBuffer()
+        assert buf._large_buf_threshold
+        buf._large_buf_threshold = large_buf_threshold
+        return buf
+
+    def check_peek(self, buf, expected):
+        size = 1
+        while size < 2 * len(expected):
+            got = self.to_bytes(buf.peek(size))
+            self.assertTrue(got)   # Not empty
+            self.assertLessEqual(len(got), size)
+            self.assertTrue(expected.startswith(got), (expected, got))
+            size = (size * 3 + 1) // 2
+
+    def check_append_all_then_skip_all(self, buf, objs, input_type):
+        self.assertEqual(len(buf), 0)
+
+        total_expected = b''.join(objs)
+        expected = b''
+
+        for o in objs:
+            expected += o
+            buf.append(input_type(o))
+            self.assertEqual(len(buf), len(expected))
+            self.check_peek(buf, expected)
+
+        total_size = len(expected)
+
+        while expected:
+            n = self.random.randrange(1, len(expected) + 1)
+            expected = expected[n:]
+            buf.skip(n)
+            self.assertEqual(len(buf), len(expected))
+            self.check_peek(buf, expected)
+
+        self.assertEqual(len(buf), 0)
+
+    def test_small(self):
+        objs = [b'12', b'345', b'67', b'89a', b'bcde', b'fgh', b'ijklmn']
+
+        buf = self.make_streambuffer()
+        self.check_append_all_then_skip_all(buf, objs, bytes)
+
+        buf = self.make_streambuffer()
+        self.check_append_all_then_skip_all(buf, objs, bytearray)
+
+        buf = self.make_streambuffer()
+        self.check_append_all_then_skip_all(buf, objs, memoryview)
+
+        # Test internal algorithm
+        buf = self.make_streambuffer(10)
+        for i in range(9):
+            buf.append(b'x')
+        self.assertEqual(len(buf._buffers), 1)
+        for i in range(9):
+            buf.append(b'x')
+        self.assertEqual(len(buf._buffers), 2)
+        buf.skip(10)
+        self.assertEqual(len(buf._buffers), 1)
+        buf.skip(8)
+        self.assertEqual(len(buf._buffers), 0)
+        self.assertEqual(len(buf), 0)
+
+    def test_large(self):
+        objs = [b'12' * 5,
+                b'345' * 2,
+                b'67' * 20,
+                b'89a' * 12,
+                b'bcde' * 1,
+                b'fgh' * 7,
+                b'ijklmn' * 2]
+
+        buf = self.make_streambuffer()
+        self.check_append_all_then_skip_all(buf, objs, bytes)
+
+        buf = self.make_streambuffer()
+        self.check_append_all_then_skip_all(buf, objs, bytearray)
+
+        buf = self.make_streambuffer()
+        self.check_append_all_then_skip_all(buf, objs, memoryview)
+
+        # Test internal algorithm
+        buf = self.make_streambuffer(10)
+        for i in range(3):
+            buf.append(b'x' * 11)
+        self.assertEqual(len(buf._buffers), 3)
+        buf.append(b'y')
+        self.assertEqual(len(buf._buffers), 4)
+        buf.append(b'z')
+        self.assertEqual(len(buf._buffers), 4)
+        buf.skip(33)
+        self.assertEqual(len(buf._buffers), 1)
+        buf.skip(2)
+        self.assertEqual(len(buf._buffers), 0)
+        self.assertEqual(len(buf), 0)


### PR DESCRIPTION
Improves performance by 35% on the following benchmark: https://github.com/tornadoweb/tornado/issues/2147#issuecomment-329146253
Makes `demos/benchmark/benchmark.py` about 2% slower.

(split from https://github.com/tornadoweb/tornado/pull/2166)