### PR TITLE
Release memoryviews explicitly

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -83,6 +83,15 @@ if hasattr(errno, "WSAEINPROGRESS"):
     _ERRNO_INPROGRESS += (errno.WSAEINPROGRESS,)  # type: ignore
 
 _WINDOWS = sys.platform.startswith('win')
+_PY3 = sys.version_info[0] >= 3
+
+if _PY3:
+    # We'd like to release memoryviews explicitly, see
+    # https://github.com/tornadoweb/tornado/pull/2008
+    _release_memoryview = memoryview.release
+else:
+    def _release_memoryview(m):
+        pass
 
 
 class StreamClosedError(IOError):
@@ -863,8 +872,14 @@ class BaseIOStream(object):
                     size = 128 * 1024
                 else:
                     size = self._write_buffer_size
-                num_bytes = self.write_to_fd(
-                    memoryview(self._write_buffer)[start:start + size])
+                mem = memoryview(self._write_buffer)
+                mem2 = mem[start:start + size]
+                try:
+                    num_bytes = self.write_to_fd(mem2)
+                finally:
+                    _release_memoryview(mem2)
+                    _release_memoryview(mem)
+                    del mem, mem2
                 if num_bytes == 0:
                     self._got_empty_write(size)
                     break
@@ -912,9 +927,14 @@ class BaseIOStream(object):
             return b""
         assert loc <= self._read_buffer_size
         # Slice the bytearray buffer into bytes, without intermediate copying
-        b = (memoryview(self._read_buffer)
-             [self._read_buffer_pos:self._read_buffer_pos + loc]
-             ).tobytes()
+        mem = memoryview(self._read_buffer)
+        mem2 = mem[self._read_buffer_pos:self._read_buffer_pos + loc]
+        try:
+            b = mem2.tobytes()
+        finally:
+            _release_memoryview(mem2)
+            _release_memoryview(mem)
+            del mem, mem2
         self._read_buffer_pos += loc
         self._read_buffer_size -= loc
         # Amortized O(1) shrink


### PR DESCRIPTION
See https://github.com/tornadoweb/tornado/pull/2008 for reasons why this might be necessary.
