### PR TITLE
Don't let invalid bytes stop the Webspider demo

### DIFF
--- a/demos/webspider/webspider.py
+++ b/demos/webspider/webspider.py
@@ -29,7 +29,7 @@ def get_links_from_url(url):
         print('fetched %s' % url)
 
         html = response.body if isinstance(response.body, str) \
-            else response.body.decode()
+            else response.body.decode(errors='ignore')
         urls = [urljoin(url, remove_fragment(new_url))
                 for new_url in get_links(html)]
     except Exception as e:


### PR DESCRIPTION
An invalid byte currently stops the webspider. For instance, try it with `https://www.google.com` and you will get the following result:
```
$ python webspider.py
fetching https://www.google.com
fetched https://www.google.com
Exception: 'utf-8' codec can't decode byte 0xe7 in position 44372: invalid continuation byte https://www.google.com
Done in 0 seconds, fetched 1 URLs.
```

Solution: Ignore bad bytes and keep on crawling :)