### PR TITLE
Skip IPv6 tests on Travis-CI

### DIFF
--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -772,3 +772,4 @@ class ChunkedWithContentLengthTest(AsyncHTTPTestCase):
                                  "with both Transfer-Encoding and Content-Length")):
             response = self.fetch('/chunkwithcl')
         self.assertEqual(response.code, 599)
+

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -270,6 +270,7 @@ class SimpleHTTPClientTestMixin(object):
         self.triggers.popleft()()
 
     @skipIfNoIPv6
+    @skipOnTravis
     def test_ipv6(self):
         try:
             [sock] = bind_sockets(None, '::1', family=socket.AF_INET6)
@@ -772,4 +773,3 @@ class ChunkedWithContentLengthTest(AsyncHTTPTestCase):
                                  "with both Transfer-Encoding and Content-Length")):
             response = self.fetch('/chunkwithcl')
         self.assertEqual(response.code, 599)
-

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -103,11 +103,13 @@ class TCPClientTest(AsyncTestCase):
         self.do_test_connect(socket.AF_INET, 'localhost')
 
     @skipIfNoIPv6
+    @skipOnTravis
     def test_connect_ipv6_ipv6(self):
         self.skipIfLocalhostV4()
         self.do_test_connect(socket.AF_INET6, '::1')
 
     @skipIfNoIPv6
+    @skipOnTravis
     def test_connect_ipv6_dual(self):
         self.skipIfLocalhostV4()
         if Resolver.configured_class().__name__.endswith('TwistedResolver'):


### PR DESCRIPTION
They have started failing very recently. See e.g. https://travis-ci.org/tornadoweb/tornado/jobs/296295766#L1151