### PR TITLE
test: More robust avoidance of broken ipv6

### DIFF
--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -326,7 +326,7 @@ class SimpleHTTPClientTestMixin(object):
         self.assertNotIn("Content-Length", response.headers)
 
     def test_host_header(self):
-        host_re = re.compile(b"^localhost:[0-9]+$")
+        host_re = re.compile(b"^127.0.0.1:[0-9]+$")
         response = self.fetch("/host_echo")
         self.assertTrue(host_re.match(response.body))
 

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -271,16 +271,9 @@ class SimpleHTTPClientTestMixin(object):
 
     @skipIfNoIPv6
     def test_ipv6(self):
-        try:
-            [sock] = bind_sockets(None, '::1', family=socket.AF_INET6)
-            port = sock.getsockname()[1]
-            self.http_server.add_socket(sock)
-        except socket.gaierror as e:
-            if e.args[0] == socket.EAI_ADDRFAMILY:
-                # python supports ipv6, but it's not configured on the network
-                # interface, so skip this test.
-                return
-            raise
+        [sock] = bind_sockets(None, '::1', family=socket.AF_INET6)
+        port = sock.getsockname()[1]
+        self.http_server.add_socket(sock)
         url = '%s://[::1]:%d/hello' % (self.get_protocol(), port)
 
         # ipv6 is currently enabled by default but can be disabled

--- a/tornado/test/util.py
+++ b/tornado/test/util.py
@@ -28,9 +28,6 @@ skipOnAppEngine = unittest.skipIf('APPENGINE_RUNTIME' in os.environ,
 skipIfNoNetwork = unittest.skipIf('NO_NETWORK' in os.environ,
                                   'network access disabled')
 
-skipIfNoIPv6 = unittest.skipIf(not socket.has_ipv6, 'ipv6 support not present')
-
-
 skipBefore33 = unittest.skipIf(sys.version_info < (3, 3), 'PEP 380 (yield from) not available')
 skipBefore35 = unittest.skipIf(sys.version_info < (3, 5), 'PEP 492 (async/await) not available')
 skipNotCPython = unittest.skipIf(platform.python_implementation() != 'CPython',
@@ -43,6 +40,24 @@ skipPypy3V58 = unittest.skipIf(platform.python_implementation() == 'PyPy' and
                                sys.version_info > (3,) and
                                sys.pypy_version_info < (5, 9),
                                'pypy3 5.8 has buggy ssl module')
+
+def _detect_ipv6():
+    if not socket.has_ipv6:
+        # socket.has_ipv6 check reports whether ipv6 was present at compile
+        # time. It's usually true even when ipv6 doesn't work for other reasons.
+        return False
+    sock = None
+    try:
+        sock = socket.socket(socket.AF_INET6)
+        sock.bind(('::1', 0))
+    except socket.error:
+        return False
+    finally:
+        if sock is not None:
+            sock.close()
+    return True
+
+skipIfNoIPv6 = unittest.skipIf(not _detect_ipv6(), 'ipv6 support not present')
 
 
 def refusing_port():

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -356,7 +356,7 @@ class AuthRedirectTest(WebTestCase):
         response = self.wait()
         self.assertEqual(response.code, 302)
         self.assertTrue(re.match(
-            'http://example.com/login\?next=http%3A%2F%2Flocalhost%3A[0-9]+%2Fabsolute',
+            'http://example.com/login\?next=http%3A%2F%2F127.0.0.1%3A[0-9]+%2Fabsolute',
             response.headers['Location']), response.headers['Location'])
 
 

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -407,7 +407,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
 
     def get_url(self, path):
         """Returns an absolute url for the given path on the test server."""
-        return '%s://localhost:%s%s' % (self.get_protocol(),
+        return '%s://127.0.0.1:%s%s' % (self.get_protocol(),
                                         self.get_http_port(), path)
 
     def tearDown(self):


### PR DESCRIPTION
There are many ways ipv6 can be disabled or broken (and it just
stopped working on travis-ci), so instead of checking flags like
socket.has_ipv6, attempt to actually bind to an ipv6 address.

Closes #2185 