### PR TITLE
Fix bind_sockets("localhost") on Travis-CI container builds

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -160,7 +160,14 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC,
             sockaddr = tuple([host, bound_port] + list(sockaddr[2:]))
 
         sock.setblocking(0)
-        sock.bind(sockaddr)
+        try:
+            sock.bind(sockaddr)
+        except socket.error as e:
+            # Some setups (e.g. Travis-CI with "localhost") might return
+            # an IPv6 address from getaddrinfo() but fail binding to it
+            if errno_from_exception(e) == errno.EADDRNOTAVAIL:
+                continue
+            raise
         bound_port = sock.getsockname()[1]
         sock.listen(backlog)
         sockets.append(sock)

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import errno
-import os
 import signal
 import socket
 from subprocess import Popen
@@ -191,8 +190,6 @@ class IsValidIPTest(unittest.TestCase):
 
 class TestPortAllocation(unittest.TestCase):
     def test_same_port_allocation(self):
-        if 'TRAVIS' in os.environ:
-            self.skipTest("dual-stack servers often have port conflicts on travis")
         sockets = bind_sockets(None, 'localhost')
         try:
             port = sockets[0].getsockname()[1]


### PR DESCRIPTION
We noticed that moving from a VM build to a container build would trigger errors in socket.bind():
https://github.com/dask/distributed/pull/1563
