### PR TITLE
gen: Use the asyncio task runner for native coroutines

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -1193,20 +1193,10 @@ def _argument_adapter(callback):
     return wrapper
 
 
-# Convert Awaitables into Futures. It is unfortunately possible
-# to have infinite recursion here if those Awaitables assume that
-# we're using a different coroutine runner and yield objects
-# we don't understand. If that happens, the solution is to
-# register that runner's yieldable objects with convert_yielded.
-if sys.version_info >= (3, 3):
-    exec(textwrap.dedent("""
-    @coroutine
-    def _wrap_awaitable(x):
-        if hasattr(x, '__await__'):
-            x = x.__await__()
-        return (yield from x)
-    """))
-else:
+# Convert Awaitables into Futures.
+try:
+    import asyncio
+except ImportError:
     # Py2-compatible version for use with Cython.
     # Copied from PEP 380.
     @coroutine
@@ -1253,6 +1243,8 @@ else:
                         _r = _value_from_stopiteration(_e)
                         break
         raise Return(_r)
+else:
+    _wrap_awaitable = asyncio.ensure_future
 
 
 def convert_yielded(yielded):

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -405,7 +405,9 @@ class TestIOLoop(AsyncTestCase):
         """The IOLoop examines exceptions from awaitables and logs them."""
         namespace = exec_test(globals(), locals(), """
         async def callback():
-            self.io_loop.add_callback(self.stop)
+            # Stop the IOLoop two iterations after raising an exception
+            # to give the exception time to be logged.
+            self.io_loop.add_callback(self.io_loop.add_callback, self.stop)
             1 / 0
         """)
         with NullContext():

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -775,6 +775,7 @@ class TestPeriodicCallback(unittest.TestCase):
         io_loop.call_later(50, io_loop.stop)
         io_loop.start()
         self.assertEqual(calls, [1010, 1020, 1030, 1040, 1050])
+        io_loop.close()
 
 
 class TestIOLoopConfiguration(unittest.TestCase):


### PR DESCRIPTION
Coroutines using `await`/`yield from` are more tightly coupled than coroutines using `yield`; they must all share the same coroutine. The asyncio task runner publishes some non-local state that common libraries rely on, so these libraries could not be used in native coroutines that were started by tornado (aio-libs/aiohttp#877). Address this by using the asyncio task runner everywhere. 