### PR TITLE
ioloop: Setting AsyncIOLoop as current also sets asyncio event loop

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -300,7 +300,17 @@ class IOLoop(Configurable):
 
         Intended primarily for use by test frameworks in between tests.
         """
+        old = IOLoop._current.instance
+        if old is not None:
+            old._clear_current_hook()
         IOLoop._current.instance = None
+
+    def _clear_current_hook(self):
+        """Instance method called when an IOLoop ceases to be current.
+
+        May be overridden by subclasses as a counterpart to make_current.
+        """
+        pass
 
     @classmethod
     def configurable_base(cls):

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -30,7 +30,6 @@ else:
 class AsyncIOLoopTest(AsyncTestCase):
     def get_new_ioloop(self):
         io_loop = AsyncIOLoop()
-        asyncio.set_event_loop(io_loop.asyncio_loop)
         return io_loop
 
     def test_asyncio_callback(self):

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -505,14 +505,6 @@ class CompatibilityTests(unittest.TestCase):
 
 @skipIfNoTwisted
 class ConvertDeferredTest(unittest.TestCase):
-    def setUp(self):
-        if asyncio is not None:
-            asyncio.set_event_loop(asyncio.new_event_loop())
-
-    def tearDown(self):
-        if asyncio is not None:
-            asyncio.set_event_loop(None)
-
     def test_success(self):
         @inlineCallbacks
         def fn():

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -217,9 +217,6 @@ class AsyncTestCase(unittest.TestCase):
         super(AsyncTestCase, self).setUp()
         self.io_loop = self.get_new_ioloop()
         self.io_loop.make_current()
-        if hasattr(self.io_loop, 'asyncio_loop'):
-            # Ensure that asyncio's current event loop matches ours.
-            asyncio.set_event_loop(self.io_loop.asyncio_loop)
 
     def tearDown(self):
         # Clean up Subprocess, so it can be used again with a new ioloop.
@@ -231,8 +228,6 @@ class AsyncTestCase(unittest.TestCase):
         # set FD_CLOEXEC on its file descriptors)
         self.io_loop.close(all_fds=True)
         super(AsyncTestCase, self).tearDown()
-        if hasattr(self.io_loop, 'asyncio_loop'):
-            asyncio.set_event_loop(None)
         # In case an exception escaped or the StackContext caught an exception
         # when there wasn't a wait() to re-raise it, do so here.
         # This is our last chance to raise an exception in a way that the


### PR DESCRIPTION
This should eliminate the need for explicit asyncio manipulations
from applications migrating to Tornado 5.0

cc @pitrou @mrocklin @bryevdv