### PR TITLE
Update web.py

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -172,7 +172,7 @@ class RequestHandler(object):
         self._headers_written = False
         self._finished = False
         self._auto_finish = True
-        self._transforms = None  # will be set in _execute
+        self._transforms = []  # will be set in _execute
         self._prepared_future = None
         self._headers = None  # type: httputil.HTTPHeaders
         self.path_args = None


### PR DESCRIPTION
When I call an API interface, the following error is reported：

```
ERROR:tornado.application:Uncaught exception
Traceback (most recent call last):
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/http1connection.py", line 238, in _read_message
    delegate.finish()
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/routing.py", line 251, in finish
    self.delegate.finish()
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/web.py", line 2096, in finish
    self.execute()
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/web.py", line 2116, in execute
    **self.handler_kwargs)
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/web.py", line 192, in __init__
    self.initialize(**kwargs)
  File "/Users/Lonersun/www/pi/kiwi-api/kiwi/core/resource/action.py", line 32, in initialize
    self.finish()
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/web.py", line 991, in finish
    self.flush(include_footers=True)
  File "/Users/Lonersun/.virtualenvs/pi/lib/python2.7/site-packages/tornado/web.py", line 927, in flush
    for transform in self._transforms:
TypeError: 'NoneType' object is not iterable
```

This is my code:

```
class ResourceApi(tornado.web.RequestHandler):

    req = {}

    def initialize(self, **kwargs):
        """

        :return:
        """
        try:
            params, body = self.rebuild_params()
            self.req['params'] = params
            self.req['body'] = body
        except errors.APIError, e:
            self.write({
                "error_code": e.code,
                "error_message": e.message,
            })
            self.finish()
            return
```

self._transforms = None 
Changed to
self._transforms = [] 
When I change this, I can use it normally。
