### PR TITLE
http: read final crlf of chunked requests

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -599,6 +599,9 @@ class HTTP1Connection(httputil.HTTPConnection):
             chunk_len = yield self.stream.read_until(b"\r\n", max_bytes=64)
             chunk_len = int(chunk_len.strip(), 16)
             if chunk_len == 0:
+                crlf = yield self.stream.read_bytes(2)
+                if crlf != b'\r\n':
+                    raise HTTPInputError("improperly terminated chunked request")
                 return
             total_size += chunk_len
             if total_size > self._max_body_size:

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -808,9 +808,12 @@ class KeepAliveTest(AsyncHTTPTestCase):
     def test_keepalive_chunked(self):
         self.http_version = b'HTTP/1.0'
         self.connect()
-        self.stream.write(b'POST / HTTP/1.0\r\nConnection: keep-alive\r\n'
+        self.stream.write(b'POST / HTTP/1.0\r\n'
+                          b'Connection: keep-alive\r\n'
                           b'Transfer-Encoding: chunked\r\n'
-                          b'\r\n0\r\n')
+                          b'\r\n'
+                          b'0\r\n'
+                          b'\r\n')
         self.read_response()
         self.assertEqual(self.headers['Connection'], 'Keep-Alive')
         self.stream.write(b'GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n')

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2138,7 +2138,7 @@ class StreamingRequestBodyTest(WebTestCase):
         stream.write(b"4\r\nqwer\r\n")
         data = yield self.data
         self.assertEquals(data, b"qwer")
-        stream.write(b"0\r\n")
+        stream.write(b"0\r\n\r\n")
         yield self.finished
         data = yield gen.Task(stream.read_until_close)
         # This would ideally use an HTTP1Connection to read the response.


### PR DESCRIPTION
otherwise a subsequent request on the same connection will fail to be parsed

thanks to @eeelin for the bug report

I have an interest in #2194 so this is my attempt to complete it.
I also hope this can be cherry-picked into tornado-4.5 for a patch release.