### PR TITLE
parse_response_start_line() re.match case

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -850,7 +850,7 @@ def parse_response_start_line(line):
     ResponseStartLine(version='HTTP/1.1', code=200, reason='OK')
     """
     line = native_str(line)
-    match = re.match("(HTTP/1.[0-9]) ([0-9]+) ([^\r]*)", line)
+    match = re.match("(HTTP/1.[0-9]) ([0-9]+)([^\r]*)", line)
     if not match:
         raise HTTPInputError("Error parsing response start line")
     return ResponseStartLine(match.group(1), int(match.group(2)),


### PR DESCRIPTION
remove space between 2nd and 3rd re.match case to allow parse_response_start_line() from handling http server without reason key/value in response header.