### PR TITLE
fix iostream exc_info using missing Exception var

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1388,7 +1388,7 @@ class SSLIOStream(IOStream):
                     err.args[0] in (errno.EBADF, errno.ENOTCONN)):
                 return self.close(exc_info=err)
             raise
-        except AttributeError:
+        except AttributeError as err:
             # On Linux, if the connection was reset before the call to
             # wrap_socket, do_handshake will fail with an
             # AttributeError.


### PR DESCRIPTION
bug introduced in #2028
this fix very similar to #2155 

No, I didn't actually run into this ... I was just trolling through merged PRs looking for candidate small fixes to suggest for the 4.5 branch. (#2028 is perhaps a bit too big to qualify)