### PR TITLE
fix HTTPInputError reference for improperly terminated chunked request

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -601,7 +601,7 @@ class HTTP1Connection(httputil.HTTPConnection):
             if chunk_len == 0:
                 crlf = yield self.stream.read_bytes(2)
                 if crlf != b'\r\n':
-                    raise HTTPInputError("improperly terminated chunked request")
+                    raise httputil.HTTPInputError("improperly terminated chunked request")
                 return
             total_size += chunk_len
             if total_size > self._max_body_size:


### PR DESCRIPTION
bug introduced in #2225 

Not noticed because no test hit the error case ... 🤦‍♂️ 