### PR TITLE
Exposes the currently running coroutine in gen.py

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -312,7 +312,6 @@ def _set_current_coroutine(handle, arguments):
             arguments.args[0], handle):
         kls = arguments.args[0]
     coroutine_stack.append((kls, handle))
-    print("Set coroutine to", coroutine_stack[-1])
 
 
 def _unset_current_coroutine():
@@ -321,7 +320,6 @@ def _unset_current_coroutine():
     ``tornado.web.RequestHandler`` instances never share state.
     """
     old = coroutine_stack.pop()
-    print("Unsetting", old)
 
 
 def _make_coroutine_wrapper(func, replace_callback):
@@ -1154,7 +1152,10 @@ class Runner(object):
                             exc_info = None
                     else:
                         _set_current_coroutine(self.handle, self.arguments)
-                        yielded = self.gen.send(value)
+                        try:
+                            yielded = self.gen.send(value)
+                        finally:
+                            _unset_current_coroutine()
 
                     if stack_context._state.contexts is not orig_stack_contexts:
                         self.gen.throw(
@@ -1188,7 +1189,6 @@ class Runner(object):
                     return
                 yielded = None
         finally:
-            _unset_current_coroutine()
             self.running = False
 
     def handle_yield(self, yielded):


### PR DESCRIPTION
At the moment there is no easy way to provide per-instance context with
global scope if users decide to use coroutines in their
``tornado.web.RequestHandler`` methods (or other coroutines).

Passing the request down the stack can be very verbose for large,
architecturally sound, code bases (service-oriented monoliths, for
example).

``tornado.stack_context.StackContext`` doesn't provide isolation between
requests when ``yield``s are encountered (and, hence, requests are
switched) over the course of a coroutine's lifetime.

This PR updates the currently running coroutine (and instance to which
it is potentially bound) to reflect which request is running in that
context, and generally what coroutine is running in others.

This is done by reference since a user can potentially make a copy of
that variable, leading to race conditions. That pitfall can be prevented
very simply in this way.