### PR TITLE
iostream: Use file objects instead of raw descriptors in PipeIOStream

### DIFF
--- a/tornado/process.py
+++ b/tornado/process.py
@@ -198,7 +198,9 @@ class Subprocess(object):
 
     * ``stdin``, ``stdout``, and ``stderr`` may have the value
       ``tornado.process.Subprocess.STREAM``, which will make the corresponding
-      attribute of the resulting Subprocess a `.PipeIOStream`.
+      attribute of the resulting Subprocess a `.PipeIOStream`. If this option
+      is used, the caller is responsible for closing the streams when done
+      with them.
 
     The ``Subprocess.STREAM`` option and the ``set_exit_callback`` and
     ``wait_for_exit`` methods do not work on Windows. There is

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -184,12 +184,16 @@ class CaresResolverTest(AsyncTestCase, _ResolverTestMixin):
 
 
 # TwistedResolver produces consistent errors in our test cases so we
-# can test the regular and error cases in the same class.
+# could test the regular and error cases in the same class. However,
+# in the error cases it appears that cleanup of socket objects is
+# handled asynchronously and occasionally results in "unclosed socket"
+# warnings if not given time to shut down (and there is no way to
+# explicitly shut it down). This makes the test flaky, so we do not
+# test error cases here.
 @skipIfNoNetwork
 @unittest.skipIf(twisted is None, "twisted module not present")
 @unittest.skipIf(getattr(twisted, '__version__', '0.0') < "12.1", "old version of twisted")
-class TwistedResolverTest(AsyncTestCase, _ResolverTestMixin,
-                          _ResolverErrorTestMixin):
+class TwistedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(TwistedResolverTest, self).setUp()
         self.resolver = TwistedResolver()

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -7,6 +7,7 @@ from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, 
 from tornado.web import Application
 import contextlib
 import os
+import platform
 import traceback
 import warnings
 
@@ -120,6 +121,8 @@ class AsyncTestCaseWrapperTest(unittest.TestCase):
         self.assertIn("should be decorated", result.errors[0][1])
 
     @skipBefore35
+    @unittest.skipIf(platform.python_implementation() == 'PyPy',
+                     'pypy destructor warnings cannot be silenced')
     def test_undecorated_coroutine(self):
         namespace = exec_test(globals(), locals(), """
         class Test(AsyncTestCase):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -29,7 +29,7 @@ except ImportError:
     netutil = None  # type: ignore
     SimpleAsyncHTTPClient = None  # type: ignore
     Subprocess = None  # type: ignore
-from tornado.log import gen_log, app_log
+from tornado.log import app_log
 from tornado.stack_context import ExceptionStackContext
 from tornado.util import raise_exc_info, basestring_type, PY3
 import functools
@@ -638,6 +638,12 @@ def main(**kwargs):
     to show many test details as they are run.
     See http://docs.python.org/library/unittest.html#unittest.main
     for full argument list.
+
+    .. versionchanged:: 5.0
+
+       This function produces no output of its own; only that produced
+       by the `unittest` module (Previously it would add a PASS or FAIL
+       log message).
     """
     from tornado.options import define, options, parse_command_line
 
@@ -673,23 +679,16 @@ def main(**kwargs):
     if __name__ == '__main__' and len(argv) == 1:
         print("No tests specified", file=sys.stderr)
         sys.exit(1)
-    try:
-        # In order to be able to run tests by their fully-qualified name
-        # on the command line without importing all tests here,
-        # module must be set to None.  Python 3.2's unittest.main ignores
-        # defaultTest if no module is given (it tries to do its own
-        # test discovery, which is incompatible with auto2to3), so don't
-        # set module if we're not asking for a specific test.
-        if len(argv) > 1:
-            unittest.main(module=None, argv=argv, **kwargs)
-        else:
-            unittest.main(defaultTest="all", argv=argv, **kwargs)
-    except SystemExit as e:
-        if e.code == 0:
-            gen_log.info('PASS')
-        else:
-            gen_log.error('FAIL')
-        raise
+    # In order to be able to run tests by their fully-qualified name
+    # on the command line without importing all tests here,
+    # module must be set to None.  Python 3.2's unittest.main ignores
+    # defaultTest if no module is given (it tries to do its own
+    # test discovery, which is incompatible with auto2to3), so don't
+    # set module if we're not asking for a specific test.
+    if len(argv) > 1:
+        unittest.main(module=None, argv=argv, **kwargs)
+    else:
+        unittest.main(defaultTest="all", argv=argv, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes the implementation of PipeIOStream more compatible with
socket streams, and allows for more of the test suite to be used with
it.

Extracted from PR #2193. This was an uncontroversial part of the change but a large diff that could land separately.  cc @pitrou