### PR TITLE
ioloop: current() and friends delegate to asyncio

### DIFF
--- a/docs/ioloop.rst
+++ b/docs/ioloop.rst
@@ -19,7 +19,6 @@
    .. automethod:: IOLoop.run_sync
    .. automethod:: IOLoop.close
    .. automethod:: IOLoop.instance
-   .. automethod:: IOLoop.initialized
    .. automethod:: IOLoop.install
    .. automethod:: IOLoop.clear_instance
 

--- a/docs/releases/v5.0.0.rst
+++ b/docs/releases/v5.0.0.rst
@@ -167,8 +167,8 @@ Other notes
 - ``tornado.ioloop.TimeoutError`` is now an alias for
   `tornado.util.TimeoutError`.
 - `.IOLoop.instance` is now a deprecated alias for `.IOLoop.current`.
-- `.IOLoop.initialized`, `.IOLoop.install`, and
-  `.IOLoop.clear_instance` are all deprecated.
+- `.IOLoop.install` and `.IOLoop.clear_instance` are deprecated.
+- ``IOLoop.initialized`` has been removed.
 - On Python 3, the `asyncio`-backed `.IOLoop` is always used and
   alternative `.IOLoop` implementations cannot be configured.
 - `~.IOLoop.run_sync` cancels its argument on a timeout. This

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -221,29 +221,6 @@ class IOLoop(Configurable):
         """
         return IOLoop.current()
 
-    @staticmethod
-    def initialized():
-        """Returns true if there is a current IOLoop.
-
-        .. versionchanged:: 5.0
-
-           Redefined in terms of `current()` instead of `instance()`.
-
-        .. deprecated:: 5.0
-
-           This method only knows about `IOLoop` objects (and not, for
-           example, `asyncio` event loops), so it is of limited use.
-        """
-        if asyncio is None:
-            return IOLoop.current(instance=False) is not None
-        else:
-            # Asyncio gives us no way to ask whether an instance
-            # exists without creating one. Even calling
-            # `IOLoop.current(instance=False)` will create the asyncio
-            # loop (but not the Tornado loop, which would break the
-            # ability to use this function for "is it safe to fork?".
-            return False
-
     def install(self):
         """Deprecated alias for `make_current()`.
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -47,6 +47,7 @@ import threading
 import time
 import traceback
 import math
+import weakref
 
 from tornado.concurrent import Future, is_future, chain_future, future_set_exc_info, future_add_done_callback  # noqa: E501
 from tornado.log import app_log, gen_log
@@ -180,10 +181,11 @@ class IOLoop(Configurable):
     WRITE = _EPOLLOUT
     ERROR = _EPOLLERR | _EPOLLHUP
 
-    # Global lock for creating global IOLoop instance
-    _instance_lock = threading.Lock()
-
+    # In Python 2, _current.instance points to the current IOLoop.
     _current = threading.local()
+
+    # In Python 3, _ioloop_for_asyncio maps from asyncio loops to IOLoops.
+    _ioloop_for_asyncio = weakref.WeakKeyDictionary()
 
     @classmethod
     def configure(cls, impl, **kwargs):
@@ -232,7 +234,15 @@ class IOLoop(Configurable):
            This method only knows about `IOLoop` objects (and not, for
            example, `asyncio` event loops), so it is of limited use.
         """
-        return IOLoop.current(instance=False) is not None
+        if asyncio is None:
+            return IOLoop.current(instance=False) is not None
+        else:
+            # Asyncio gives us no way to ask whether an instance
+            # exists without creating one. Even calling
+            # `IOLoop.current(instance=False)` will create the asyncio
+            # loop (but not the Tornado loop, which would break the
+            # ability to use this function for "is it safe to fork?".
+            return False
 
     def install(self):
         """Deprecated alias for `make_current()`.
@@ -276,22 +286,36 @@ class IOLoop(Configurable):
            Added ``instance`` argument to control the fallback to
            `IOLoop.instance()`.
         .. versionchanged:: 5.0
+           On Python 3, control of the current `IOLoop` is delegated
+           to `asyncio`, with this and other methods as pass-through accessors.
            The ``instance`` argument now controls whether an `IOLoop`
            is created automatically when there is none, instead of
            whether we fall back to `IOLoop.instance()` (which is now
-           an alias for this method)
+           an alias for this method). ``instance=False`` is deprecated,
+           since even if we do not create an `IOLoop`, this method
+           may initialize the asyncio loop.
         """
-        current = getattr(IOLoop._current, "instance", None)
-        if current is None and instance:
-            current = None
-            if asyncio is not None:
-                from tornado.platform.asyncio import AsyncIOLoop, AsyncIOMainLoop
-                if IOLoop.configured_class() is AsyncIOLoop:
-                    current = AsyncIOMainLoop()
-            if current is None:
+        if asyncio is None:
+            current = getattr(IOLoop._current, "instance", None)
+            if current is None and instance:
                 current = IOLoop()
-            if IOLoop._current.instance is not current:
-                raise RuntimeError("new IOLoop did not become current")
+                if IOLoop._current.instance is not current:
+                    raise RuntimeError("new IOLoop did not become current")
+        else:
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                if not instance:
+                    return None
+                raise
+            try:
+                return IOLoop._ioloop_for_asyncio[loop]
+            except KeyError:
+                if instance:
+                    from tornado.platform.asyncio import AsyncIOMainLoop
+                    current = AsyncIOMainLoop(make_current=True)
+                else:
+                    current = None
         return current
 
     def make_current(self):
@@ -310,6 +334,8 @@ class IOLoop(Configurable):
         .. versionchanged:: 5.0
            This method also sets the current `asyncio` event loop.
         """
+        # The asyncio event loops override this method.
+        assert asyncio is None
         old = getattr(IOLoop._current, "instance", None)
         if old is not None:
             old.clear_current()
@@ -324,10 +350,11 @@ class IOLoop(Configurable):
         .. versionchanged:: 5.0
            This method also clears the current `asyncio` event loop.
         """
-        old = getattr(IOLoop._current, "instance", None)
+        old = IOLoop.current(instance=False)
         if old is not None:
             old._clear_current_hook()
-        IOLoop._current.instance = None
+        if asyncio is None:
+            IOLoop._current.instance = None
 
     def _clear_current_hook(self):
         """Instance method called when an IOLoop ceases to be current.
@@ -352,7 +379,9 @@ class IOLoop(Configurable):
             if IOLoop.current(instance=False) is None:
                 self.make_current()
         elif make_current:
-            if IOLoop.current(instance=False) is not None:
+            current = IOLoop.current(instance=False)
+            # AsyncIO loops can already be current by this point.
+            if current is not None and current is not self:
                 raise RuntimeError("current IOLoop already exists")
             self.make_current()
 

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -125,10 +125,6 @@ def fork_processes(num_processes, max_restarts=100):
     assert _task_id is None
     if num_processes is None or num_processes <= 0:
         num_processes = cpu_count()
-    if ioloop.IOLoop.initialized():
-        raise RuntimeError("Cannot run in multiple processes: IOLoop instance "
-                           "has already been initialized. You cannot call "
-                           "IOLoop.instance() before calling start_processes()")
     gen_log.info("Starting %d processes", num_processes)
     children = {}
 

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -725,6 +725,8 @@ class TestIOLoopRunSync(unittest.TestCase):
         self.io_loop.run_sync(namespace['f'])
 
 
+@unittest.skipIf(asyncio is not None,
+                 'IOLoop configuration not available')
 class TestPeriodicCallback(unittest.TestCase):
     def setUp(self):
         self.io_loop = FakeTimeIOLoop()
@@ -830,6 +832,8 @@ class TestIOLoopConfiguration(unittest.TestCase):
         self.assertEqual(cls, 'AsyncIOMainLoop')
 
     @unittest.skipIf(twisted is None, "twisted module not present")
+    @unittest.skipIf(asyncio is not None,
+                     "IOLoop configuration not available")
     def test_twisted(self):
         cls = self.run_python(
             'from tornado.platform.twisted import TwistedIOLoop',

--- a/tornado/test/process_test.py
+++ b/tornado/test/process_test.py
@@ -66,7 +66,6 @@ class ProcessTest(unittest.TestCase):
         # place for it).
         skip_if_twisted()
         with ExpectLog(gen_log, "(Starting .* processes|child .* exited|uncaught exception)"):
-            self.assertFalse(IOLoop.initialized())
             sock, port = bind_unused_port()
 
             def get_url(path):


### PR DESCRIPTION
Instead of a redundant IOLoop._current thread-local, pass through
directly to asyncio and maintain a one-to-one mapping of asyncio loops
to IOLoops. This brings us a bit closer to the asyncio-only future.

Also remove IOLoop.initialized(). It is no longer possible to provide this method with reasonable
semantics.