### PR TITLE
test: Adjust unittest for tornado_http2 compatibility

### DIFF
--- a/tornado/test/routing_test.py
+++ b/tornado/test/routing_test.py
@@ -171,8 +171,11 @@ class RuleRouterTest(AsyncHTTPTestCase):
         app = Application()
 
         def request_callable(request):
-            request.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK")
-            request.finish()
+            request.connection.write_headers(
+                ResponseStartLine("HTTP/1.1", 200, "OK"),
+                HTTPHeaders({"Content-Length": "2"}))
+            request.connection.write(b"OK")
+            request.connection.finish()
 
         router = CustomRouter()
         router.add_routes({

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -8,6 +8,7 @@ from tornado.concurrent import Future
 from tornado import gen
 from tornado.httpclient import HTTPError, HTTPRequest
 from tornado.log import gen_log, app_log
+from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from tornado.template import DictLoader
 from tornado.testing import AsyncHTTPTestCase, gen_test, bind_unused_port, ExpectLog
 from tornado.test.util import unittest, skipBefore35, exec_test
@@ -183,6 +184,10 @@ class WebSocketTest(WebSocketBaseTestCase):
         ], template_loader=DictLoader({
             'message.html': '<b>{{ message }}</b>',
         }))
+
+    def get_http_client(self):
+        # These tests require HTTP/1; force the use of SimpleAsyncHTTPClient.
+        return SimpleAsyncHTTPClient()
 
     def tearDown(self):
         super(WebSocketTest, self).tearDown()


### PR DESCRIPTION
Some recently-introduced tests are failing under tornado_http2, so fix
them.