### PR TITLE
fix gen.multi with gen.moment

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -814,6 +814,9 @@ def multi_future(children, quiet_exceptions=()):
     else:
         keys = None
     children = list(map(convert_yielded, children))
+    # filter out NullFutures, like gen.moment
+    children = [child for child in children
+                if not isinstance(child, _NullFuture)]
     assert all(is_future(i) for i in children)
     unfinished_children = set(children)
 

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -814,10 +814,7 @@ def multi_future(children, quiet_exceptions=()):
     else:
         keys = None
     children = list(map(convert_yielded, children))
-    # filter out NullFutures, like gen.moment
-    children = [child for child in children
-                if not isinstance(child, _NullFuture)]
-    assert all(is_future(i) for i in children)
+    assert all(is_future(i) or isinstance(i, _NullFuture) for i in children)
     unfinished_children = set(children)
 
     future = _create_future()

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1603,10 +1603,12 @@ class RunnerGCTest(AsyncTestCase):
         # now that it's not a real Future
         @gen.coroutine
         def wait_a_moment():
-            yield gen.multi([gen.moment, gen.moment])
+            result = yield gen.multi([gen.moment, gen.moment])
+            raise gen.Return(result)
 
         loop = self.get_new_ioloop()
-        loop.run_sync(wait_a_moment)
+        result = loop.run_sync(wait_a_moment)
+        self.assertEqual(result, [None, None])
 
 
 if __name__ == '__main__':

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1598,6 +1598,16 @@ class RunnerGCTest(AsyncTestCase):
             # coroutine finalizer was called (not on PyPy3 apparently)
             self.assertIs(result[-1], None)
 
+    def test_multi_moment(self):
+        # Test gen.multi with moment
+        # now that it's not a real Future
+        @gen.coroutine
+        def wait_a_moment():
+            yield gen.multi([gen.moment, gen.moment])
+
+        loop = self.get_new_ioloop()
+        loop.run_sync(wait_a_moment)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fixes assertion in gen.multi when calling convert_yielded with more than one gen.moment or None

convert_yielded can be called with None or [None]. When it is called with [None], gen.multi gets [gen.moment], which fails assert(is_future) now that gen.moment is no longer a real Future.