### PR TITLE
Handle non-ascii in debug_msg

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -499,7 +499,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
 
     def _curl_debug(self, debug_type, debug_msg):
         debug_types = ('I', '<', '>', '<', '>')
-        debug_msg = native_str(debug_msg)
+        debug_msg = native_str(debug_msg.decode('latin1'))
         if debug_type == 0:
             curl_log.debug('%s', debug_msg.strip())
         elif debug_type in (1, 2):


### PR DESCRIPTION
After running my server on a staging server I've got following error:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
  File "tornado/curl_httpclient.py", line 496, in _curl_debug
    debug_msg = native_str(debug_msg)
  File "tornado/escape.py", line 218, in to_unicode
    return value.decode("utf-8")
```

Where value is equal to:
```
b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03]\x8eA\n\x80 \x10E\xf7Aw\x90.0E-'\x97\xdd#sP\xc1\x14d\xa0\xba}Z.\xa2\xe5\xfc\xffx\x7f\xd0\xf2\xeee\xdb\xa0\xa5UKd\xc7\x9e\xe4\xd4\x8fb\x89I9\xad) \xbc!\xc2\x83dTE}\te\xb6\xe8c\x9a\xbb\xc3:\xa6\xae(6\nLI\xa2\x1d\xfe\x86\x9c \xd4\xbale\xa8^\xc1\xb8p~;(\xf6b\x83\xfa\xd9\r\xf4iB\xa9\xa2\x00\x00\x00"
```

After small googling, I found this issue https://github.com/tornadoweb/tornado/issues/1608 and this fix https://github.com/tornadoweb/tornado/commit/d7d9c467cda38f4c9352172ba7411edc29a85196. 

Seems that this error is relating to the fixed issue and the line should be fixed with the same way