### PR TITLE
Remove legacy author comment

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -17,7 +17,6 @@ the protocol (known as "draft 76") and are not compatible with this module.
 """
 
 from __future__ import absolute_import, division, print_function
-# Author: Jacob Kristhammar, 2010
 
 import base64
 import collections


### PR DESCRIPTION
I think my fifteen minutes have passed, and, I doubt that any of the original code is still here.

It was originally added based on this proposal on the mailing list https://groups.google.com/forum/#!searchin/python-tornado/jacob%7Csort:date/python-tornado/Blgj0MZZO4U/ETFALLYvz2EJ

Anyway, since I'm not affiliated with this project I think it can be removed.