### PR TITLE
Support jitter in PeriodicCallback

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -47,6 +47,7 @@ import threading
 import time
 import traceback
 import math
+import random
 
 from tornado.concurrent import Future, is_future, chain_future, future_set_exc_info, future_add_done_callback  # noqa: E501
 from tornado.log import app_log, gen_log
@@ -1161,6 +1162,11 @@ class PeriodicCallback(object):
     Note that the timeout is given in milliseconds, while most other
     time-related functions in Tornado use seconds.
 
+    If ``jitter`` is specified, each callback time will be randomly selected
+    between ``callback_time`` and ``callback_time * (1 + jitter)``.
+    Jitter can be used to reduce alignment of events with similar periods.
+    A jitter of 0.1 means allowing a 10% variation in callback time.
+
     If the callback runs for longer than ``callback_time`` milliseconds,
     subsequent invocations will be skipped to get back on schedule.
 
@@ -1168,12 +1174,16 @@ class PeriodicCallback(object):
 
     .. versionchanged:: 5.0
        The ``io_loop`` argument (deprecated since version 4.1) has been removed.
+
+    .. versionchanged:: 5.1
+       The ``jitter`` argument is added.
     """
-    def __init__(self, callback, callback_time):
+    def __init__(self, callback, callback_time, jitter=0):
         self.callback = callback
         if callback_time <= 0:
             raise ValueError("Periodic callback must have a positive callback_time")
         self.callback_time = callback_time
+        self.jitter = jitter
         self._running = False
         self._timeout = None
 
@@ -1218,6 +1228,9 @@ class PeriodicCallback(object):
 
     def _update_next(self, current_time):
         callback_time_sec = self.callback_time / 1000.0
+        if self.jitter:
+            # apply jitter fraction
+            callback_time_sec *= 1 + (self.jitter * random.random())
         if self._next_timeout <= current_time:
             # The period should be measured from the start of one call
             # to the start of the next. If one call takes too long,

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -1163,9 +1163,12 @@ class PeriodicCallback(object):
     time-related functions in Tornado use seconds.
 
     If ``jitter`` is specified, each callback time will be randomly selected
-    between ``callback_time`` and ``callback_time * (1 + jitter)``.
+    within a window of ``jitter * callback_time`` milliseconds.
     Jitter can be used to reduce alignment of events with similar periods.
     A jitter of 0.1 means allowing a 10% variation in callback time.
+    The window is centered on ``callback_time`` so the total number of calls
+    within a given interval should not be significantly affected by adding
+    jitter.
 
     If the callback runs for longer than ``callback_time`` milliseconds,
     subsequent invocations will be skipped to get back on schedule.
@@ -1230,7 +1233,7 @@ class PeriodicCallback(object):
         callback_time_sec = self.callback_time / 1000.0
         if self.jitter:
             # apply jitter fraction
-            callback_time_sec *= 1 + (self.jitter * random.random())
+            callback_time_sec *= 1 + (self.jitter * (random.random() - 0.5))
         if self._next_timeout <= current_time:
             # The period should be measured from the start of one call
             # to the start of the next. If one call takes too long,

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -854,8 +854,8 @@ class TestPeriodicCallbackMath(unittest.TestCase):
 
     @unittest.skipIf(mock is None, 'mock package not present')
     def test_jitter(self):
-        random_times = [0, 1, 0.5, 0.25]
-        expected = [1010, 1025, 1037.5, 1048.75]
+        random_times = [0.5, 1, 0, 0.75]
+        expected = [1010, 1022.5, 1030, 1041.25]
         call_durations = [0] * len(random_times)
         pc = PeriodicCallback(None, 10000, jitter=0.5)
 


### PR DESCRIPTION
A performance issue I have run into in several tornado applications is alignment of callbacks under load, causing brief periods of unresponsiveness at regular intervals, e.g. several similar PeriodicCallbacks aligning so that they fire in the same eventloop iteration. A solution that I have applied on a number of occasions is adding jitter to my periodic events, to reduce the occurrence of alignment. I thought it might be nice to support this in the default PeriodicCallback class.

`jitter` is a fraction and `callback_time` is used as the lower bound, so callbacks are scheduled on the interval

```python
[callback_time, callback_time * (1 + jitter)]
```