### PR TITLE
Support Blueprints to implement larger or more pluggable applications

### DIFF
--- a/tornado/blueprints.py
+++ b/tornado/blueprints.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+    tornado.blueprints
+    ~~~~~~~~~~~~~~~~
+
+    Blueprints are the recommended way to implement larger or more
+    pluggable applications in Tornado.
+"""
+from __future__ import absolute_import
+
+from tornado.web import RequestHandler
+
+__all__ = ["Blueprint", "RouteRuleDuplicate"]
+
+
+class RouteRuleDuplicate(Exception):
+    """Exception class for register duplicate handlers with the same url.
+    """
+
+    def __init__(self, url, handler):
+        error = "Url {!r} already registerd with handler {!r}".format(url, handler.__name__)
+        super(RouteRuleDuplicate, self).__init__(error)
+
+
+class Blueprint(object):
+    """Represents a blueprint.  A blueprint is an object that records
+    handlers that will be registered with the web application.
+    """
+
+    def __init__(self, name, verbose=True):
+        self.name = name
+        self.verbose = verbose
+        self.router = {}
+
+    def route(self, url, host_pattern=None):
+        def wrapper(handler):
+            assert issubclass(handler, RequestHandler)
+            _rules = self.router.get(url)
+            if _rules and self.verbose:
+                raise RouteRuleDuplicate(url, _rules[0])
+            self.router[url] = (handler, host_pattern or ".*$")
+            return handler
+        return wrapper
+
+    def register(self, app, url_prefix=None):
+        for url, rule in self.router.items():
+            handler, host_pattern = rule
+            if url_prefix:
+                _prefix = url_prefix.rstrip("/").split("/")
+                _suffix = url.strip("/").split("/")
+                url = "/".join(_prefix + _suffix)
+            app.add_handlers(host_pattern, [(url, handler)])

--- a/tornado/test/blueprints_test.py
+++ b/tornado/test/blueprints_test.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from tornado.web import RequestHandler, Application, asynchronous
+from tornado.blueprints import Blueprint
+from tornado.test.util import unittest
+from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
+
+""" auth module
+"""
+AUTH = Blueprint("auth")
+
+@AUTH.route("/login")
+class LoginHandler(RequestHandler):
+
+    def get(self):
+        self.write("Login Page")
+
+
+@AUTH.route("/logout")
+class LogoutHandler(RequestHandler):
+    def get(self):
+        self.write("Logged out")
+
+
+""" user module
+"""
+USER = Blueprint("user")
+
+@USER.route("/students")
+class StudentsHandler(RequestHandler):
+    def get(self):
+        self.write("Students List")
+
+
+@USER.route("/teachers")
+class TeachersHandler(RequestHandler):
+
+    def get(self):
+        self.write("Teachers List")
+
+
+class BlueprintsTest(AsyncHTTPTestCase):
+    def get_app(self):
+        self.app = Application()
+        AUTH.register(self.app, url_prefix="/auth")
+        USER.register(self.app, url_prefix="/user")
+        return self.app
+
+    def test_auth_login(self):
+        response = self.fetch("/auth/login")
+        # Test contents of response
+        self.assertEqual(response.body, b"Login Page")
+
+    def test_auth_logout(self):
+        response = self.fetch("/auth/logout")
+        # Test contents of response
+        self.assertEqual(response.body, b"Logged out")
+
+    def test_user_students(self):
+        response = self.fetch("/user/students")
+        # Test contents of response
+        self.assertEqual(response.body, b"Students List")
+
+    def test_user_teachers(self):
+        response = self.fetch("/user/teachers")
+        # Test contents of response
+        self.assertEqual(response.body, b"Teachers List")
+
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
We can create a blueprint for every module as follow:

```
auth_blueprint = Blueprint('auth')
```
For the handlers of the module, use a decorator to register it into blueprint as follow:
```
@auth_blueprint.route("/login") 
class LoginHandler(RequestHandler): 
    def get(self):
        self.write("Login page")
```
When we create a web application, we can register a blueprint as we needed.
```
app = Application() 
auth_blueprint.register(app, url_prefix="/auth")
```