### PR TITLE
Ignore ENOPROTOOPT errors from SO_REUSEADDR or SO_ERROR

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1349,7 +1349,12 @@ class IOStream(BaseIOStream):
         return future
 
     def _handle_connect(self):
-        err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+        try:
+            err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+        except socket.error as e:
+            err = e.args[0]
+            if err == errno.ENOPROTOOPT:
+                err = 0
         if err != 0:
             self.error = socket.error(err, os.strerror(err))
             # IOLoop implementations may vary: some of them return

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -138,9 +138,17 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC,
             raise
         set_close_exec(sock.fileno())
         if os.name != 'nt':
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            except socket.error as e:
+                if e.args[0] != errno.ENOPROTOOPT:
+                    raise
         if reuse_port:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            except socket.error as e:
+                if e.args[0] != errno.ENOPROTOOPT:
+                    raise
         if af == socket.AF_INET6:
             # On linux, ipv6 sockets accept ipv4 too by default,
             # but this makes it impossible to bind to both
@@ -180,7 +188,11 @@ if hasattr(socket, 'AF_UNIX'):
         """
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         set_close_exec(sock.fileno())
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        except socket.error as e:
+            if e.args[0] != errno.ENOPROTOOPT:
+                raise
         sock.setblocking(0)
         try:
             st = os.stat(file)


### PR DESCRIPTION
Some systems, for example Hurd doesn't support SO_REUSEADDR.