### PR TITLE
fix non-ASCII header exception in Python 3

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -382,7 +382,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         # are fixed.
         header_lines = (native_str(n) + ": " + native_str(v) for n, v in headers.get_all())
         if PY3:
-            lines.extend(l.encode('latin1') for l in header_lines)
+            lines.extend(l.encode('utf-8') for l in header_lines)
         else:
             lines.extend(header_lines)
         for line in lines:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -372,7 +372,7 @@ class RequestHandler(object):
         elif isinstance(value, bytes):  # py3
             # Non-ascii characters in headers are not well supported,
             # but if you pass bytes, use latin1 so they pass through as-is.
-            retval = value.decode('latin1')
+            retval = value.decode('utf-8')
         elif isinstance(value, unicode_type):  # py2
             # TODO: This is inconsistent with the use of latin1 above,
             # but it's been that way for a long time. Should it change?


### PR DESCRIPTION
Hi there!

This Pull Request contains fix for non-ASCII(emoji, CJK characters, etc.) http headers in Python 3.
For example, refer to the following code:
```python
def get(self):
    file_name, file_content = 'hello😁.txt', 'how are you'
    self.set_header("Content-Type", "application/bin; charset='utf-8'")
    self.set_header("Content-Disposition", "attachment; filename=%s" % file_name)
    self.write(file_content)
```
Above code will trigger browser to download `hello😁.txt` instead of open it.
However, above code would raise such exception: 
`UnicodeEncodeError: 'latin-1' codec can't encode characters in position 45-46: ordinal not in range(256)`
And also, non-ASCII header set in any field would raise this exception,
for example `self.set_header("laugh😁", "emoji")`

The error occurs in the [L385 of http1connection.py](https://github.com/tornadoweb/tornado/blob/master/tornado/http1connection.py#L385):
`lines.extend(l.encode('latin1') for l in header_lines)`
Of course encoding an emoji or CJK in latin1 would throw an exception. 

The solution varies, whether `url_escape(file_name)` when we programs or fix the implementation in `http1connection.py`


Though according to [RFC7230 section 3.2.4](https://tools.ietf.org/html/rfc7230#section-3.2.4):
> Historically, HTTP has allowed field content with text in the
   ISO-8859-1 charset [ISO-8859-1], supporting other charsets only
   through use of [RFC2047] encoding.  In practice, most HTTP header
   field values use only a subset of the US-ASCII charset [USASCII].
   Newly defined header fields SHOULD limit their field values to
   US-ASCII octets.  A recipient SHOULD treat other octets in field
   content (obs-text) as opaque data.

HTTP Header should be limited to ASCII value. 

However, this PR seems like a temporary solution since the Python 2 version just send the header in raw.

Anyway, thanks for your precious time in reviewing this.