### PR TITLE
test: Reinstate a test that was mistakenly left disabled

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,9 +48,9 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
 
-  - "pip install tox wheel"
+  - "python -m pip install tox wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
This test required some refactoring to construct invalid headers that
we no longer allow handlers to return directly.