### PR TITLE
Use `log_exception` method in WebSocketProtocol instead of custom logging

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import, division, print_function
 import base64
 import hashlib
 import os
+import sys
 import struct
 import tornado.escape
 import tornado.web
@@ -512,8 +513,7 @@ class WebSocketProtocol(object):
         try:
             result = callback(*args, **kwargs)
         except Exception:
-            app_log.error("Uncaught exception in %s",
-                          getattr(self.request, 'path', None), exc_info=True)
+            self.handler.log_exception(*sys.exc_info())
             self._abort()
         else:
             if result is not None:


### PR DESCRIPTION
It is usefull if we need to add some custom handlers for all unexpected exceptions.
For example, in sentry project:
https://github.com/getsentry/raven-python/issues/980
