### PR TITLE
docs: Start release notes for 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install pycurl; fi
     # Twisted runs on 2.x and 3.3+, but is flaky on pypy.
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then travis_retry pip install Twisted; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8; fi
     # On travis the extension should always be built
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
@@ -81,7 +81,7 @@ script:
     - if [[ "$RUN_COVERAGE" == 1 ]]; then coverage xml; fi
     - export TORNADO_EXTENSION=0
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8; fi
 
 after_success:

--- a/docs/guide/async.rst
+++ b/docs/guide/async.rst
@@ -53,6 +53,12 @@ transparent to its callers (systems like `gevent
 comparable to asynchronous systems, but they do not actually make
 things asynchronous).
 
+Asynchronous operations in Tornado generally return placeholder
+objects (``Futures``), with the exception of some low-level components
+like the `.IOLoop` that use callbacks. ``Futures`` are usually
+transformed into their result with the ``await`` or ``yield``
+keywords.
+
 Examples
 ~~~~~~~~
 
@@ -70,65 +76,59 @@ Here is a sample synchronous function:
 .. testoutput::
    :hide:
 
-And here is the same function rewritten to be asynchronous with a
-callback argument:
+And here is the same function rewritten asynchronously as a native coroutine:
 
 .. testcode::
 
-    from tornado.httpclient import AsyncHTTPClient
+   from tornado.httpclient import AsyncHTTPClient
 
-    def asynchronous_fetch(url, callback):
-        http_client = AsyncHTTPClient()
-        def handle_response(response):
-            callback(response.body)
-        http_client.fetch(url, callback=handle_response)
+   async def asynchronous_fetch(url):
+       http_client = AsyncHTTPClient()
+       response = await http_client.fetch(url)
+       return response.body
 
 .. testoutput::
    :hide:
 
-And again with a `.Future` instead of a callback:
+Or for compatibility with older versions of Python, using the `tornado.gen` module:
+
+..  testcode::
+
+    from tornado.httpclient import AsyncHTTPClient
+    from tornado import gen
+
+    @gen.coroutine
+    def async_fetch_gen(url):
+        http_client = AsyncHTTPClient()
+        response = yield http_client.fetch(url)
+        raise gen.Return(response.body)
+
+Coroutines are a little magical, but what they do internally is something like this:
 
 .. testcode::
 
     from tornado.concurrent import Future
 
-    def async_fetch_future(url):
+    def async_fetch_manual(url):
         http_client = AsyncHTTPClient()
         my_future = Future()
         fetch_future = http_client.fetch(url)
-        fetch_future.add_done_callback(
-            lambda f: my_future.set_result(f.result()))
+        def on_fetch(f):
+            my_future.set_result(f.result().body)
+        fetch_future.add_done_callback(on_fetch)
         return my_future
 
 .. testoutput::
    :hide:
 
-The raw `.Future` version is more complex, but ``Futures`` are
-nonetheless recommended practice in Tornado because they have two
-major advantages.  Error handling is more consistent since the
-``Future.result`` method can simply raise an exception (as opposed to
-the ad-hoc error handling common in callback-oriented interfaces), and
-``Futures`` lend themselves well to use with coroutines.  Coroutines
-will be discussed in depth in the next section of this guide.  Here is
-the coroutine version of our sample function, which is very similar to
-the original synchronous version:
+Notice that the coroutine returns its `.Future` before the fetch is
+done. This is what makes coroutines *asynchronous*.
 
-.. testcode::
-
-    from tornado import gen
-
-    @gen.coroutine
-    def fetch_coroutine(url):
-        http_client = AsyncHTTPClient()
-        response = yield http_client.fetch(url)
-        raise gen.Return(response.body)
-
-.. testoutput::
-   :hide:
-
-The statement ``raise gen.Return(response.body)`` is an artifact of
-Python 2, in which generators aren't allowed to return
-values. To overcome this, Tornado coroutines raise a special kind of
-exception called a `.Return`. The coroutine catches this exception and
-treats it like a returned value. In Python 3.3 and later, a ``return
-response.body`` achieves the same result.
+Anything you can do with coroutines you can also do by passing
+callback objects around, but coroutines provide an important
+simplification by letting you organize your code in the same way you
+would if it were synchronous. This is especially important for error
+handling, since ``try``/``except`` blocks work as you would expect in
+coroutines while this is difficult to achieve with callbacks.
+Coroutines will be discussed in depth in the next section of this
+guide.

--- a/docs/guide/intro.rst
+++ b/docs/guide/intro.rst
@@ -20,7 +20,9 @@ Tornado can be roughly divided into four major components:
   components and can also be used to implement other protocols.
 * A coroutine library (`tornado.gen`) which allows asynchronous
   code to be written in a more straightforward way than chaining
-  callbacks.
+  callbacks. This is similar to the native coroutine feature introduced
+  in Python 3.5 (``async def``). Native coroutines are recommended
+  in place of the `tornado.gen` module when available.
 
 The Tornado web framework and HTTP server together offer a full-stack
 alternative to `WSGI <http://www.python.org/dev/peps/pep-3333/>`_.

--- a/docs/guide/security.rst
+++ b/docs/guide/security.rst
@@ -189,15 +189,14 @@ the Google credentials in a cookie for later access:
 
     class GoogleOAuth2LoginHandler(tornado.web.RequestHandler,
                                    tornado.auth.GoogleOAuth2Mixin):
-        @tornado.gen.coroutine
-        def get(self):
+        async def get(self):
             if self.get_argument('code', False):
-                user = yield self.get_authenticated_user(
+                user = await self.get_authenticated_user(
                     redirect_uri='http://your.site.com/auth/google',
                     code=self.get_argument('code'))
                 # Save the user with e.g. set_secure_cookie
             else:
-                yield self.authorize_redirect(
+                await self.authorize_redirect(
                     redirect_uri='http://your.site.com/auth/google',
                     client_id=self.settings['google_oauth']['key'],
                     scope=['profile', 'email'],

--- a/docs/guide/structure.rst
+++ b/docs/guide/structure.rst
@@ -193,9 +193,9 @@ place:
    etc. If the URL regular expression contains capturing groups, they
    are passed as arguments to this method.
 5. When the request is finished, `~.RequestHandler.on_finish()` is
-   called.  For synchronous handlers this is immediately after
-   ``get()`` (etc) return; for asynchronous handlers it is after the
-   call to `~.RequestHandler.finish()`.
+   called. For most handlers this is immediately after ``get()`` (etc)
+   return; for handlers using the `tornado.web.asynchronous` decorator
+   it is after the call to `~.RequestHandler.finish()`.
 
 All methods designed to be overridden are noted as such in the
 `.RequestHandler` documentation.  Some of the most commonly
@@ -295,65 +295,23 @@ To send a temporary redirect with a `.RedirectHandler`, add
 Asynchronous handlers
 ~~~~~~~~~~~~~~~~~~~~~
 
-Tornado handlers are synchronous by default: when the
-``get()``/``post()`` method returns, the request is considered
-finished and the response is sent.  Since all other requests are
-blocked while one handler is running, any long-running handler should
-be made asynchronous so it can call its slow operations in a
-non-blocking way.  This topic is covered in more detail in
-:doc:`async`; this section is about the particulars of
-asynchronous techniques in `.RequestHandler` subclasses.
+Certain handler methods (including ``prepare()`` and the HTTP verb
+methods ``get()``/``post()``/etc) may be overridden as coroutines to
+make the handler asynchronous.
 
-The simplest way to make a handler asynchronous is to use the
-`.coroutine` decorator or ``async def``. This allows you to perform
-non-blocking I/O with the ``yield`` or ``await`` keywords, and no
-response will be sent until the coroutine has returned. See
-:doc:`coroutines` for more details.
+Tornado also supports a callback-based style of asynchronous handler
+with the `tornado.web.asynchronous` decorator, but this style is
+deprecated and will be removed in Tornado 6.0. New applications should
+use coroutines instead.
 
-In some cases, coroutines may be less convenient than a
-callback-oriented style, in which case the `.tornado.web.asynchronous`
-decorator can be used instead.  When this decorator is used the response
-is not automatically sent; instead the request will be kept open until
-some callback calls `.RequestHandler.finish`.  It is up to the application
-to ensure that this method is called, or else the user's browser will
-simply hang.
-
-Here is an example that makes a call to the FriendFeed API using
-Tornado's built-in `.AsyncHTTPClient`:
+For example, here is a simple handler using a coroutine:
 
 .. testcode::
 
     class MainHandler(tornado.web.RequestHandler):
-        @tornado.web.asynchronous
-        def get(self):
+        async def get(self):
             http = tornado.httpclient.AsyncHTTPClient()
-            http.fetch("http://friendfeed-api.com/v2/feed/bret",
-                       callback=self.on_response)
-
-        def on_response(self, response):
-            if response.error: raise tornado.web.HTTPError(500)
-            json = tornado.escape.json_decode(response.body)
-            self.write("Fetched " + str(len(json["entries"])) + " entries "
-                       "from the FriendFeed API")
-            self.finish()
-
-.. testoutput::
-   :hide:
-
-When ``get()`` returns, the request has not finished. When the HTTP
-client eventually calls ``on_response()``, the request is still open,
-and the response is finally flushed to the client with the call to
-``self.finish()``.
-
-For comparison, here is the same example using a coroutine:
-
-.. testcode::
-
-    class MainHandler(tornado.web.RequestHandler):
-        @tornado.gen.coroutine
-        def get(self):
-            http = tornado.httpclient.AsyncHTTPClient()
-            response = yield http.fetch("http://friendfeed-api.com/v2/feed/bret")
+            response = await http.fetch("http://friendfeed-api.com/v2/feed/bret")
             json = tornado.escape.json_decode(response.body)
             self.write("Fetched " + str(len(json["entries"])) + " entries "
                        "from the FriendFeed API")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,12 +88,13 @@ installed in this way, so you may wish to download a copy of the
 source tarball or clone the `git repository
 <https://github.com/tornadoweb/tornado>`_ as well.
 
-**Prerequisites**: Tornado runs on Python 2.7, and 3.4+.
-The updates to the `ssl` module in Python 2.7.9 are required
-(in some distributions, these updates may be available in
-older python versions). In addition to the requirements
-which will be installed automatically by ``pip`` or ``setup.py install``,
-the following optional packages may be useful:
+**Prerequisites**: Tornado 5.x runs on Python 2.7, and 3.4+ (Tornado
+6.0 will require Python 3.5+; Python 2 will no longer be supported).
+The updates to the `ssl` module in Python 2.7.9 are required (in some
+distributions, these updates may be available in older python
+versions). In addition to the requirements which will be installed
+automatically by ``pip`` or ``setup.py install``, the following
+optional packages may be useful:
 
 * `pycurl <http://pycurl.sourceforge.net>`_ is used by the optional
   ``tornado.curl_httpclient``.  Libcurl version 7.22 or higher is required.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   releases/v5.1.0
    releases/v5.0.2
    releases/v5.0.1
    releases/v5.0.0

--- a/docs/releases/v5.1.0.rst
+++ b/docs/releases/v5.1.0.rst
@@ -1,0 +1,152 @@
+What's new in Tornado 5.1
+=========================
+
+In progress
+-----------
+
+Deprecation notice
+~~~~~~~~~~~~~~~~~~
+
+- Tornado 6.0 will drop support for Python 2.7 and 3.4. The minimum
+  supported Python version will be 3.5.2.
+- The `tornado.stack_context` module is deprecated and will be removed
+  in Tornado 6.0. The reason for this is that it is not feasible to
+  provide this module's semantics in the presence of ``async def``
+  native coroutines. `.ExceptionStackContext` is mainly obsolete
+  thanks to coroutines. `.StackContext` lacks a direct replacement
+  although the new ``contextvars`` package (in the Python standard
+  library beginning in Python 3.7) may be an alternative.
+- Callback-oriented code often relies on `.ExceptionStackContext` to
+  handle errors and prevent leaked connections. In order to avoid the
+  risk of silently introducing subtle leaks (and to consolidate all of
+  Tornado's interfaces behind the coroutine pattern), ``callback``
+  arguments throughout the package are deprecated and will be removed
+  in version 6.0. All functions that had a ``callback`` argument
+  removed now return a `.Future` which should be used instead.
+- Where possible, deprecation warnings are emitted when any of these
+  deprecated interfaces is used. However, Python does not display
+  deprecation warnings by default. To prepare your application for
+  Tornado 6.0, run Python with the ``-Wd`` argument or set the
+  environment variable ``PYTHONWARNINGS`` to ``d``. If your
+  application runs on Python 3 without deprecation warnings, it should
+  be able to move to Tornado 6.0 without disruption.
+
+`tornado.auth`
+~~~~~~~~~~~~~~
+
+- `.OAuthMixin._oauth_get_user_future` may now be a native coroutine.
+- All ``callback`` arguments in this package are deprecated and will
+  be removed in 6.0. Use the coroutine interfaces instead.
+- The ``OAuthMixin._oauth_get_user`` method is deprecated and will be removed in
+  6.0. Override `~.OAuthMixin._oauth_get_user_future` instead.
+
+`tornado.concurrent`
+~~~~~~~~~~~~~~~~~~~~
+
+- `.run_on_executor` now returns `.Future` objects that are compatible
+  with ``await``.
+- The ``callback`` argument to `.run_on_executor` is deprecated and will
+  be removed in 6.0.
+- `.return_future` is deprecated. The wrapped function will no longer
+  accept ``callback`` arguments in Tornado 6.0, although the decorator
+  itself will not be removed.
+
+`tornado.gen`
+~~~~~~~~~~~~~
+
+- Some older portions of this module are deprecated and will be removed
+  in 6.0. This includes `.engine`, `.YieldPoint`, `.Callback`,
+  `.Wait`, `.WaitAll`, `.MultiYieldPoint`, and `.Task`.
+- Functions decorated with ``@gen.coroutine`` will no longer accept
+  ``callback`` arguments in 6.0.
+
+`tornado.httpclient`
+~~~~~~~~~~~~~~~~~~~~
+
+- The behavior of ``raise_error=False`` is changing in 6.0. Currently
+  it suppresses all errors; in 6.0 it will only suppress the errors
+  raised due to completed responses with non-200 status codes.
+- The ``callback`` argument to `.AsyncHTTPClient.fetch` is deprecated
+  and will be removed in 6.0.
+- `tornado.httpclient.HTTPError` has been renamed to
+  `.HTTPClientError` to avoid ambiguity in code that also has to deal
+  with `tornado.web.HTTPError`. The old name remains as an alias.
+
+`tornado.httputil`
+~~~~~~~~~~~~~~~~~~
+
+- `.HTTPServerRequest.write` is deprecated and will be removed in 6.0. Use
+  the methods of ``request.connection`` instead.
+- Malformed HTTP headers are now logged less noisily.
+
+`tornado.ioloop`
+~~~~~~~~~~~~~~~~
+
+- `.PeriodicCallback` now supports a ``jitter`` argument to randomly
+  vary the timeout.
+- `.IOLoop.set_blocking_signal_threshold`,
+  `~.IOLoop.set_blocking_log_threshold`, `~.IOLoop.log_stack`,
+  and `.IOLoop.handle_callback_exception` are deprecated and will
+  be removed in 6.0.
+
+`tornado.iostream`
+~~~~~~~~~~~~~~~~~~
+
+- All ``callback`` arguments in this module are deprecated except for
+  `.BaseIOStream.set_close_callback`. They will be removed in 6.0.
+- ``streaming_callback`` arguments to `.BaseIOStream.read_bytes` and
+  `.BaseIOStream.read_until_close` are deprecated and will be removed
+  in 6.0.
+
+`tornado.platform.twisted`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `.TornadoReactor` and `.TwistedIOLoop` are deprecated and will be
+  removed in 6.0. Instead, Tornado will always use the asyncio event loop
+  and twisted can be configured to do so as well.
+
+`tornado.stack_context`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- The `tornado.stack_context` module is deprecated and will be removed
+  in 6.0.
+
+`tornado.testing`
+~~~~~~~~~~~~~~~~~
+
+- `.AsyncHTTPTestCase.fetch` now takes a ``raise_error`` argument.
+  This argument has the same semantics as `.AsyncHTTPClient.fetch`,
+  but defaults to false because tests often need to deal with non-200
+  responses (and for backwards-compatibility).
+- The `.AsyncTestCase.stop` and `.AsyncTestCase.wait` methods are
+  deprecated.
+
+`tornado.web`
+~~~~~~~~~~~~~
+
+- New method `.RequestHandler.detach` can be used from methods
+  that are not decorated with ``@asynchronous`` (the decorator
+  was required to use ``self.request.connection.detach()``.
+- `.FallbackHandler` now calls ``on_finish`` for the benefit of
+  subclasses that may have overridden it.
+- The `.asynchronous` decorator is deprecated and will be removed in 6.0.
+- The ``callback`` argument to `.RequestHandler.flush` is deprecated
+  and will be removed in 6.0.
+
+
+`tornado.websocket`
+~~~~~~~~~~~~~~~~~~~
+
+- The `.WebSocketHandler.select_subprotocol` method is now called only
+  when a subprotocol header is provided (previously it would be called
+  with a list containing an empty string).
+- The ``data`` argument to `.WebSocketHandler.ping` is now optional.
+- Client-side websocket connections no longer buffer more than one
+  message in memory at a time.
+- Exception logging now uses `.RequestHandler.log_exception`.
+
+`tornado.wsgi`
+~~~~~~~~~~~~~~
+
+- `.WSGIApplication` and `.WSGIAdapter` are deprecated and will be removed
+  in Tornado 6.0.

--- a/docs/releases/v5.1.0.rst
+++ b/docs/releases/v5.1.0.rst
@@ -47,9 +47,7 @@ Deprecation notice
   with ``await``.
 - The ``callback`` argument to `.run_on_executor` is deprecated and will
   be removed in 6.0.
-- `.return_future` is deprecated. The wrapped function will no longer
-  accept ``callback`` arguments in Tornado 6.0, although the decorator
-  itself will not be removed.
+- `.return_future` is deprecated and will be removed in 6.0.
 
 `tornado.gen`
 ~~~~~~~~~~~~~

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -125,6 +125,7 @@
    .. automethod:: RequestHandler.compute_etag
    .. automethod:: RequestHandler.create_template_loader
    .. autoattribute:: RequestHandler.current_user
+   .. automethod:: RequestHandler.detach
    .. automethod:: RequestHandler.get_browser_locale
    .. automethod:: RequestHandler.get_current_user
    .. automethod:: RequestHandler.get_login_url

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -74,8 +74,8 @@ import time
 import uuid
 import warnings
 
-from tornado.concurrent import (Future, return_future, chain_future,
-                                future_set_exc_info,
+from tornado.concurrent import (Future, _non_deprecated_return_future,
+                                future_set_exc_info, chain_future,
                                 future_set_result_unless_cancelled)
 from tornado import gen
 from tornado import httpclient
@@ -148,7 +148,7 @@ class OpenIdMixin(object):
 
     * ``_OPENID_ENDPOINT``: the identity provider's URI.
     """
-    @return_future
+    @_non_deprecated_return_future
     def authenticate_redirect(self, callback_uri=None,
                               ax_attrs=["name", "email", "language", "username"],
                               callback=None):
@@ -343,7 +343,7 @@ class OAuthMixin(object):
     Subclasses must also override the `_oauth_get_user_future` and
     `_oauth_consumer_token` methods.
     """
-    @return_future
+    @_non_deprecated_return_future
     def authorize_redirect(self, callback_uri=None, extra_params=None,
                            http_client=None, callback=None):
         """Redirects the user to obtain OAuth authorization for this service.
@@ -524,7 +524,7 @@ class OAuthMixin(object):
         """
         raise NotImplementedError()
 
-    @return_future
+    @_non_deprecated_return_future
     def _oauth_get_user_future(self, access_token, callback):
         """Subclasses must override this to get basic information about the
         user.
@@ -617,7 +617,7 @@ class OAuth2Mixin(object):
     * ``_OAUTH_AUTHORIZE_URL``: The service's authorization url.
     * ``_OAUTH_ACCESS_TOKEN_URL``:  The service's access token url.
     """
-    @return_future
+    @_non_deprecated_return_future
     def authorize_redirect(self, redirect_uri=None, client_id=None,
                            client_secret=None, extra_params=None,
                            callback=None, scope=None, response_type="code"):
@@ -778,7 +778,7 @@ class TwitterMixin(OAuthMixin):
     _OAUTH_NO_CALLBACKS = False
     _TWITTER_BASE_URL = "https://api.twitter.com/1.1"
 
-    @return_future
+    @_non_deprecated_return_future
     def authenticate_redirect(self, callback_uri=None, callback=None):
         """Just like `~OAuthMixin.authorize_redirect`, but
         auto-redirects if authorized.

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -37,15 +37,14 @@ Example usage for Google OAuth:
 
     class GoogleOAuth2LoginHandler(tornado.web.RequestHandler,
                                    tornado.auth.GoogleOAuth2Mixin):
-        @tornado.gen.coroutine
-        def get(self):
+        async def get(self):
             if self.get_argument('code', False):
-                user = yield self.get_authenticated_user(
+                user = await self.get_authenticated_user(
                     redirect_uri='http://your.site.com/auth/google',
                     code=self.get_argument('code'))
                 # Save the user with e.g. set_secure_cookie
             else:
-                yield self.authorize_redirect(
+                await self.authorize_redirect(
                     redirect_uri='http://your.site.com/auth/google',
                     client_id=self.settings['google_oauth']['key'],
                     scope=['profile', 'email'],
@@ -683,16 +682,15 @@ class OAuth2Mixin(object):
             class MainHandler(tornado.web.RequestHandler,
                               tornado.auth.FacebookGraphMixin):
                 @tornado.web.authenticated
-                @tornado.gen.coroutine
-                def get(self):
-                    new_entry = yield self.oauth2_request(
+                async def get(self):
+                    new_entry = await self.oauth2_request(
                         "https://graph.facebook.com/me/feed",
                         post_args={"message": "I am posting from my Tornado application!"},
                         access_token=self.current_user["access_token"])
 
                     if not new_entry:
                         # Call failed; perhaps missing permission?
-                        yield self.authorize_redirect()
+                        await self.authorize_redirect()
                         return
                     self.finish("Posted a message!")
 
@@ -758,13 +756,12 @@ class TwitterMixin(OAuthMixin):
 
         class TwitterLoginHandler(tornado.web.RequestHandler,
                                   tornado.auth.TwitterMixin):
-            @tornado.gen.coroutine
-            def get(self):
+            async def get(self):
                 if self.get_argument("oauth_token", None):
-                    user = yield self.get_authenticated_user()
+                    user = await self.get_authenticated_user()
                     # Save the user using e.g. set_secure_cookie()
                 else:
-                    yield self.authorize_redirect()
+                    await self.authorize_redirect()
 
     .. testoutput::
        :hide:
@@ -829,9 +826,8 @@ class TwitterMixin(OAuthMixin):
             class MainHandler(tornado.web.RequestHandler,
                               tornado.auth.TwitterMixin):
                 @tornado.web.authenticated
-                @tornado.gen.coroutine
-                def get(self):
-                    new_entry = yield self.twitter_request(
+                async def get(self):
+                    new_entry = await self.twitter_request(
                         "/statuses/update",
                         post_args={"status": "Testing Tornado Web Server"},
                         access_token=self.current_user["access_token"])
@@ -942,19 +938,18 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
 
             class GoogleOAuth2LoginHandler(tornado.web.RequestHandler,
                                            tornado.auth.GoogleOAuth2Mixin):
-                @tornado.gen.coroutine
-                def get(self):
+                async def get(self):
                     if self.get_argument('code', False):
-                        access = yield self.get_authenticated_user(
+                        access = await self.get_authenticated_user(
                             redirect_uri='http://your.site.com/auth/google',
                             code=self.get_argument('code'))
-                        user = yield self.oauth2_request(
+                        user = await self.oauth2_request(
                             "https://www.googleapis.com/oauth2/v1/userinfo",
                             access_token=access["access_token"])
                         # Save the user and access token with
                         # e.g. set_secure_cookie.
                     else:
-                        yield self.authorize_redirect(
+                        await self.authorize_redirect(
                             redirect_uri='http://your.site.com/auth/google',
                             client_id=self.settings['google_oauth']['key'],
                             scope=['profile', 'email'],
@@ -1014,17 +1009,16 @@ class FacebookGraphMixin(OAuth2Mixin):
 
             class FacebookGraphLoginHandler(tornado.web.RequestHandler,
                                             tornado.auth.FacebookGraphMixin):
-              @tornado.gen.coroutine
-              def get(self):
+              async def get(self):
                   if self.get_argument("code", False):
-                      user = yield self.get_authenticated_user(
+                      user = await self.get_authenticated_user(
                           redirect_uri='/auth/facebookgraph/',
                           client_id=self.settings["facebook_api_key"],
                           client_secret=self.settings["facebook_secret"],
                           code=self.get_argument("code"))
                       # Save the user with e.g. set_secure_cookie
                   else:
-                      yield self.authorize_redirect(
+                      await self.authorize_redirect(
                           redirect_uri='/auth/facebookgraph/',
                           client_id=self.settings["facebook_api_key"],
                           extra_params={"scope": "read_stream,offline_access"})
@@ -1134,9 +1128,8 @@ class FacebookGraphMixin(OAuth2Mixin):
             class MainHandler(tornado.web.RequestHandler,
                               tornado.auth.FacebookGraphMixin):
                 @tornado.web.authenticated
-                @tornado.gen.coroutine
-                def get(self):
-                    new_entry = yield self.facebook_request(
+                async def get(self):
+                    new_entry = await self.facebook_request(
                         "/me/feed",
                         post_args={"message": "I am posting from my Tornado application!"},
                         access_token=self.current_user["access_token"])

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -483,7 +483,7 @@ def return_future(f):
 
     If no callback is given, the caller should use the ``Future`` to
     wait for the function to complete (perhaps by yielding it in a
-    `.gen.engine` function, or passing it to `.IOLoop.add_future`).
+    coroutine, or passing it to `.IOLoop.add_future`).
 
     Usage:
 
@@ -494,10 +494,8 @@ def return_future(f):
             # Do stuff (possibly asynchronous)
             callback(result)
 
-        @gen.engine
-        def caller(callback):
-            yield future_func(arg1, arg2)
-            callback()
+        async def caller():
+            await future_func(arg1, arg2)
 
     ..
 

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -510,9 +510,22 @@ def return_future(f):
 
     .. deprecated:: 5.1
 
-       New code should use coroutines directly instead of wrapping
-       callback-based code with this decorator.
+       This decorator will be removed in Tornado 6.0. New code should
+       use coroutines directly instead of wrapping callback-based code
+       with this decorator. Interactions with non-Tornado
+       callback-based code should be managed explicitly to avoid
+       relying on the `.ExceptionStackContext` built into this
+       decorator.
     """
+    warnings.warn("@return_future is deprecated, use coroutines instead",
+                  DeprecationWarning)
+    return _non_deprecated_return_future(f)
+
+
+def _non_deprecated_return_future(f):
+    # Allow auth.py to use this decorator without triggering
+    # deprecation warnings. This will go away once auth.py has removed
+    # its legacy interfaces in 6.0.
     replacer = ArgReplacer(f, 'callback')
 
     @functools.wraps(f)

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -17,7 +17,7 @@ environment than chaining callbacks. Code using coroutines is
 technically asynchronous, but it is written as a single generator
 instead of a collection of separate functions.
 
-For example, the following asynchronous handler:
+For example, the following callback-based asynchronous handler:
 
 .. testcode::
 

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -125,14 +125,14 @@ class AsyncHTTPClient(Configurable):
 
     Example usage::
 
-        def handle_response(response):
-            if response.error:
-                print("Error: %s" % response.error)
+        async def f():
+            http_client = AsyncHTTPClient()
+            try:
+                response = await http_client.fetch("http://www.google.com")
+            except Exception as e:
+                print("Error: %s" % e)
             else:
                 print(response.body)
-
-        http_client = AsyncHTTPClient()
-        http_client.fetch("http://www.google.com/", handle_response)
 
     The constructor for this class is magic in several respects: It
     actually creates an instance of an implementation-specific

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -104,10 +104,9 @@ class IOLoop(Configurable):
         from tornado import gen
         from tornado.iostream import IOStream
 
-        @gen.coroutine
-        def handle_connection(connection, address):
+        async def handle_connection(connection, address):
             stream = IOStream(connection)
-            message = yield stream.read_until_close()
+            message = await stream.read_until_close()
             print("message from client:", message.decode().strip())
 
         def connection_ready(sock, fd, events):
@@ -504,17 +503,6 @@ class IOLoop(Configurable):
         If the event loop is not currently running, the next call to `start()`
         will return immediately.
 
-        To use asynchronous methods from otherwise-synchronous code (such as
-        unit tests), you can start and stop the event loop like this::
-
-          ioloop = IOLoop()
-          async_method(ioloop=ioloop, callback=ioloop.stop)
-          ioloop.start()
-
-        ``ioloop.start()`` will return after ``async_method`` has run
-        its callback, whether that callback was invoked before or
-        after ``ioloop.start``.
-
         Note that even after `stop` has been called, the `IOLoop` is not
         completely stopped until `IOLoop.start` has also returned.
         Some work that was scheduled before the call to `stop` may still
@@ -525,10 +513,10 @@ class IOLoop(Configurable):
     def run_sync(self, func, timeout=None):
         """Starts the `IOLoop`, runs the given function, and stops the loop.
 
-        The function must return either a yieldable object or
-        ``None``. If the function returns a yieldable object, the
-        `IOLoop` will run until the yieldable is resolved (and
-        `run_sync()` will return the yieldable's result). If it raises
+        The function must return either an awaitable object or
+        ``None``. If the function returns an awaitable object, the
+        `IOLoop` will run until the awaitable is resolved (and
+        `run_sync()` will return the awaitable's result). If it raises
         an exception, the `IOLoop` will stop and the exception will be
         re-raised to the caller.
 
@@ -536,21 +524,21 @@ class IOLoop(Configurable):
         a maximum duration for the function.  If the timeout expires,
         a `tornado.util.TimeoutError` is raised.
 
-        This method is useful in conjunction with `tornado.gen.coroutine`
-        to allow asynchronous calls in a ``main()`` function::
+        This method is useful to allow asynchronous calls in a
+        ``main()`` function::
 
-            @gen.coroutine
-            def main():
+            async def main():
                 # do stuff...
 
             if __name__ == '__main__':
                 IOLoop.current().run_sync(main)
 
         .. versionchanged:: 4.3
-           Returning a non-``None``, non-yieldable value is now an error.
+           Returning a non-``None``, non-awaitable value is now an error.
 
         .. versionchanged:: 5.0
            If a timeout occurs, the ``func`` coroutine will be cancelled.
+
         """
         future_cell = [None]
 
@@ -720,6 +708,10 @@ class IOLoop(Configurable):
 
         The callback is invoked with one argument, the
         `.Future`.
+
+        This method only accepts `.Future` objects and not other
+        awaitables (unlike most of Tornado where the two are
+        interchangeable).
         """
         assert is_future(future)
         callback = stack_context.wrap(callback)

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1190,24 +1190,23 @@ class IOStream(BaseIOStream):
         import tornado.iostream
         import socket
 
-        def send_request():
-            stream.write(b"GET / HTTP/1.0\r\nHost: friendfeed.com\r\n\r\n")
-            stream.read_until(b"\r\n\r\n", on_headers)
-
-        def on_headers(data):
+        async def main():
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+            stream = tornado.iostream.IOStream(s)
+            await stream.connect(("friendfeed.com", 80))
+            await stream.write(b"GET / HTTP/1.0\r\nHost: friendfeed.com\r\n\r\n")
+            header_data = await stream.read_until(b"\r\n\r\n")
             headers = {}
-            for line in data.split(b"\r\n"):
-               parts = line.split(b":")
-               if len(parts) == 2:
-                   headers[parts[0].strip()] = parts[1].strip()
-            stream.read_bytes(int(headers[b"Content-Length"]), on_body)
-
-        def on_body(data):
-            print(data)
+            for line in header_data.split(b"\r\n"):
+                parts = line.split(b":")
+                if len(parts) == 2:
+                    headers[parts[0].strip()] = parts[1].strip()
+            body_data = await stream.read_bytes(int(headers[b"Content-Length"]))
+            print(body_data)
             stream.close()
-            tornado.ioloop.IOLoop.current().stop()
 
         if __name__ == '__main__':
+            tornado.ioloop.IOLoop.current().run_sync(main)
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
             stream = tornado.iostream.IOStream(s)
             stream.connect(("friendfeed.com", 80), send_request)

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -61,22 +61,19 @@ class Condition(_TimeoutGarbageCollector):
 
         condition = Condition()
 
-        @gen.coroutine
-        def waiter():
+        async def waiter():
             print("I'll wait right here")
-            yield condition.wait()  # Yield a Future.
+            await condition.wait()
             print("I'm done waiting")
 
-        @gen.coroutine
-        def notifier():
+        async def notifier():
             print("About to notify")
             condition.notify()
             print("Done notifying")
 
-        @gen.coroutine
-        def runner():
-            # Yield two Futures; wait for waiter() and notifier() to finish.
-            yield [waiter(), notifier()]
+        async def runner():
+            # Wait for waiter() and notifier() in parallel
+            await gen.multi([waiter(), notifier()])
 
         IOLoop.current().run_sync(runner)
 
@@ -93,12 +90,12 @@ class Condition(_TimeoutGarbageCollector):
         io_loop = IOLoop.current()
 
         # Wait up to 1 second for a notification.
-        yield condition.wait(timeout=io_loop.time() + 1)
+        await condition.wait(timeout=io_loop.time() + 1)
 
     ...or a `datetime.timedelta` for a timeout relative to the current time::
 
         # Wait up to 1 second.
-        yield condition.wait(timeout=datetime.timedelta(seconds=1))
+        await condition.wait(timeout=datetime.timedelta(seconds=1))
 
     The method returns False if there's no notification before the deadline.
 
@@ -170,22 +167,19 @@ class Event(object):
 
         event = Event()
 
-        @gen.coroutine
-        def waiter():
+        async def waiter():
             print("Waiting for event")
-            yield event.wait()
+            await event.wait()
             print("Not waiting this time")
-            yield event.wait()
+            await event.wait()
             print("Done")
 
-        @gen.coroutine
-        def setter():
+        async def setter():
             print("About to set the event")
             event.set()
 
-        @gen.coroutine
-        def runner():
-            yield [waiter(), setter()]
+        async def runner():
+            await gen.multi([waiter(), setter()])
 
         IOLoop.current().run_sync(runner)
 
@@ -290,12 +284,11 @@ class Semaphore(_TimeoutGarbageCollector):
        # Ensure reliable doctest output: resolve Futures one at a time.
        futures_q = deque([Future() for _ in range(3)])
 
-       @gen.coroutine
-       def simulator(futures):
+       async def simulator(futures):
            for f in futures:
                # simulate the asynchronous passage of time
-               yield gen.moment
-               yield gen.moment
+               await gen.sleep(0)
+               await gen.sleep(0)
                f.set_result(None)
 
        IOLoop.current().add_callback(simulator, list(futures_q))
@@ -311,20 +304,18 @@ class Semaphore(_TimeoutGarbageCollector):
 
         sem = Semaphore(2)
 
-        @gen.coroutine
-        def worker(worker_id):
-            yield sem.acquire()
+        async def worker(worker_id):
+            await sem.acquire()
             try:
                 print("Worker %d is working" % worker_id)
-                yield use_some_resource()
+                await use_some_resource()
             finally:
                 print("Worker %d is done" % worker_id)
                 sem.release()
 
-        @gen.coroutine
-        def runner():
+        async def runner():
             # Join all workers.
-            yield [worker(i) for i in range(3)]
+            await gen.multi([worker(i) for i in range(3)])
 
         IOLoop.current().run_sync(runner)
 
@@ -340,7 +331,18 @@ class Semaphore(_TimeoutGarbageCollector):
     Workers 0 and 1 are allowed to run concurrently, but worker 2 waits until
     the semaphore has been released once, by worker 0.
 
-    `.acquire` is a context manager, so ``worker`` could be written as::
+    The semaphore can be used as an async context manager::
+
+        async def worker(worker_id):
+            async with sem:
+                print("Worker %d is working" % worker_id)
+                await use_some_resource()
+
+            # Now the semaphore has been released.
+            print("Worker %d is done" % worker_id)
+
+    For compatibility with older versions of Python, `.acquire` is a
+    context manager, so ``worker`` could also be written as::
 
         @gen.coroutine
         def worker(worker_id):
@@ -351,19 +353,9 @@ class Semaphore(_TimeoutGarbageCollector):
             # Now the semaphore has been released.
             print("Worker %d is done" % worker_id)
 
-    In Python 3.5, the semaphore itself can be used as an async context
-    manager::
-
-        async def worker(worker_id):
-            async with sem:
-                print("Worker %d is working" % worker_id)
-                await use_some_resource()
-
-            # Now the semaphore has been released.
-            print("Worker %d is done" % worker_id)
-
     .. versionchanged:: 4.3
        Added ``async with`` support in Python 3.5.
+
     """
     def __init__(self, value=1):
         super(Semaphore, self).__init__()
@@ -464,26 +456,24 @@ class Lock(object):
 
     Releasing an unlocked lock raises `RuntimeError`.
 
-    `acquire` supports the context manager protocol in all Python versions:
+    A Lock can be used as an async context manager with the ``async
+    with`` statement:
 
     >>> from tornado import gen, locks
     >>> lock = locks.Lock()
     >>>
-    >>> @gen.coroutine
-    ... def f():
-    ...    with (yield lock.acquire()):
+    >>> async def f():
+    ...    async with lock:
     ...        # Do something holding the lock.
     ...        pass
     ...
     ...    # Now the lock is released.
 
-    In Python 3.5, `Lock` also supports the async context manager
-    protocol. Note that in this case there is no `acquire`, because
-    ``async with`` includes both the ``yield`` and the ``acquire``
-    (just as it does with `threading.Lock`):
+    For compatibility with older versions of Python, the `.acquire`
+    method asynchronously returns a regular context manager:
 
-    >>> async def f2():  # doctest: +SKIP
-    ...    async with lock:
+    >>> async def f2():
+    ...    with (yield lock.acquire()):
     ...        # Do something holding the lock.
     ...        pass
     ...

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -46,12 +46,11 @@ class TCPServer(object):
       from tornado import gen
 
       class EchoServer(TCPServer):
-          @gen.coroutine
-          def handle_stream(self, stream, address):
+          async def handle_stream(self, stream, address):
               while True:
                   try:
-                      data = yield stream.read_until(b"\n")
-                      yield stream.write(data)
+                      data = await stream.read_until(b"\n")
+                      await stream.write(data)
                   except StreamClosedError:
                       break
 

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -59,32 +59,33 @@ class MiscFutureTest(AsyncTestCase):
 
 
 class ReturnFutureTest(AsyncTestCase):
-    @return_future
-    def sync_future(self, callback):
-        callback(42)
+    with ignore_deprecation():
+        @return_future
+        def sync_future(self, callback):
+            callback(42)
 
-    @return_future
-    def async_future(self, callback):
-        self.io_loop.add_callback(callback, 42)
+        @return_future
+        def async_future(self, callback):
+            self.io_loop.add_callback(callback, 42)
 
-    @return_future
-    def immediate_failure(self, callback):
-        1 / 0
+        @return_future
+        def immediate_failure(self, callback):
+            1 / 0
 
-    @return_future
-    def delayed_failure(self, callback):
-        self.io_loop.add_callback(lambda: 1 / 0)
+        @return_future
+        def delayed_failure(self, callback):
+            self.io_loop.add_callback(lambda: 1 / 0)
 
-    @return_future
-    def return_value(self, callback):
-        # Note that the result of both running the callback and returning
-        # a value (or raising an exception) is unspecified; with current
-        # implementations the last event prior to callback resolution wins.
-        return 42
+        @return_future
+        def return_value(self, callback):
+            # Note that the result of both running the callback and returning
+            # a value (or raising an exception) is unspecified; with current
+            # implementations the last event prior to callback resolution wins.
+            return 42
 
-    @return_future
-    def no_result_future(self, callback):
-        callback()
+        @return_future
+        def no_result_future(self, callback):
+            callback()
 
     def test_immediate_failure(self):
         with self.assertRaises(ZeroDivisionError):
@@ -151,9 +152,10 @@ class ReturnFutureTest(AsyncTestCase):
             future.result()
 
     def test_kw_only_callback(self):
-        @return_future
-        def f(**kwargs):
-            kwargs['callback'](42)
+        with ignore_deprecation():
+            @return_future
+            def f(**kwargs):
+                kwargs['callback'](42)
         future = f()
         self.assertEqual(future.result(), 42)
 
@@ -307,14 +309,15 @@ class ManualCapClient(BaseCapClient):
 
 
 class DecoratorCapClient(BaseCapClient):
-    @return_future
-    def capitalize(self, request_data, callback):
-        logging.debug("capitalize")
-        self.request_data = request_data
-        self.stream = IOStream(socket.socket())
-        self.stream.connect(('127.0.0.1', self.port),
-                            callback=self.handle_connect)
-        self.callback = callback
+    with ignore_deprecation():
+        @return_future
+        def capitalize(self, request_data, callback):
+            logging.debug("capitalize")
+            self.request_data = request_data
+            self.stream = IOStream(socket.socket())
+            self.stream.connect(('127.0.0.1', self.port),
+                                callback=self.handle_connect)
+            self.callback = callback
 
     def handle_connect(self):
         logging.debug("handle_connect")

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -68,9 +68,10 @@ class GenEngineTest(AsyncTestCase):
             self.io_loop.add_callback(functools.partial(
                 self.delay_callback, iterations - 1, callback, arg))
 
-    @return_future
-    def async_future(self, result, callback):
-        self.io_loop.add_callback(callback, result)
+    with ignore_deprecation():
+        @return_future
+        def async_future(self, result, callback):
+            self.io_loop.add_callback(callback, result)
 
     @gen.coroutine
     def async_exception(self, e):
@@ -678,9 +679,10 @@ class GenBasicTest(AsyncTestCase):
             yield gen.moment
         raise gen.Return(arg)
 
-    @return_future
-    def async_future(self, result, callback):
-        self.io_loop.add_callback(callback, result)
+    with ignore_deprecation():
+        @return_future
+        def async_future(self, result, callback):
+            self.io_loop.add_callback(callback, result)
 
     @gen.coroutine
     def async_exception(self, e):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -144,15 +144,16 @@ class AsyncTestCase(unittest.TestCase):
     asynchronous code.
 
     The unittest framework is synchronous, so the test must be
-    complete by the time the test method returns.  This means that
-    asynchronous code cannot be used in quite the same way as usual.
-    To write test functions that use the same ``yield``-based patterns
-    used with the `tornado.gen` module, decorate your test methods
-    with `tornado.testing.gen_test` instead of
-    `tornado.gen.coroutine`.  This class also provides the `stop()`
-    and `wait()` methods for a more manual style of testing.  The test
-    method itself must call ``self.wait()``, and asynchronous
-    callbacks should call ``self.stop()`` to signal completion.
+    complete by the time the test method returns. This means that
+    asynchronous code cannot be used in quite the same way as usual
+    and must be adapted to fit. To write your tests with coroutines,
+    decorate your test methods with `tornado.testing.gen_test` instead
+    of `tornado.gen.coroutine`.
+
+    This class also provides the (deprecated) `stop()` and `wait()`
+    methods for a more manual style of testing. The test method itself
+    must call ``self.wait()``, and asynchronous callbacks should call
+    ``self.stop()`` to signal completion.
 
     By default, a new `.IOLoop` is constructed for each test and is available
     as ``self.io_loop``.  If the code being tested requires a
@@ -183,22 +184,6 @@ class AsyncTestCase(unittest.TestCase):
                 response = self.wait()
                 # Test contents of response
                 self.assertIn("FriendFeed", response.body)
-
-        # This test uses an explicit callback-based style.
-        class MyTestCase3(AsyncTestCase):
-            def test_http_fetch(self):
-                client = AsyncHTTPClient()
-                client.fetch("http://www.tornadoweb.org/", self.handle_fetch)
-                self.wait()
-
-            def handle_fetch(self, response):
-                # Test contents of response (failures and exceptions here
-                # will cause self.wait() to throw an exception and end the
-                # test).
-                # Exceptions thrown here are magically propagated to
-                # self.wait() in test_http_fetch() via stack_context.
-                self.assertIn("FriendFeed", response.body)
-                self.stop()
     """
     def __init__(self, methodName='runTest'):
         super(AsyncTestCase, self).__init__(methodName)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -946,6 +946,11 @@ class RequestHandler(object):
 
         .. versionchanged:: 4.0
            Now returns a `.Future` if no callback is given.
+
+        .. deprecated:: 5.1
+
+           The ``callback`` argument is deprecated and will be removed in
+           Tornado 6.0.
         """
         chunk = b"".join(self._write_buffer)
         self._write_buffer = []

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ envlist =
         py3-sphinx-docs,
         # Run the doctests via sphinx (which covers things not run
         # in the regular test suite and vice versa)
-        {py2,py3}-sphinx-doctest,
+        py3-sphinx-doctest,
 
         py3-lint
 
@@ -143,16 +143,10 @@ setenv = TORNADO_EXTENSION=0
 commands =
     sphinx-build -q -E -n -W -b html . {envtmpdir}/html
 
-[testenv:py2-sphinx-doctest]
-changedir = docs
-setenv = TORNADO_EXTENSION=0
-# No -W for doctests because that disallows tests with empty output.
-commands =
-     sphinx-build -q -E -n -b doctest . {envtmpdir}/doctest
-
 [testenv:py3-sphinx-doctest]
 changedir = docs
 setenv = TORNADO_EXTENSION=0
+# No -W for doctests because that disallows tests with empty output.
 commands =
      sphinx-build -q -E -n -b doctest . {envtmpdir}/doctest
 


### PR DESCRIPTION
Update examples to modern interfaces.

Fully deprecate concurrent.return_future.