### PR TITLE
iostream,netutil: Ignore ENOPROTOOPT errors from SO_REUSEADDR or SO_ERROR

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1413,8 +1413,9 @@ class IOStream(BaseIOStream):
         try:
             err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
         except socket.error as e:
-            err = e.args[0]
-            if err == errno.ENOPROTOOPT:
+            # Hurd doesn't allow SO_ERROR for loopback sockets because all
+            # errors for such sockets are reported synchronously.
+            if errno_from_exception(e) == errno.ENOPROTOOPT:
                 err = 0
         if err != 0:
             self.error = socket.error(err, os.strerror(err))

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1410,7 +1410,12 @@ class IOStream(BaseIOStream):
         return future
 
     def _handle_connect(self):
-        err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+        try:
+            err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+        except socket.error as e:
+            err = e.args[0]
+            if err == errno.ENOPROTOOPT:
+                err = 0
         if err != 0:
             self.error = socket.error(err, os.strerror(err))
             # IOLoop implementations may vary: some of them return

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -138,9 +138,17 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC,
             raise
         set_close_exec(sock.fileno())
         if os.name != 'nt':
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            except socket.error as e:
+                if e.args[0] != errno.ENOPROTOOPT:
+                    raise
         if reuse_port:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            except socket.error as e:
+                if e.args[0] != errno.ENOPROTOOPT:
+                    raise
         if af == socket.AF_INET6:
             # On linux, ipv6 sockets accept ipv4 too by default,
             # but this makes it impossible to bind to both
@@ -180,7 +188,11 @@ if hasattr(socket, 'AF_UNIX'):
         """
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         set_close_exec(sock.fileno())
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        except socket.error as e:
+            if e.args[0] != errno.ENOPROTOOPT:
+                raise
         sock.setblocking(0)
         try:
             st = os.stat(file)

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -141,14 +141,11 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC,
             try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             except socket.error as e:
-                if e.args[0] != errno.ENOPROTOOPT:
+                if errno_from_exception(e) != errno.ENOPROTOOPT:
+                    # Hurd doesn't support SO_REUSEADDR.
                     raise
         if reuse_port:
-            try:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-            except socket.error as e:
-                if e.args[0] != errno.ENOPROTOOPT:
-                    raise
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         if af == socket.AF_INET6:
             # On linux, ipv6 sockets accept ipv4 too by default,
             # but this makes it impossible to bind to both
@@ -191,7 +188,8 @@ if hasattr(socket, 'AF_UNIX'):
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         except socket.error as e:
-            if e.args[0] != errno.ENOPROTOOPT:
+            if errno_from_exception(e) != errno.ENOPROTOOPT:
+                # Hurd doesn't support SO_REUSEADDR
                 raise
         sock.setblocking(0)
         try:


### PR DESCRIPTION
Closes #2353 