### PR TITLE
Add abspath for __file__

### DIFF
--- a/docs/guide/running.rst
+++ b/docs/guide/running.rst
@@ -156,7 +156,7 @@ You can serve static files from Tornado by specifying the
 ``static_path`` setting in your application::
 
     settings = {
-        "static_path": os.path.join(os.path.dirname(__file__), "static"),
+        "static_path": os.path.join(os.path.dirname(os.path.abspath(__file__)), "static"),
         "cookie_secret": "__TODO:_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__",
         "login_url": "/login",
         "xsrf_cookies": True,


### PR DESCRIPTION
In some cases os.path.dirname(__file__) returns relative path instead of absolute path which causes problems.