### PR TITLE
_HTTPConnection: check location on _should_follow_redirect() and retain safe request when following redirects

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -491,9 +491,17 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             self.request.header_callback('\r\n')
 
     def _should_follow_redirect(self):
-        return (self.request.follow_redirects and
+        if not (self.request.follow_redirects and
                 self.request.max_redirects > 0 and
-                self.code in (301, 302, 303, 307, 308))
+                self.code in (301, 302, 303, 307, 308)):
+            return False
+        # http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4
+        # According to the spec, the temporary URI may not be specified when the
+        # request method was HEAD.
+        # TODO: Unless the request method was HEAD, give a warning or raise an
+        # exception when the temporary URI is not specified?
+        redirect_location = self.headers.get("Location")
+        return (redirect_location is not None)
 
     def finish(self):
         data = b''.join(self.chunks)
@@ -515,7 +523,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             # compatibility with pre-HTTP/1.1 user agents which don't
             # understand the 303 status.
             if self.code in (302, 303):
-                new_request.method = "GET"
+                if self.request.method != "HEAD":
+                    new_request.method = "GET"
                 new_request.body = None
                 for h in ["Content-Length", "Content-Type",
                           "Content-Encoding", "Transfer-Encoding"]:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -209,7 +209,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
 
 class _HTTPConnection(httputil.HTTPMessageDelegate):
     _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-    _SAFE_NETHODS = set(["GET", "HEAD", "OPTIONS"])
+    _SAFE_METHODS = set(["GET", "HEAD", "OPTIONS"])
 
     def __init__(self, client, request, release_callback,
                  final_callback, max_buffer_size, tcp_client,
@@ -517,7 +517,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             # compatibility with pre-HTTP/1.1 user agents which don't
             # understand the 303 status.
             if self.code in (301, 302, 303):
-                if self.request.method not in self._SAFE_NETHODS:
+                if self.request.method not in self._SAFE_METHODS:
                     new_request.method = "GET"
                 new_request.body = None
                 for h in ["Content-Length", "Content-Type",


### PR DESCRIPTION
1. http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3
According to the spec, the temporary URI may not be specified when the request method was HEAD.
**while check _should_follow_redirect(), doesn't verify whether location is specified.**
https://github.com/tornadoweb/tornado/blob/9bb6463c07b11c6f58ee52fb59bb97ba9217c652/tornado/simple_httpclient.py#L493-L496

2.  **AsyncHTTPClient always use GET method on following redirects**：
https://github.com/tornadoweb/tornado/blob/9bb6463c07b11c6f58ee52fb59bb97ba9217c652/tornado/simple_httpclient.py#L517-L518

    **but while use CURL with HEAD method, CURL will also use HEAD method on following redirects:**
```
# curl -v -L --head http://172.18.231.164:9999/test
* Hostname was NOT found in DNS cache
*   Trying 172.18.231.164...
* Connected to 172.18.231.164 (172.18.231.164) port 9999 (#0)
> HEAD /test HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 172.18.231.164:9999
> Accept: */*
> 
< HTTP/1.1 302 Found
HTTP/1.1 302 Found
< Location: /dest
Location: /dest
* Server TornadoServer/5.0.2 is not blacklisted
< Server: TornadoServer/5.0.2
Server: TornadoServer/5.0.2
< Content-Length: 0
Content-Length: 0
< Content-Type: text/html; charset=UTF-8
Content-Type: text/html; charset=UTF-8
< Date: Fri, 01 Jun 2018 11:21:35 GMT
Date: Fri, 01 Jun 2018 11:21:35 GMT

< 
* Connection #0 to host 172.18.231.164 left intact
* Issue another request to this URL: 'http://172.18.231.164:9999/dest'
* Found bundle for host 172.18.231.164: 0xba18f0
* Re-using existing connection! (#0) with host 172.18.231.164
* Connected to 172.18.231.164 (172.18.231.164) port 9999 (#0)
> HEAD /dest HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 172.18.231.164:9999
> Accept: */*
> 
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Content-Length: 10
Content-Length: 10
* Server TornadoServer/5.0.2 is not blacklisted
< Server: TornadoServer/5.0.2
Server: TornadoServer/5.0.2
< Etag: "9c0e5ce7f4b8696ea9ab7095b94bb717d09718a9"
Etag: "9c0e5ce7f4b8696ea9ab7095b94bb717d09718a9"
< Content-Type: text/html; charset=UTF-8
Content-Type: text/html; charset=UTF-8
< Date: Fri, 01 Jun 2018 11:21:35 GMT
Date: Fri, 01 Jun 2018 11:21:35 GMT

< 
* Connection #0 to host 172.18.231.164 left intact
```

