### PR TITLE
Revert "_HTTPConnection: check location on _should_follow_redirect() …

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -210,7 +210,6 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
 
 class _HTTPConnection(httputil.HTTPMessageDelegate):
     _SUPPORTED_METHODS = set(["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-    _SAFE_METHODS = set(["GET", "HEAD", "OPTIONS"])
 
     def __init__(self, client, request, release_callback,
                  final_callback, max_buffer_size, tcp_client,
@@ -497,8 +496,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
     def _should_follow_redirect(self):
         return (self.request.follow_redirects and
                 self.request.max_redirects > 0 and
-                self.code in (301, 302, 303, 307, 308) and
-                self.headers.get("Location") is not None)
+                self.code in (301, 302, 303, 307, 308))
 
     def finish(self):
         data = b''.join(self.chunks)
@@ -519,9 +517,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             # treat 302 the same as 303, and many servers use 302 for
             # compatibility with pre-HTTP/1.1 user agents which don't
             # understand the 303 status.
-            if self.code in (301, 302, 303):
-                if self.request.method not in self._SAFE_METHODS:
-                    new_request.method = "GET"
+            if self.code in (302, 303):
+                new_request.method = "GET"
                 new_request.body = None
                 for h in ["Content-Length", "Content-Type",
                           "Content-Encoding", "Transfer-Encoding"]:


### PR DESCRIPTION
…and retain safe request when following redirects (#2409)"

This reverts commit 859a038eb9c1af99d3871c9972f0826a1d05475d.

This commit was merged after the release of 5.1b1 with insufficient
consideration and testing. I'll bring this back in the 6.0 cycle with
a test.

FYI @garenchan 

Original PR was #2409 