### PR TITLE
httpclient: Validate redirect location header and method

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -390,7 +390,10 @@ class HTTP1Connection(httputil.HTTPConnection):
             self._chunking_output = (
                 start_line.method in ("POST", "PUT", "PATCH")
                 and "Content-Length" not in headers
-                and "Transfer-Encoding" not in headers
+                and (
+                    "Transfer-Encoding" not in headers
+                    or headers["Transfer-Encoding"] == "chunked"
+                )
             )
         else:
             assert isinstance(start_line, httputil.ResponseStartLine)

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -608,6 +608,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             return (
                 self.code in (301, 302, 303, 307, 308)
                 and self.request.max_redirects > 0
+                and self.headers is not None
+                and self.headers.get("Location") is not None
             )
         return False
 

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -307,6 +307,21 @@ Transfer-Encoding: chunked
         # don't either).
         self.assertEqual(301, response.code)
 
+    def test_redirect_put_with_body(self):
+        response = self.fetch(
+            "/redirect?url=/put&status=307", method="PUT", body="hello"
+        )
+        self.assertEqual(response.body, b"Put body: hello")
+
+    def test_redirect_put_without_body(self):
+        # This "without body" edge case is similar to what happens with body_producer.
+        response = self.fetch(
+            "/redirect?url=/put&status=307",
+            method="PUT",
+            allow_nonstandard_methods=True,
+        )
+        self.assertEqual(response.body, b"Put body: ")
+
     def test_credentials_in_url(self):
         url = self.get_url("/auth").replace("http://", "http://me:secret@")
         response = self.fetch(url)


### PR DESCRIPTION
This is a second attempt at #2409, which was reverted in #2439 because it was merged too close to 5.1's release. This should have a test added (to verify that the behavior is consistent between simple and curl clients) before it is merged. 