### PR TITLE
fix issue #2438: clear input in demo projects

### DIFF
--- a/demos/websocket/templates/index.html
+++ b/demos/websocket/templates/index.html
@@ -16,7 +16,7 @@
         <form action="/a/message/new" method="post" id="messageform">
           <table>
             <tr>
-              <td><input name="body" id="message" style="width:500px"></td>
+              <td><input type="text" name="body" id="message" style="width:500px"></td>
               <td style="padding-left:5px">
                 <input type="submit" value="{{ _("Post") }}">
                 <input type="hidden" name="next" value="{{ request.path }}">


### PR DESCRIPTION
The **websocket** demo is useful for new newcomers. 

But is has a bug as #2438 said: after send message, not clear input and focus on it!

@bdarnell, may be it too trivial?

