### PR TITLE
Add/update mypy annotations for util, httputil, escape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
     # version supported. But Python 3.7 requires slower-to-start VMs,
     # so we run it on 3.6 to minimize total CI run time.
     - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8 mypy; fi
     # On travis the extension should always be built
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi
     - travis_retry python setup.py install
@@ -91,9 +91,10 @@ script:
     # make coverage reports for Codecov to find
     - if [[ "$RUN_COVERAGE" == 1 ]]; then coverage xml; fi
     - export TORNADO_EXTENSION=0
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then cd .. && flake8; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then (cd ../docs && mkdir sphinx-out && sphinx-build -E -n -W -b html . sphinx-out); fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then (cd ../docs && mkdir sphinx-doctest-out && sphinx-build -E -n -b doctest . sphinx-out); fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then (cd .. && flake8); fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then (cd .. && mypy tornado); fi
 
 after_success:
     # call codecov from project root

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ disallow_untyped_defs = True
 
 [mypy-tornado.httputil]
 disallow_untyped_defs = True
+
+[mypy-tornado.escape]
+disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ python_version = 3.5
 
 [mypy-tornado.util]
 disallow_untyped_defs = True
+
+[mypy-tornado.httputil]
+disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.5
+
+[mypy-tornado.util]
+disallow_untyped_defs = True

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -93,7 +93,7 @@ from tornado.util import exec_in
 try:
     import signal
 except ImportError:
-    signal = None
+    signal = None  # type: ignore
 
 # os.execv is broken on Windows and can't properly parse command line
 # arguments and executable name if they contain whitespaces. subprocess

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -26,7 +26,8 @@ import urllib.parse
 
 from tornado.util import unicode_type, basestring_type
 
-import typing  # noqa
+import typing
+from typing import Union, Any, Optional, Dict, List, Callable
 
 
 _XHTML_ESCAPE_RE = re.compile('[&<>"\']')
@@ -34,7 +35,7 @@ _XHTML_ESCAPE_DICT = {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;',
                       '\'': '&#39;'}
 
 
-def xhtml_escape(value):
+def xhtml_escape(value: Union[str, bytes]) -> str:
     """Escapes a string so it is valid within HTML or XML.
 
     Escapes the characters ``<``, ``>``, ``"``, ``'``, and ``&``.
@@ -49,7 +50,7 @@ def xhtml_escape(value):
                                 to_basestring(value))
 
 
-def xhtml_unescape(value):
+def xhtml_unescape(value: Union[str, bytes]) -> str:
     """Un-escapes an XML-escaped string."""
     return re.sub(r"&(#?)(\w+?);", _convert_entity, _unicode(value))
 
@@ -57,7 +58,7 @@ def xhtml_unescape(value):
 # The fact that json_encode wraps json.dumps is an implementation detail.
 # Please see https://github.com/tornadoweb/tornado/pull/706
 # before sending a pull request that adds **kwargs to this function.
-def json_encode(value):
+def json_encode(value: Any) -> str:
     """JSON-encodes the given Python object."""
     # JSON permits but does not require forward slashes to be escaped.
     # This is useful when json data is emitted in a <script> tag
@@ -68,17 +69,17 @@ def json_encode(value):
     return json.dumps(value).replace("</", "<\\/")
 
 
-def json_decode(value):
+def json_decode(value: Union[str, bytes]) -> Any:
     """Returns Python objects for the given JSON string."""
     return json.loads(to_basestring(value))
 
 
-def squeeze(value):
+def squeeze(value: str) -> str:
     """Replace all sequences of whitespace chars with a single space."""
     return re.sub(r"[\x00-\x20]+", " ", value).strip()
 
 
-def url_escape(value, plus=True):
+def url_escape(value: Union[str, bytes], plus: bool=True) -> str:
     """Returns a URL-encoded version of the given value.
 
     If ``plus`` is true (the default), spaces will be represented
@@ -93,7 +94,18 @@ def url_escape(value, plus=True):
     return quote(utf8(value))
 
 
-def url_unescape(value, encoding='utf-8', plus=True):
+@typing.overload
+def url_unescape(value: Union[str, bytes], encoding: None, plus: bool=True) -> bytes:
+    pass
+
+
+@typing.overload  # noqa: F811
+def url_unescape(value: Union[str, bytes], encoding: str='utf-8', plus: bool=True) -> str:
+    pass
+
+
+def url_unescape(value: Union[str, bytes], encoding: Optional[str]='utf-8',  # noqa: F811
+                 plus: bool=True) -> Union[str, bytes]:
     """Decodes the given value from a URL.
 
     The argument may be either a byte or unicode string.
@@ -121,7 +133,8 @@ def url_unescape(value, encoding='utf-8', plus=True):
         return unquote(to_basestring(value), encoding=encoding)
 
 
-def parse_qs_bytes(qs, keep_blank_values=False, strict_parsing=False):
+def parse_qs_bytes(qs: str, keep_blank_values: bool=False,
+                   strict_parsing: bool=False) -> Dict[str, List[bytes]]:
     """Parses a query string like urlparse.parse_qs, but returns the
     values as byte strings.
 
@@ -157,7 +170,7 @@ def utf8(value: None) -> None:
     pass
 
 
-def utf8(value):  # noqa: F811
+def utf8(value: Union[None, str, bytes]) -> Optional[bytes]:  # noqa: F811
     """Converts a string argument to a byte string.
 
     If the argument is already a byte string or None, it is returned unchanged.
@@ -175,7 +188,22 @@ def utf8(value):  # noqa: F811
 _TO_UNICODE_TYPES = (unicode_type, type(None))
 
 
-def to_unicode(value):
+@typing.overload
+def to_unicode(value: str) -> str:
+    pass
+
+
+@typing.overload  # noqa: F811
+def to_unicode(value: bytes) -> str:
+    pass
+
+
+@typing.overload  # noqa: F811
+def to_unicode(value: None) -> None:
+    pass
+
+
+def to_unicode(value: Union[None, str, bytes]) -> Optional[str]:  # noqa: F811
     """Converts a string argument to a unicode string.
 
     If the argument is already a unicode string or None, it is returned
@@ -201,7 +229,22 @@ native_str = to_unicode
 _BASESTRING_TYPES = (basestring_type, type(None))
 
 
-def to_basestring(value):
+@typing.overload
+def to_basestring(value: str) -> str:
+    pass
+
+
+@typing.overload  # noqa: F811
+def to_basestring(value: bytes) -> str:
+    pass
+
+
+@typing.overload  # noqa: F811
+def to_basestring(value: None) -> None:
+    pass
+
+
+def to_basestring(value: Union[None, str, bytes]) -> Optional[str]:  # noqa: F811
     """Converts a string argument to a subclass of basestring.
 
     In python2, byte and unicode strings are mostly interchangeable,
@@ -219,7 +262,7 @@ def to_basestring(value):
     return value.decode("utf-8")
 
 
-def recursive_unicode(obj):
+def recursive_unicode(obj: Any) -> Any:
     """Walks a simple data structure, converting byte strings to unicode.
 
     Supports lists, tuples, and dictionaries.
@@ -248,8 +291,9 @@ _URL_RE = re.compile(to_unicode(
 ))
 
 
-def linkify(text, shorten=False, extra_params="",
-            require_protocol=False, permitted_protocols=["http", "https"]):
+def linkify(text: Union[str, bytes], shorten: bool=False,
+            extra_params: Union[str, Callable[[str], str]]="",
+            require_protocol: bool=False, permitted_protocols: List[str]=["http", "https"]) -> str:
     """Converts plain text into HTML with links.
 
     For example: ``linkify("Hello http://tornadoweb.org!")`` would return
@@ -282,7 +326,7 @@ def linkify(text, shorten=False, extra_params="",
     if extra_params and not callable(extra_params):
         extra_params = " " + extra_params.strip()
 
-    def make_link(m):
+    def make_link(m: typing.Match) -> str:
         url = m.group(1)
         proto = m.group(2)
         if require_protocol and not proto:
@@ -344,7 +388,7 @@ def linkify(text, shorten=False, extra_params="",
     return _URL_RE.sub(make_link, text)
 
 
-def _convert_entity(m):
+def _convert_entity(m: typing.Match) -> str:
     if m.group(1) == "#":
         try:
             if m.group(2)[:1].lower() == 'x':
@@ -359,7 +403,7 @@ def _convert_entity(m):
         return "&%s;" % m.group(2)
 
 
-def _build_unicode_map():
+def _build_unicode_map() -> Dict[str, str]:
     unicode_map = {}
     for name, value in html.entities.name2codepoint.items():
         unicode_map[name] = chr(value)

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -142,8 +142,22 @@ def parse_qs_bytes(qs, keep_blank_values=False, strict_parsing=False):
 _UTF8_TYPES = (bytes, type(None))
 
 
-def utf8(value):
-    # type: (typing.Union[bytes,unicode_type,None])->typing.Union[bytes,None]
+@typing.overload
+def utf8(value: bytes) -> bytes:
+    pass
+
+
+@typing.overload  # noqa: F811
+def utf8(value: str) -> bytes:
+    pass
+
+
+@typing.overload  # noqa: F811
+def utf8(value: None) -> None:
+    pass
+
+
+def utf8(value):  # noqa: F811
     """Converts a string argument to a byte string.
 
     If the argument is already a byte string or None, it is returned unchanged.

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -45,6 +45,8 @@ from tornado.concurrent import Future, is_future, chain_future, future_set_exc_i
 from tornado.log import app_log
 from tornado.util import Configurable, TimeoutError, unicode_type, import_object
 
+import typing  # noqa
+
 
 class IOLoop(Configurable):
     """A level-triggered I/O loop.
@@ -135,7 +137,7 @@ class IOLoop(Configurable):
     ERROR = 0x018
 
     # In Python 3, _ioloop_for_asyncio maps from asyncio loops to IOLoops.
-    _ioloop_for_asyncio = dict()
+    _ioloop_for_asyncio = dict()  # type: typing.Dict[typing.Any, typing.Any]
 
     @classmethod
     def configure(cls, impl, **kwargs):

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -42,7 +42,7 @@ from tornado.util import errno_from_exception
 try:
     from tornado.platform.posix import _set_nonblocking
 except ImportError:
-    _set_nonblocking = None
+    _set_nonblocking = None  # type: ignore
 
 # These errnos indicate that a non-blocking operation must be retried
 # at a later time.  On most platforms they're the same value, but on

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -35,14 +35,14 @@ from tornado.escape import _unicode
 from tornado.util import unicode_type, basestring_type
 
 try:
-    import colorama
+    import colorama  # type: ignore
 except ImportError:
     colorama = None
 
 try:
     import curses  # type: ignore
 except ImportError:
-    curses = None
+    curses = None  # type: ignore
 
 # Logger objects for internal tornado use
 access_log = logging.getLogger("tornado.access")

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -268,7 +268,7 @@ def to_asyncio_future(tornado_future):
     return convert_yielded(tornado_future)
 
 
-class AnyThreadEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+class AnyThreadEventLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore
     """Event loop policy that allows loop creation on any thread.
 
     The default `asyncio` event loop policy only automatically creates

--- a/tornado/platform/windows.py
+++ b/tornado/platform/windows.py
@@ -1,11 +1,11 @@
 # NOTE: win32 support is currently experimental, and not recommended
 # for production use.
 
-import ctypes  # type: ignore
-import ctypes.wintypes  # type: ignore
+import ctypes
+import ctypes.wintypes
 
 # See: http://msdn.microsoft.com/en-us/library/ms724935(VS.85).aspx
-SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation
+SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation  # type: ignore
 SetHandleInformation.argtypes = (ctypes.wintypes.HANDLE, ctypes.wintypes.DWORD, ctypes.wintypes.DWORD)  # noqa: E501
 SetHandleInformation.restype = ctypes.wintypes.BOOL
 

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -373,7 +373,7 @@ class ReversibleRuleRouter(ReversibleRouter, RuleRouter):
     """
 
     def __init__(self, rules=None):
-        self.named_rules = {}  # type: typing.Dict[str]
+        self.named_rules = {}  # type: typing.Dict[str, Any]
         super(ReversibleRuleRouter, self).__init__(rules)
 
     def process_rule(self, rule):

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -103,7 +103,7 @@ class PatchHandler(RequestHandler):
 
 
 class AllMethodsHandler(RequestHandler):
-    SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ('OTHER',)
+    SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ('OTHER',)  # type: ignore
 
     def method(self):
         self.write(self.request.method)

--- a/tornado/test/routing_test.py
+++ b/tornado/test/routing_test.py
@@ -16,6 +16,8 @@ from tornado.testing import AsyncHTTPTestCase
 from tornado.web import Application, HTTPError, RequestHandler
 from tornado.wsgi import WSGIContainer
 
+import typing  # noqa
+
 
 class BasicRouter(Router):
     def find_handler(self, request, **kwargs):
@@ -44,7 +46,7 @@ class BasicRouterTestCase(AsyncHTTPTestCase):
         self.assertEqual(response.body, b"OK")
 
 
-resources = {}
+resources = {}  # type: typing.Dict[str, bytes]
 
 
 class GetResource(RequestHandler):

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -33,7 +33,7 @@ from tornado.web import RequestHandler, Application
 try:
     from twisted.internet.defer import Deferred, inlineCallbacks, returnValue  # type: ignore
     from twisted.internet.protocol import Protocol  # type: ignore
-    from twisted.internet.asyncioreactor import AsyncioSelectorReactor
+    from twisted.internet.asyncioreactor import AsyncioSelectorReactor  # type: ignore
     from twisted.web.client import Agent, readBody  # type: ignore
     from twisted.web.resource import Resource  # type: ignore
     from twisted.web.server import Site  # type: ignore

--- a/tornado/test/util.py
+++ b/tornado/test/util.py
@@ -30,7 +30,7 @@ skipNotCPython = unittest.skipIf(platform.python_implementation() != 'CPython',
 # TODO: remove this after pypy3 5.8 is obsolete.
 skipPypy3V58 = unittest.skipIf(platform.python_implementation() == 'PyPy' and
                                sys.version_info > (3,) and
-                               sys.pypy_version_info < (5, 9),
+                               sys.pypy_version_info < (5, 9),  # type: ignore
                                'pypy3 5.8 has buggy ssl module')
 
 

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1938,7 +1938,7 @@ class AllHTTPMethodsTest(SimpleHandlerTestCase):
 
 class PatchMethodTest(SimpleHandlerTestCase):
     class Handler(RequestHandler):
-        SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ('OTHER',)
+        SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ('OTHER',)  # type: ignore
 
         def patch(self):
             self.write('patch')

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -30,7 +30,7 @@ from tornado.websocket import (
 try:
     from tornado import speedups
 except ImportError:
-    speedups = None
+    speedups = None  # type: ignore
 
 
 class TestWebSocketHandler(WebSocketHandler):

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -24,24 +24,15 @@ bytes_type = bytes
 unicode_type = str
 basestring_type = str
 
-try:
-    import typing  # noqa
-    from typing import cast
+import typing
 
-    _ObjectDictBase = typing.Dict[str, typing.Any]
-except ImportError:
-    _ObjectDictBase = dict
+# More imports that are only needed in type annotations.
+import datetime  # noqa
+import types
+from typing import Any, AnyStr, Union, Optional, Dict, Mapping, List  # noqa
+from typing import Tuple, Match, Callable  # noqa
 
-    def cast(typ, x):
-        return x
-else:
-    # More imports that are only needed in type comments.
-    import datetime  # noqa
-    import types  # noqa
-    from typing import Any, AnyStr, Union, Optional, Dict, Mapping  # noqa
-    from typing import Tuple, Match, Callable  # noqa
-
-    _BaseString = str
+_BaseString = str
 
 try:
     from sys import is_finalizing
@@ -70,7 +61,7 @@ class TimeoutError(Exception):
     """
 
 
-class ObjectDict(_ObjectDictBase):
+class ObjectDict(typing.Dict[str, typing.Any]):
     """Makes a dictionary behave like an object, with attribute-style access.
     """
     def __getattr__(self, name):
@@ -151,10 +142,10 @@ def import_object(name):
         # on python 2 a byte string is required.
         name = name.encode('utf-8')
     if name.count('.') == 0:
-        return __import__(name, None, None)
+        return __import__(name)
 
     parts = name.split('.')
-    obj = __import__('.'.join(parts[:-1]), None, None, [parts[-1]], 0)
+    obj = __import__('.'.join(parts[:-1]), fromlist=[parts[-1]])
     try:
         return getattr(obj, parts[-1])
     except AttributeError:
@@ -170,10 +161,10 @@ def exec_in(code, glob, loc=None):
     exec(code, glob, loc)
 
 
-def raise_exc_info(exc_info):
-    # type: (Tuple[type, BaseException, types.TracebackType]) -> None
+def raise_exc_info(exc_info: Optional[Tuple[type, BaseException, types.TracebackType]]) -> None:
     try:
-        raise exc_info[1].with_traceback(exc_info[2])
+        if exc_info is not None:
+            raise exc_info[1].with_traceback(exc_info[2])
     finally:
         exc_info = None
 
@@ -356,7 +347,7 @@ class ArgReplacer(object):
         # type: (Callable, str) -> None
         self.name = name
         try:
-            self.arg_pos = self._getargnames(func).index(name)
+            self.arg_pos = self._getargnames(func).index(name)  # type: Optional[int]
         except ValueError:
             # Not a positional parameter
             self.arg_pos = None

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ envlist =
         py3-sphinx-doctest,
 
         py3-lint
+        py3-mypy
 
 [testenv]
 # Most of these are defaults, but if you specify any you can't fall back
@@ -125,3 +126,8 @@ commands =
 [testenv:py3-lint]
 commands = flake8 {posargs:}
 changedir = {toxinidir}
+
+[testenv:py3-mypy]
+commands = mypy {posargs:tornado}
+changedir = {toxinidir}
+deps = mypy


### PR DESCRIPTION
Now that we're no longer working in the superposition of python 2 and 3 (and we have py3 annotation syntax, although not 3.6 variable annotations), type annotations are a lot simpler. Add annotations to the lowest-level modules and enforce type checks in CI. 

Note that this doesn't yet provide much type-safety; it only typechecks the internals of these methods. Since other files don't have type annotations, they are ignored even when types could be inferred for calls to typed methods (there's an option for this but enabling it currently triggers a lot of warnings).