### PR TITLE
fix issue #2455: AttributeError: 'list' object has no attribute 'slug'

### DIFF
--- a/demos/blog/blog.py
+++ b/demos/blog/blog.py
@@ -186,7 +186,7 @@ class ComposeHandler(BaseHandler):
             entry = await self.query("SELECT * FROM entries WHERE id = %s", int(id))
             if not entry:
                 raise tornado.web.HTTPError(404)
-            slug = entry.slug
+            slug = entry[0].slug
             await self.execute(
                 "UPDATE entries SET title = %s, markdown = %s, html = %s "
                 "WHERE id = %s", title, text, html, int(id))

--- a/demos/blog/blog.py
+++ b/demos/blog/blog.py
@@ -183,10 +183,11 @@ class ComposeHandler(BaseHandler):
         text = self.get_argument("markdown")
         html = markdown.markdown(text)
         if id:
-            entry = await self.query("SELECT * FROM entries WHERE id = %s", int(id))
-            if not entry:
+            try:
+                entry = await self.queryone("SELECT * FROM entries WHERE id = %s", int(id))
+            except NoResultError:
                 raise tornado.web.HTTPError(404)
-            slug = entry[0].slug
+            slug = entry.slug
             await self.execute(
                 "UPDATE entries SET title = %s, markdown = %s, html = %s "
                 "WHERE id = %s", title, text, html, int(id))


### PR DESCRIPTION
Blog demo has a bug as #2455 said.

The BaseHandler.query() method always returns a list. So we should access items through subscripts.