### PR TITLE
Always import Type.

### DIFF
--- a/tornado/util.py
+++ b/tornado/util.py
@@ -18,14 +18,16 @@ import re
 import typing
 import zlib
 
-from typing import Any, Optional, Dict, Mapping, List, Tuple, Match, Callable
+from typing import (
+    Any, Optional, Dict, Mapping, List, Tuple, Match, Callable, Type,
+)
 
 if typing.TYPE_CHECKING:
     # Additional imports only used in type comments.
     # This lets us make these imports lazy.
     import datetime  # noqa
     import types  # noqa
-    from typing import Type, Union  # noqa
+    from typing import Union  # noqa
     import unittest  # noqa
 
 # Aliases for types that are spelled differently in different Python


### PR DESCRIPTION
In another pull request https://github.com/tornadoweb/tornado/pull/2452 the use of the [`typing.Type` class](https://github.com/tornadoweb/tornado/pull/2452/files#diff-81cf6f67d1aefe4c51a51199b636b6e4R302) was added but not imported. This pull request fixes that issue.