### PR TITLE
Add thread identity check to add_callback

### DIFF
--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -53,7 +53,7 @@ class BaseAsyncIOLoop(IOLoop):
                 del IOLoop._ioloop_for_asyncio[loop]
         IOLoop._ioloop_for_asyncio[asyncio_loop] = self
 
-        self.thread_identity = 0
+        self._thread_identity = 0
         super(BaseAsyncIOLoop, self).initialize(**kwargs)
 
     def close(self, all_fds=False):
@@ -123,7 +123,7 @@ class BaseAsyncIOLoop(IOLoop):
         handler_func(fileobj, events)
 
     def start(self):
-        self.thread_identity = get_ident()
+        self._thread_identity = get_ident()
         try:
             old_loop = asyncio.get_event_loop()
         except (RuntimeError, AssertionError):
@@ -150,7 +150,7 @@ class BaseAsyncIOLoop(IOLoop):
         timeout.cancel()
 
     def add_callback(self, callback, *args, **kwargs):
-        if get_ident() == self.thread_identity:
+        if get_ident() == self._thread_identity:
             call_soon = self.asyncio_loop.call_soon
         else:
             call_soon = self.asyncio_loop.call_soon_threadsafe

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -54,7 +54,13 @@ class BaseAsyncIOLoop(IOLoop):
         IOLoop._ioloop_for_asyncio[asyncio_loop] = self
 
         self._thread_identity = 0
+
         super(BaseAsyncIOLoop, self).initialize(**kwargs)
+
+        def assign_thread_identity():
+            self._thread_identity = get_ident()
+
+        self.add_callback(assign_thread_identity)
 
     def close(self, all_fds=False):
         self.closing = True
@@ -123,7 +129,6 @@ class BaseAsyncIOLoop(IOLoop):
         handler_func(fileobj, events)
 
     def start(self):
-        self._thread_identity = get_ident()
         try:
             old_loop = asyncio.get_event_loop()
         except (RuntimeError, AssertionError):

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -170,7 +170,13 @@ class BaseAsyncIOLoop(IOLoop):
             # eventually execute).
             pass
 
-    add_callback_from_signal = add_callback
+    def add_callback_from_signal(self, callback, *args, **kwargs):
+        try:
+            self.asyncio_loop.call_soon_threadsafe(
+                self._run_callback,
+                functools.partial(callback, *args, **kwargs))
+        except RuntimeError:
+            pass
 
     def run_in_executor(self, executor, func, *args):
         return self.asyncio_loop.run_in_executor(executor, func, *args)

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -53,11 +53,7 @@ class BaseAsyncIOLoop(IOLoop):
                 del IOLoop._ioloop_for_asyncio[loop]
         IOLoop._ioloop_for_asyncio[asyncio_loop] = self
 
-        def assign_thread_ident():
-            self.thread_identity = get_ident()
-
         self.thread_identity = 0
-        self.add_callback(assign_thread_ident)
         super(BaseAsyncIOLoop, self).initialize(**kwargs)
 
     def close(self, all_fds=False):
@@ -127,6 +123,7 @@ class BaseAsyncIOLoop(IOLoop):
         handler_func(fileobj, events)
 
     def start(self):
+        self.thread_identity = get_ident()
         try:
             old_loop = asyncio.get_event_loop()
         except (RuntimeError, AssertionError):


### PR DESCRIPTION
Fixes #2463

This reduces the overhead of add_callback when called on the same thread
as the event loop.  This uses asyncio's call_soon rather than
call_soon_threadsafe.