### PR TITLE
Fix IOLoop doc example code

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -67,7 +67,7 @@ class IOLoop(Configurable):
         import socket
 
         import tornado.ioloop
-        from tornado import gen
+        from tornado.gen import convert_yielded
         from tornado.iostream import IOStream
 
         async def handle_connection(connection, address):
@@ -84,7 +84,8 @@ class IOLoop(Configurable):
                         raise
                     return
                 connection.setblocking(0)
-                handle_connection(connection, address)
+                coro = handle_connection(connection, address)
+                convert_yielded(coro)
 
         if __name__ == '__main__':
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -67,7 +67,6 @@ class IOLoop(Configurable):
         import socket
 
         import tornado.ioloop
-        from tornado.gen import convert_yielded
         from tornado.iostream import IOStream
 
         async def handle_connection(connection, address):
@@ -84,8 +83,8 @@ class IOLoop(Configurable):
                         raise
                     return
                 connection.setblocking(0)
-                coro = handle_connection(connection, address)
-                convert_yielded(coro)
+                io_loop = tornado.ioloop.IOLoop.current()
+                io_loop.spawn_callback(handle_connection, connection, address)
 
         if __name__ == '__main__':
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)


### PR DESCRIPTION
fixes #2471

Uses `tornado.gen.convert_yielded` to convert the `handle_connection` coroutine into a future and schedules it in the event loop.