### PR TITLE
Ioloop's time function uses `time.monotonic` by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
     # Ideally we'd run the docs/lint stuff on the latest Python
     # version supported. But Python 3.7 requires slower-to-start VMs,
     # so we run it on 3.6 to minimize total CI run time.
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx==1.7.6 sphinx_rtd_theme; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx!=1.7.7 sphinx_rtd_theme; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8 mypy; fi
     # On travis the extension should always be built
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
     # Ideally we'd run the docs/lint stuff on the latest Python
     # version supported. But Python 3.7 requires slower-to-start VMs,
     # so we run it on 3.6 to minimize total CI run time.
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx sphinx_rtd_theme; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install sphinx==1.7.6 sphinx_rtd_theme; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8 mypy; fi
     # On travis the extension should always be built
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TORNADO_EXTENSION=1; fi

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -473,14 +473,13 @@ class IOLoop(Configurable):
         The return value is a floating-point number relative to an
         unspecified time in the past.
 
-        By default, the `IOLoop`'s time function is `time.time`.  However,
-        it may be configured to use e.g. `time.monotonic` instead.
+        By default, the `IOLoop`'s time function is `time.monotonic`.
         Calls to `add_timeout` that pass a number instead of a
         `datetime.timedelta` should use this function to compute the
         appropriate time, so they can work no matter what time function
         is chosen.
         """
-        return time.time()
+        return time.monotonic()
 
     def add_timeout(self, deadline, callback, *args, **kwargs):
         """Runs the ``callback`` at the time ``deadline`` from the I/O loop.


### PR DESCRIPTION
As Tornado 6.0 will drop support for Python 2.7 and 3.4, maybe ioloop's time function needs to use `time.monotonic` by default?

1. Since Python 3.5, `time.monotonic` function is always available; 

2. Since Python 3.5, many builtin functions switch to use a monotonic clock to compute timeouts, such as socket methods. See https://bugs.python.org/issue22043;

3. `time.monotonic` is faster than `time.time` on many platforms:

   on Windows:
![image](https://user-images.githubusercontent.com/13200012/44378972-5ce30900-a536-11e8-85be-88393d6c98ae.png)
   
   on Linux:
![image](https://user-images.githubusercontent.com/13200012/44379244-95371700-a537-11e8-91cc-2a86325fb338.png)