### PR TITLE
setup: Fix minor typo in version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ MacOS users should run:
 
 kwargs = {}
 
-version = "5.1.1 "
+version = "5.1.1"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()


### PR DESCRIPTION
I'm not sure whether this matters, but setup.py warns about it.