### PR TITLE
allow configurable max_restarts in TCPServer.start

### DIFF
--- a/tornado/process.py
+++ b/tornado/process.py
@@ -85,7 +85,7 @@ def _pipe_cloexec() -> Tuple[int, int]:
 _task_id = None
 
 
-def fork_processes(num_processes: Optional[int], max_restarts: int = 100) -> int:
+def fork_processes(num_processes: Optional[int], max_restarts: int = None) -> int:
     """Starts multiple worker processes.
 
     If ``num_processes`` is None or <= 0, we detect the number of cores
@@ -109,7 +109,12 @@ def fork_processes(num_processes: Optional[int], max_restarts: int = 100) -> int
     process, ``fork_processes`` returns None if all child processes
     have exited normally, but will otherwise only exit by throwing an
     exception.
+
+    max_restarts defaults to 100.
     """
+    if max_restarts is None:
+        max_restarts = 100
+
     global _task_id
     assert _task_id is None
     if num_processes is None or num_processes <= 0:

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -209,7 +209,7 @@ class TCPServer(object):
         else:
             self._pending_sockets.extend(sockets)
 
-    def start(self, num_processes: Optional[int] = 1) -> None:
+    def start(self, num_processes: Optional[int] = 1, max_restarts: int = None) -> None:
         """Starts this server in the `.IOLoop`.
 
         By default, we run the server in this process and do not fork any
@@ -232,7 +232,7 @@ class TCPServer(object):
         assert not self._started
         self._started = True
         if num_processes != 1:
-            process.fork_processes(num_processes)
+            process.fork_processes(num_processes, max_restarts)
         sockets = self._pending_sockets
         self._pending_sockets = []
         self.add_sockets(sockets)


### PR DESCRIPTION
#1628 redux

Current use case: we have a memory leak we're working on fixing. In the mean time, we can allow for 0 down time and capping memory usage by periodically killing child processes and setting max_restarts very high.