### PR TITLE
iostream: Add errno 0 to the list of silent errors in TLS handshakes

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1402,7 +1402,13 @@ class SSLIOStream(IOStream):
             # to cause do_handshake to raise EBADF and ENOTCONN, so make
             # those errors quiet as well.
             # https://groups.google.com/forum/?fromgroups#!topic/python-tornado/ApucKJat1_0
-            if self._is_connreset(err) or err.args[0] in (errno.EBADF, errno.ENOTCONN):
+            # Errno 0 is also possible in some cases (nc -z).
+            # https://github.com/tornadoweb/tornado/issues/2504
+            if self._is_connreset(err) or err.args[0] in (
+                0,
+                errno.EBADF,
+                errno.ENOTCONN,
+            ):
                 return self.close(exc_info=err)
             raise
         except AttributeError as err:


### PR DESCRIPTION
This error is possible for some connections that don't follow through
with the TLS handshake.

Fixes #2504