### PR TITLE
*: Convert most non-test coroutines to native

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -30,7 +30,6 @@ import ssl
 
 from tornado.escape import native_str
 from tornado.http1connection import HTTP1ServerConnection, HTTP1ConnectionParameters
-from tornado import gen
 from tornado import httputil
 from tornado import iostream
 from tornado import netutil
@@ -38,18 +37,7 @@ from tornado.tcpserver import TCPServer
 from tornado.util import Configurable
 
 import typing
-from typing import (
-    Union,
-    Any,
-    Dict,
-    Callable,
-    List,
-    Type,
-    Generator,
-    Tuple,
-    Optional,
-    Awaitable,
-)
+from typing import Union, Any, Dict, Callable, List, Type, Tuple, Optional, Awaitable
 
 if typing.TYPE_CHECKING:
     from typing import Set  # noqa: F401
@@ -209,12 +197,11 @@ class HTTPServer(TCPServer, Configurable, httputil.HTTPServerConnectionDelegate)
     def configurable_default(cls) -> Type[Configurable]:
         return HTTPServer
 
-    @gen.coroutine
-    def close_all_connections(self) -> Generator[Any, Any, None]:
+    async def close_all_connections(self) -> None:
         while self._connections:
             # Peek at an arbitrary element of the set
             conn = next(iter(self._connections))
-            yield conn.close()
+            await conn.close()
 
     def handle_stream(self, stream: iostream.IOStream, address: Tuple) -> None:
         context = _HTTPRequestContext(

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -20,7 +20,7 @@ import types
 from tornado import gen, ioloop
 from tornado.concurrent import Future, future_set_result_unless_cancelled
 
-from typing import Union, Optional, Type, Any, Generator
+from typing import Union, Optional, Type, Any
 import typing
 
 if typing.TYPE_CHECKING:
@@ -453,9 +453,8 @@ class Semaphore(_TimeoutGarbageCollector):
     ) -> None:
         self.__enter__()
 
-    @gen.coroutine
-    def __aenter__(self) -> Generator[Any, Any, None]:
-        yield self.acquire()
+    async def __aenter__(self) -> None:
+        await self.acquire()
 
     async def __aexit__(
         self,
@@ -562,9 +561,8 @@ class Lock(object):
     ) -> None:
         self.__enter__()
 
-    @gen.coroutine
-    def __aenter__(self) -> Generator[Any, Any, None]:
-        yield self.acquire()
+    async def __aenter__(self) -> None:
+        await self.acquire()
 
     async def __aexit__(
         self,

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -18,7 +18,6 @@ from tornado.ioloop import IOLoop
 from tornado.iostream import UnsatisfiableReadError
 from tornado.locks import Event
 from tornado.log import gen_log
-from tornado.concurrent import Future
 from tornado.netutil import Resolver, bind_sockets
 from tornado.simple_httpclient import (
     SimpleAsyncHTTPClient,
@@ -273,9 +272,14 @@ class SimpleHTTPClientTestMixin(object):
     def test_connect_timeout(self):
         timeout = 0.1
 
+        cleanup_event = Event()
+        test = self
+
         class TimeoutResolver(Resolver):
-            def resolve(self, *args, **kwargs):
-                return Future()  # never completes
+            async def resolve(self, *args, **kwargs):
+                await cleanup_event.wait()
+                # Return something valid so the test doesn't raise during shutdown.
+                return [(socket.AF_INET, ("127.0.0.1", test.get_http_port()))]
 
         with closing(self.create_client(resolver=TimeoutResolver())) as client:
             with self.assertRaises(HTTPTimeoutError):
@@ -285,6 +289,12 @@ class SimpleHTTPClientTestMixin(object):
                     request_timeout=3600,
                     raise_error=True,
                 )
+
+        # Let the hanging coroutine clean up after itself. We need to
+        # wait more than a single IOLoop iteration for the SSL case,
+        # which logs errors on unexpected EOF.
+        cleanup_event.set()
+        yield gen.sleep(0.2)
 
     @skipOnTravis
     def test_request_timeout(self):
@@ -694,11 +704,16 @@ class HostnameMappingTestCase(AsyncHTTPTestCase):
 
 class ResolveTimeoutTestCase(AsyncHTTPTestCase):
     def setUp(self):
+        self.cleanup_event = Event()
+        test = self
+
         # Dummy Resolver subclass that never finishes.
         class BadResolver(Resolver):
             @gen.coroutine
             def resolve(self, *args, **kwargs):
-                yield Event().wait()
+                yield test.cleanup_event.wait()
+                # Return something valid so the test doesn't raise during cleanup.
+                return [(socket.AF_INET, ("127.0.0.1", test.get_http_port()))]
 
         super(ResolveTimeoutTestCase, self).setUp()
         self.http_client = SimpleAsyncHTTPClient(resolver=BadResolver())
@@ -709,6 +724,10 @@ class ResolveTimeoutTestCase(AsyncHTTPTestCase):
     def test_resolve_timeout(self):
         with self.assertRaises(HTTPTimeoutError):
             self.fetch("/hello", connect_timeout=0.1, raise_error=True)
+
+        # Let the hanging coroutine clean up after itself
+        self.cleanup_event.set()
+        self.io_loop.run_sync(lambda: gen.sleep(0))
 
 
 class MaxHeaderSizeTest(AsyncHTTPTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2571,11 +2571,10 @@ class StaticFileHandler(RequestHandler):
         with cls._lock:
             cls._static_hashes = {}
 
-    def head(self, path: str) -> "Future[None]":
+    def head(self, path: str) -> Awaitable[None]:
         return self.get(path, include_body=False)
 
-    @gen.coroutine
-    def get(self, path: str, include_body: bool = True) -> Generator[Any, Any, None]:
+    async def get(self, path: str, include_body: bool = True) -> None:
         # Set up our path instance variables.
         self.path = self.parse_url_path(path)
         del path  # make sure we don't refer to path instead of self.path again
@@ -2644,7 +2643,7 @@ class StaticFileHandler(RequestHandler):
             for chunk in content:
                 try:
                     self.write(chunk)
-                    yield self.flush()
+                    await self.flush()
                 except iostream.StreamClosedError:
                     return
         else:

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1444,16 +1444,17 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
                     WebSocketError("Non-websocket response")
                 )
 
-    def headers_received(
+    async def headers_received(
         self,
         start_line: Union[httputil.RequestStartLine, httputil.ResponseStartLine],
         headers: httputil.HTTPHeaders,
     ) -> None:
         assert isinstance(start_line, httputil.ResponseStartLine)
         if start_line.code != 101:
-            return super(WebSocketClientConnection, self).headers_received(
+            await super(WebSocketClientConnection, self).headers_received(
                 start_line, headers
             )
+            return
 
         self.headers = headers
         self.protocol = self.get_websocket_protocol()


### PR DESCRIPTION
This improves performance by avoiding the creation of a separate `Runner` object for each coroutine call. Now there is one runner for the connection and one for each request. 

Some rough numbers from a "hello world" HTTPServer benchmark on a 24-cpu VM:
4.5.3: 35.7k qps
5.1.1: 33.2k qps
master prior to this change: 35.7k qps
with this change: 37.2k qps
this change + uvloop: 39.6k qps

The websocket module was not updated yet because it needs a little more refactoring to continue to support clean shutdown in tests. 