### PR TITLE
Fix #2521: Serve full file when range start is negative and exceeds the total length

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1280,6 +1280,17 @@ class StaticFileTest(WebTestCase):
         self.assertEqual(response.headers.get("Content-Length"), "4")
         self.assertEqual(response.headers.get("Content-Range"), "bytes 22-25/26")
 
+    def test_static_with_range_neg_past_start(self):
+        response = self.get_and_head(
+            "/static/robots.txt", headers={"Range": "bytes=-1000000"}
+        )
+        self.assertEqual(response.code, 200)
+        robots_file_path = os.path.join(self.static_dir, "robots.txt")
+        with open(robots_file_path) as f:
+            self.assertEqual(response.body, utf8(f.read()))
+        self.assertEqual(response.headers.get("Content-Length"), "26")
+        self.assertEqual(response.headers.get("Content-Range"), None)
+
     def test_static_invalid_range(self):
         response = self.get_and_head("/static/robots.txt", headers={"Range": "asdf"})
         self.assertEqual(response.code, 200)

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1309,6 +1309,13 @@ class StaticFileTest(WebTestCase):
         self.assertEqual(response.code, 416)
         self.assertEqual(response.headers.get("Content-Range"), "bytes */26")
 
+    def test_static_unsatisfiable_range_end_less_than_start(self):
+        response = self.get_and_head(
+            "/static/robots.txt", headers={"Range": "bytes=10-3"}
+        )
+        self.assertEqual(response.code, 416)
+        self.assertEqual(response.headers.get("Content-Range"), "bytes */26")
+
     def test_static_head(self):
         response = self.fetch("/static/robots.txt", method="HEAD")
         self.assertEqual(response.code, 200)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2600,7 +2600,10 @@ class StaticFileHandler(RequestHandler):
         size = self.get_content_size()
         if request_range:
             start, end = request_range
-            if (start is not None and (start >= size or (end is not None and start >= end))) or end == 0:
+            if (
+                start is not None
+                and (start >= size or (end is not None and start >= end))
+            ) or end == 0:
                 # As per RFC 2616 14.35.1, a range is not satisfiable only: if
                 # the first requested byte is equal to or greater than the
                 # content, or when a suffix with length 0 is specified.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2600,10 +2600,14 @@ class StaticFileHandler(RequestHandler):
         size = self.get_content_size()
         if request_range:
             start, end = request_range
-            if (start is not None and start >= size) or end == 0:
+            if (start is not None and (start >= size or (end is not None and start >= end))) or end == 0:
                 # As per RFC 2616 14.35.1, a range is not satisfiable only: if
                 # the first requested byte is equal to or greater than the
-                # content, or when a suffix with length 0 is specified
+                # content, or when a suffix with length 0 is specified.
+
+                # https://tools.ietf.org/html/rfc7233#section-2.1
+                # A byte-range-spec is invalid if the last-byte-pos value is present
+                # and less than the first-byte-pos.
                 self.set_status(416)  # Range Not Satisfiable
                 self.set_header("Content-Type", "text/plain")
                 self.set_header("Content-Range", "bytes */%s" % (size,))

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2600,6 +2600,10 @@ class StaticFileHandler(RequestHandler):
         size = self.get_content_size()
         if request_range:
             start, end = request_range
+            if start is not None and start < 0:
+                start += size
+                if start < 0:
+                    start = 0
             if (
                 start is not None
                 and (start >= size or (end is not None and start >= end))
@@ -2607,7 +2611,6 @@ class StaticFileHandler(RequestHandler):
                 # As per RFC 2616 14.35.1, a range is not satisfiable only: if
                 # the first requested byte is equal to or greater than the
                 # content, or when a suffix with length 0 is specified.
-
                 # https://tools.ietf.org/html/rfc7233#section-2.1
                 # A byte-range-spec is invalid if the last-byte-pos value is present
                 # and less than the first-byte-pos.
@@ -2615,10 +2618,6 @@ class StaticFileHandler(RequestHandler):
                 self.set_header("Content-Type", "text/plain")
                 self.set_header("Content-Range", "bytes */%s" % (size,))
                 return
-            if start is not None and start < 0:
-                start += size
-                if start < 0:
-                    start = 0
             if end is not None and end > size:
                 # Clients sometimes blindly use a large range to limit their
                 # download size; cap the endpoint at the actual file size.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2610,6 +2610,8 @@ class StaticFileHandler(RequestHandler):
                 return
             if start is not None and start < 0:
                 start += size
+                if start < 0:
+                    start = 0
             if end is not None and end > size:
                 # Clients sometimes blindly use a large range to limit their
                 # download size; cap the endpoint at the actual file size.


### PR DESCRIPTION
Fix issue #2521 and another similar one:

    While the range end is less than start, a HTTPOutputError will also be raised.

## Question about the solution to issue #2521
I did the same test under `Nginx`. It served the full file but the status code is **206** with a **Content-Range** header.
```
$ curl http://localhost:8881 -s -I -H "Range: bytes=-10000000000"
HTTP/1.1 206 Partial Content
Server: nginx/1.15.5
Date: Tue, 30 Oct 2018 14:40:27 GMT
Content-Type: text/html
Content-Length: 612
Last-Modified: Tue, 02 Oct 2018 15:13:52 GMT
Connection: keep-alive
ETag: "5bb38b30-264"
Content-Range: bytes 0-611/612
```

I've also tested some other web frameworks, some of which return **416** status code.
```
$ curl http://127.0.0.1:5000/static/test.txt -s -I -H "Range: bytes=-100000"
HTTP/1.0 416 REQUESTED RANGE NOT SATISFIABLE
Content-Type: text/html
Content-Range: bytes */3
Content-Length: 202
Server: Werkzeug/0.14.1 Python/3.5.4
Date: Tue, 30 Oct 2018 15:26:51 GMT
```