### PR TITLE
Define XSRF cookie expires_day via settings

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1418,13 +1418,9 @@ class RequestHandler(object):
             else:
                 raise ValueError("unknown xsrf cookie version %d", output_version)
             if version is None:
-                expires_days = 30 if self.current_user else None
-                self.set_cookie(
-                    "_xsrf",
-                    self._xsrf_token,
-                    expires_days=expires_days,
-                    **cookie_kwargs
-                )
+                if self.current_user and "expires_days" not in cookie_kwargs:
+                    cookie_kwargs["expires_days"] = 30
+                self.set_cookie("_xsrf", self._xsrf_token, **cookie_kwargs)
         return self._xsrf_token
 
     def _get_raw_xsrf_token(self) -> Tuple[Optional[int], bytes, float]:


### PR DESCRIPTION
Hi,

We are adopting Tornado at work, and I started reading its internal API (which is super neat! kudos!, and pending issues to get familiar with the code.

Found #462, and thought it looked simple, so decided to try to understand where the change would occur and suggest a fix in a pull request.

First time contributing to Tornado, so feel free to point me if I forgot anything. Not sure if that's something easy to be tested? If so, if someone could point me to a similar test, I'd be happy to include one here. It worked testing locally and confirming in Firefox web developer Storage tab for the cookie info.

Thank you very much for Tornado!
Bruno