### PR TITLE
ignore trailing operators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,5 +13,5 @@ ignore =
     # flake8 and black disagree about
     # W503 line break before binary operator
     # E203 whitespace before ':'
-    W503,E203
+    W503,W504,E203
 doctests = true


### PR DESCRIPTION
Without this, we have several flake8 errors:

```
./demos/facebook/facebook.py:76:19: W504 line break after binary operator
./demos/facebook/facebook.py:77:19: W504 line break after binary operator
./demos/file_upload/file_uploader.py:38:13: W504 line break after binary operator
./demos/file_upload/file_uploader.py:40:13: W504 line break after binary operator
./demos/file_upload/file_uploader.py:41:13: W504 line break after binary operator
./demos/s3server/s3server.py:92:22: W504 line break after binary operator
./demos/s3server/s3server.py:96:21: W504 line break after binary operator
./tornado/http1connection.py:409:17: W504 line break after binary operator
./tornado/http1connection.py:413:17: W504 line break after binary operator
./tornado/http1connection.py:417:17: W504 line break after binary operator
```