### PR TITLE
Add support for source IP address to SimpleAsyncHTTPClient.

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -422,8 +422,8 @@ class HTTPRequest(object):
            New in Tornado 4.0.
         :arg bool use_gzip: Deprecated alias for ``decompress_response``
            since Tornado 4.0.
-        :arg str network_interface: Network interface to use for request.
-           ``curl_httpclient`` only; see note below.
+        :arg str network_interface: Network interface or source IP to use for request.
+           See ``curl_httpclient`` note below.
         :arg collections.abc.Callable streaming_callback: If set, ``streaming_callback`` will
            be run with each chunk of data as it is received, and
            ``HTTPResponse.body`` and ``HTTPResponse.buffer`` will be empty in

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -467,6 +467,18 @@ X-XSS-Protection: 1;
         response2 = yield self.http_client.fetch(response.request)
         self.assertEqual(response2.body, b"Hello world!")
 
+    @gen_test
+    def test_bind_source_ip(self):
+        url = self.get_url("/hello")
+        request = HTTPRequest(url, network_interface="127.0.0.1")
+        response = yield self.http_client.fetch(request)
+        self.assertEqual(response.code, 200)
+
+        with self.assertRaises((ValueError, HTTPError)) as context:
+            request = HTTPRequest(url, network_interface="not-interface-or-ip")
+            yield self.http_client.fetch(request)
+        self.assertIn("not-interface-or-ip", str(context.exception))
+
     def test_all_methods(self):
         for method in ["GET", "DELETE", "OPTIONS"]:
             response = self.fetch("/all_methods", method=method)


### PR DESCRIPTION
Extend support for HTTPRequest's network_interface parameter to SimpleAsyncHTTPClient. This enables binding to specific local IP and enables connecting to WebSockets via a specific IP address.

To use it you create a HTTPRequest with network_interface parameter set to local IP address to be used as source IP. websocket_connect then passes the request to SimpleAsyncHTTPClient.

Note that even though the parameter name is `network_interface`, the CurlAsyncHTTPClient may support (OS dependant) passing in interface name, resolvable hostname or IP address, while this patch only adds IP address support to SimpleAsyncHTTPClient.

As a curious side note, the curl library also supports prefixing the passed-in string with `"if!"` or `"host!"` to force parsing parameter as interface or host name respectively. For reference, the parts of curl that deal with binding client socket are function `bindlocal` in [connect.c](https://github.com/curl/curl/blob/master/lib/connect.c). Resolving interface names and addresses is done in [if2ip.c](https://github.com/curl/curl/blob/master/lib/if2ip.c).