### PR TITLE
Provide a way to see of a Lock is already acquired

### DIFF
--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -550,6 +550,14 @@ class Lock(object):
         except ValueError:
             raise RuntimeError("release unlocked lock")
 
+    def is_locked(self) -> bool:
+        """Check to see if already locked.
+
+        Returns a bool.
+        """
+        return self._block._value == 0
+
+
     def __enter__(self) -> None:
         raise RuntimeError("Use Lock like 'with (yield lock)', not like 'with lock'")
 


### PR DESCRIPTION
This adds `is_locked` to the `Lock` implementation by checking to see if the semaphore's `_value` is already at 0.

The use case I have for this is to be able to check if the lock is already set and then do nothing (I'd prefer this over doing an acquire with a small timeout). It's a use case where I only want to perform an operation if no one else has the lock.

If this is a welcome addition, I'd love to see it backported to the 5.x release line. I added types to make sure this is in line with Tornado 6 efforts.

cc @willingc @charsmith

xref: https://github.com/nteract/bookstore/pull/20