### PR TITLE
concurrent: Add future_set_exception_unless_cancelled

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -217,8 +217,8 @@ def future_set_exc_info(
 ) -> None:
     """Set the given ``exc_info`` as the `Future`'s exception.
 
-    Understands both `asyncio.Future` and Tornado's extensions to
-    enable better tracebacks on Python 2.
+    Understands both `asyncio.Future` and the extensions in older
+    versions of Tornado to enable better tracebacks on Python 2.
 
     .. versionadded:: 5.0
 
@@ -228,14 +228,9 @@ def future_set_exc_info(
        (previously asyncio.InvalidStateError would be raised)
 
     """
-    if hasattr(future, "set_exc_info"):
-        # Tornado's Future
-        future.set_exc_info(exc_info)  # type: ignore
-    else:
-        # asyncio.Future
-        if exc_info[1] is None:
-            raise Exception("future_set_exc_info called with no exception")
-        future_set_exception_unless_cancelled(future, exc_info[1])
+    if exc_info[1] is None:
+        raise Exception("future_set_exc_info called with no exception")
+    future_set_exception_unless_cancelled(future, exc_info[1])
 
 
 @typing.overload

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -45,7 +45,11 @@ import ssl
 import time
 import weakref
 
-from tornado.concurrent import Future, future_set_result_unless_cancelled
+from tornado.concurrent import (
+    Future,
+    future_set_result_unless_cancelled,
+    future_set_exception_unless_cancelled,
+)
 from tornado.escape import utf8, native_str
 from tornado import gen, httputil
 from tornado.ioloop import IOLoop
@@ -290,7 +294,7 @@ class AsyncHTTPClient(Configurable):
         def handle_response(response: "HTTPResponse") -> None:
             if response.error:
                 if raise_error or not response._error_is_response_code:
-                    future.set_exception(response.error)
+                    future_set_exception_unless_cancelled(future, response.error)
                     return
             future_set_result_unless_cancelled(future, response)
 

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -27,7 +27,11 @@ import time
 
 from binascii import hexlify
 
-from tornado.concurrent import Future, future_set_result_unless_cancelled
+from tornado.concurrent import (
+    Future,
+    future_set_result_unless_cancelled,
+    future_set_exception_unless_cancelled,
+)
 from tornado import ioloop
 from tornado.iostream import PipeIOStream
 from tornado.log import gen_log
@@ -296,7 +300,9 @@ class Subprocess(object):
         def callback(ret: int) -> None:
             if ret != 0 and raise_error:
                 # Unfortunately we don't have the original args any more.
-                future.set_exception(CalledProcessError(ret, "unknown"))
+                future_set_exception_unless_cancelled(
+                    future, CalledProcessError(ret, "unknown")
+                )
             else:
                 future_set_result_unless_cancelled(future, ret)
 


### PR DESCRIPTION
Tornado's limited support for cancellation means that errors after a
Future is cancelled could get raised (and probably logged) as
InvalidStateErrors.

This new function effectively changes the behavior to log the real
exception instead of the InvalidStateError. We log them instead of
ignoring them because it's generally not a good idea to let errors
pass silently even if they're after the point that no one is listening
for them (this is consistent with the way gen.multi() handles multiple
errors, for example).

Fixes #2540