### PR TITLE
Use 'future_add_done_callback' to add callback.

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -492,7 +492,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         else:
             future = self._write_future = Future()
             self._pending_write = self.stream.write(self._format_chunk(chunk))
-            self._pending_write.add_done_callback(self._on_write_complete)
+            future_add_done_callback(self._pending_write, self._on_write_complete)
         return future
 
     def finish(self) -> None:

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -224,6 +224,13 @@ class FinalReturnTest(WebTestCase):
                 test.final_return = self.finish()
                 yield test.final_return
 
+            @gen.coroutine
+            def post(self):
+                self.write("hello,")
+                yield self.flush()
+                test.final_return = self.finish("world")
+                yield test.final_return
+
         class RenderHandler(RequestHandler):
             def create_template_loader(self, path):
                 return DictLoader({"foo.html": "hi"})
@@ -239,6 +246,11 @@ class FinalReturnTest(WebTestCase):
 
     def test_finish_method_return_future(self):
         response = self.fetch(self.get_url("/finish"))
+        self.assertEqual(response.code, 200)
+        self.assertIsInstance(self.final_return, Future)
+        self.assertTrue(self.final_return.done())
+
+        response = self.fetch(self.get_url("/finish"), method="POST", body=b"")
         self.assertEqual(response.code, 200)
         self.assertIsInstance(self.final_return, Future)
         self.assertTrue(self.final_return.done())


### PR DESCRIPTION
I'm so sorry that the PR #2449 was incomplete, it omited consideration of another
branch of the `RequestHandler.flush()`. In short, the future returned by
`RequestHandler.finish()` may also be the return value of
`HTTP1Connection.write()`. So we should make the same change to
`HTTP1Connection.write()`.

Fix #2448.