### PR TITLE
Release app references in AsyncHTTPTestCase tearDown method

### DIFF
--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -181,8 +181,8 @@ class AsyncHTTPTestCaseSetUpTearDownTest(unittest.TestCase):
                 return Application()
 
             def test(self):
-                self.assertTrue(hasattr(test, "_app"))
-                self.assertTrue(hasattr(test, "http_server"))
+                self.assertTrue(hasattr(self, "_app"))
+                self.assertTrue(hasattr(self, "http_server"))
 
         test = SetUpTearDown("test")
         test.run(result)

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -181,13 +181,13 @@ class AsyncHTTPTestCaseSetUpTearDownTest(unittest.TestCase):
                 return Application()
 
             def test(self):
-                self.assertTrue(hasattr(test, '_app'))
-                self.assertTrue(hasattr(test, 'http_server'))
+                self.assertTrue(hasattr(test, "_app"))
+                self.assertTrue(hasattr(test, "http_server"))
 
-        test = SetUpTearDown('test')
+        test = SetUpTearDown("test")
         test.run(result)
-        self.assertFalse(hasattr(test, '_app'))
-        self.assertFalse(hasattr(test, 'http_server'))
+        self.assertFalse(hasattr(test, "_app"))
+        self.assertFalse(hasattr(test, "http_server"))
 
 
 class GenTest(AsyncTestCase):

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -172,6 +172,24 @@ class SetUpTearDownTest(unittest.TestCase):
         self.assertEqual(expected, events)
 
 
+class AsyncHTTPTestCaseSetUpTearDownTest(unittest.TestCase):
+    def test_tear_down_releases_app_and_http_server(self):
+        result = unittest.TestResult()
+
+        class SetUpTearDown(AsyncHTTPTestCase):
+            def get_app(self):
+                return Application()
+
+            def test(self):
+                self.assertTrue(hasattr(test, '_app'))
+                self.assertTrue(hasattr(test, 'http_server'))
+
+        test = SetUpTearDown('test')
+        test.run(result)
+        self.assertFalse(hasattr(test, '_app'))
+        self.assertFalse(hasattr(test, 'http_server'))
+
+
 class GenTest(AsyncTestCase):
     def setUp(self):
         super(GenTest, self).setUp()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -432,6 +432,8 @@ class AsyncHTTPTestCase(AsyncTestCase):
             self.http_server.close_all_connections, timeout=get_async_test_timeout()
         )
         self.http_client.close()
+        del self.http_server
+        del self._app
         super(AsyncHTTPTestCase, self).tearDown()
 
 


### PR DESCRIPTION
For your consideration, this change adds a couple `del` statements to the `tearDown` method in `AsyncHTTPTestCase` in order to encourage the GC to free up resources passed through `Application` settings.

If you are willing to merge this PR, I'd love to also see it applied to the 5.x and 4.x branches.