### PR TITLE
websocket reconnect ability

### DIFF
--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -104,6 +104,14 @@ class NonWebSocketHandler(RequestHandler):
         self.write("ok")
 
 
+class RedirectHandler(RequestHandler):
+    def initialize(self, target_location):
+        self._target_location = target_location
+
+    def get(self):
+        self.redirect(self._target_location)
+
+
 class CloseReasonHandler(TestWebSocketHandler):
     def open(self):
         self.on_close_called = False
@@ -209,6 +217,12 @@ class WebSocketTest(WebSocketBaseTestCase):
         return Application(
             [
                 ("/echo", EchoHandler, dict(close_future=self.close_future)),
+                ("/redirect", RedirectHandler, dict(target_location="/echo")),
+                (
+                    "/double_redirect",
+                    RedirectHandler,
+                    dict(target_location="/redirect")
+                ),
                 ("/non_ws", NonWebSocketHandler),
                 ("/header", HeaderHandler, dict(close_future=self.close_future)),
                 (
@@ -355,6 +369,21 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_websocket_http_success(self):
         with self.assertRaises(WebSocketError):
             yield self.ws_connect("/non_ws")
+    
+    @gen_test
+    def test_websocket_redirect(self):
+        conn = yield self.ws_connect("/redirect")
+        yield conn.write_message("hello redirect")
+        msg = yield conn.read_message()
+        self.assertEqual("hello redirect", msg)
+
+    @gen_test
+    def test_websocket_double_redirect(self):
+        conn = yield self.ws_connect("/double_redirect")
+        yield conn.write_message("hello redirect")
+        msg = yield conn.read_message()
+        self.assertEqual("hello redirect", msg)
+
 
     @gen_test
     def test_websocket_network_fail(self):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -189,6 +189,7 @@ class WebSocketBaseTestCase(AsyncHTTPTestCase):
         ws = yield websocket_connect(
             "ws://127.0.0.1:%d%s" % (self.get_http_port(), path), **kwargs
         )
+        print(f'result of ws connect {ws}')
         raise gen.Return(ws)
 
     @gen.coroutine

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1477,9 +1477,13 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         headers: httputil.HTTPHeaders,
     ) -> None:
         assert isinstance(start_line, httputil.ResponseStartLine)
-        if start_line.code in (302, 303):
+        self.code = start_line.code
+        self.reason = start_line.reason
+        self.headers = headers
+
+        if self._should_follow_redirect():
             self._redirect_location = headers['Location']
-            raise WebSocketRedirect(self._redirect_location)
+            return
 
         if start_line.code != 101:
             await super(WebSocketClientConnection, self).headers_received(
@@ -1506,6 +1510,17 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         self.final_callback = None  # type: ignore
 
         future_set_result_unless_cancelled(self.connect_future, self)
+    
+    def finish(self):
+
+        if self._should_follow_redirect():
+            self.connect_future.set_exception(
+                WebSocketRedirect(self._redirect_location))
+            # close connection
+            self.on_connection_close()
+            self.connection.close()
+        else:
+            super().finish()
 
     def write_message(
         self, message: Union[str, bytes], binary: bool = False

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1451,17 +1451,20 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
 
     def on_connection_close(self) -> None:
         if not self.connect_future.done():
-            self.connect_future.set_exception(StreamClosedError())
+            if self._redirect_location is not None:
+                # websocket redirect, raise exception for reconnect
+                # to redirected url
+                self.connect_future.set_exception(
+                    WebSocketRedirect(self._redirect_location))
+            else:
+                self.connect_future.set_exception(StreamClosedError())
         self._on_message(None)
         self.tcp_client.close()
         super(WebSocketClientConnection, self).on_connection_close()
 
     def _on_http_response(self, response: httpclient.HTTPResponse) -> None:
         if not self.connect_future.done():
-            if self._redirect_location is not None:
-                self.connect_future.set_exception(
-                    WebSocketRedirect(self._redirect_location))
-            elif response.error:
+            if response.error:
                 self.connect_future.set_exception(response.error)
             else:
                 self.connect_future.set_exception(
@@ -1476,7 +1479,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         assert isinstance(start_line, httputil.ResponseStartLine)
         if start_line.code in (302, 303):
             self._redirect_location = headers['Location']
-            return
+            raise WebSocketRedirect(self._redirect_location)
 
         if start_line.code != 101:
             await super(WebSocketClientConnection, self).headers_received(
@@ -1689,7 +1692,7 @@ def websocket_connect(
                     wrapped_conn_future, e)
             else:
                 conn_future = do_connect(new_request)
-                IOLoop.current.add_future(
+                IOLoop.current().add_future(
                     conn_future, wrap_conn_future_callback)
         except Exception as e:
             future_set_exception_unless_cancelled(
@@ -1697,11 +1700,11 @@ def websocket_connect(
         else:
             future_set_result_unless_cancelled(wrapped_conn_future, conn)
 
-        wrapped_conn_future = Future()
-        conn_future = do_connect(request)
-        IOLoop.current.add_future(conn_future, wrap_conn_future_callback)
+    wrapped_conn_future = Future()
+    conn_future = do_connect(request)
+    IOLoop.current().add_future(conn_future, wrap_conn_future_callback)
 
-        return wrapped_conn_future
+    return wrapped_conn_future
 
 
 def redirect_request(
@@ -1715,8 +1718,12 @@ def redirect_request(
         raise RequestRedirectError('max_redirects occurred, no more redirect')
 
     original_request = getattr(request, "original_request", request)
-    new_request = copy.copy(request)
+    new_request = copy.copy(request.request)
     new_request.url = urljoin(request.url, target_location)
+    schema, sep, rest = new_request.url.partition(':')
+    schema = {'http': 'ws', 'https': 'wss'}[schema]
+    new_request.url = schema + sep + rest
+
     new_request.max_redirects = request.max_redirects - 1
     del new_request.headers["Host"]
     # http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4
@@ -1739,6 +1746,12 @@ def redirect_request(
         except KeyError:
             pass
     new_request.original_request = original_request
+    new_request = cast(
+        httpclient.HTTPRequest,
+        httpclient._RequestProxy(
+            new_request, httpclient.HTTPRequest._DEFAULTS)
+    )
+    
     return new_request
 
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -18,13 +18,14 @@ the protocol (known as "draft 76") and are not compatible with this module.
 
 import abc
 import base64
+import copy
 import hashlib
 import os
 import sys
 import struct
 import tornado.escape
 import tornado.web
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 import zlib
 
 from tornado.concurrent import Future, future_set_result_unless_cancelled
@@ -140,6 +141,21 @@ class WebSocketClosedError(WebSocketError):
     .. versionadded:: 3.2
     """
 
+    pass
+
+
+class WebSocketRedirect(WebSocketError):
+    """Raised when code is 302/303 in received headers
+       while doing websocket handshake
+    """
+    def __init__(self, target_location: str) -> None:
+        self.target_location = target_location
+
+
+class RequestRedirectError(WebSocketError):
+    """Raised when request's max_redirects <= 0
+       or follow_redirect is False
+    """
     pass
 
 
@@ -1376,6 +1392,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         self.ping_interval = ping_interval
         self.ping_timeout = ping_timeout
         self.max_message_size = max_message_size
+        self._redirect_location = None
 
         scheme, sep, rest = request.url.partition(":")
         scheme = {"ws": "http", "wss": "https"}[scheme]
@@ -1437,7 +1454,10 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
 
     def _on_http_response(self, response: httpclient.HTTPResponse) -> None:
         if not self.connect_future.done():
-            if response.error:
+            if self._redirect_location is not None:
+                self.connect_future.set_exception(
+                    WebSocketRedirect(self._redirect_location))
+            elif response.error:
                 self.connect_future.set_exception(response.error)
             else:
                 self.connect_future.set_exception(
@@ -1450,6 +1470,10 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         headers: httputil.HTTPHeaders,
     ) -> None:
         assert isinstance(start_line, httputil.ResponseStartLine)
+        if start_line.code in (302, 303):
+            self._redirect_location = headers['Location']
+            return
+
         if start_line.code != 101:
             await super(WebSocketClientConnection, self).headers_received(
                 start_line, headers
@@ -1634,6 +1658,102 @@ def websocket_connect(
         httpclient.HTTPRequest,
         httpclient._RequestProxy(request, httpclient.HTTPRequest._DEFAULTS),
     )
+
+    conn_future = _websocket_connect(
+        request,
+        callback,
+        connect_timeout,
+        on_message_callback,
+        compression_options,
+        ping_interval,
+        ping_timeout,
+        max_message_size,
+        subprotocols,
+    )
+    wrapped_conn_future = Future()
+
+    def wrap_conn_future_callback(conn_future):
+        try:
+            conn = conn_future.result()
+        except WebSocketRedirect as e:
+            try:
+                new_request = redirect_request(request, e.target_location)
+            except RequestRedirectError as e:
+                wrapped_conn_future.set_exception(e)
+                return
+            else:
+                conn_future = _websocket_connect(
+                    new_request,
+                    callback,
+                    connect_timeout,
+                    on_message_callback,
+                    compression_options,
+                    ping_interval,
+                    ping_timeout,
+                    max_message_size,
+                    subprotocols,
+                )
+                IOLoop.current.add_future(
+                    conn_future, wrap_conn_future_callback)
+        except Exception as e:
+            wrapped_conn_future.set_exception(e)
+        else:
+            future_set_result_unless_cancelled(wrapped_conn_future, conn)
+
+        IOLoop.current.add_future(conn_future, wrap_conn_future_callback)
+
+        return wrapped_conn_future
+
+
+def redirect_request(
+        request: httpclient.HTTPRequest,
+        target_location: str
+) -> httpclient.HTTPRequest:
+    if not request.follow_redirects:
+        raise RequestRedirectError('follow_redirects is not True')
+
+    if request.max_redirects is None or request.max_redirects <= 0:
+        raise RequestRedirectError('max_redirects occurred, no more redirect')
+
+    original_request = getattr(request, "original_request", request)
+    new_request = copy.copy(request)
+    new_request.url = urljoin(request.url, target_location)
+    new_request.max_redirects = request.max_redirects - 1
+    del new_request.headers["Host"]
+    # http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4
+    # Client SHOULD make a GET request after a 303.
+    # According to the spec, 302 should be followed by the same
+    # method as the original request, but in practice browsers
+    # treat 302 the same as 303, and many servers use 302 for
+    # compatibility with pre-HTTP/1.1 user agents which don't
+    # understand the 303 status.
+    new_request.method = "GET"
+    new_request.body = None
+    for h in [
+        "Content-Length",
+        "Content-Type",
+        "Content-Encoding",
+        "Transfer-Encoding",
+    ]:
+        try:
+            del new_request.headers[h]
+        except KeyError:
+            pass
+    new_request.original_request = original_request
+    return new_request
+
+
+def _websocket_connect(
+    request: httpclient.HTTPRequest,
+    callback: Callable[["Future[WebSocketClientConnection]"], None] = None,
+    connect_timeout: float = None,
+    on_message_callback: Callable[[Union[None, str, bytes]], None] = None,
+    compression_options: Dict[str, Any] = None,
+    ping_interval: float = None,
+    ping_timeout: float = None,
+    max_message_size: int = _default_max_message_size,
+    subprotocols: List[str] = None,
+) -> "Future[WebSocketClientConnection]":
     conn = WebSocketClientConnection(
         request,
         on_message_callback=on_message_callback,


### PR DESCRIPTION
After meeting the same problem as issue #2405, following the 'raise an exception and do new websocket_connect to target location' mechanism, this PR was made.

* To be compliant with already existed HTTP1Connection workflow, This PR added a finish function to 
WebSocketConnection class to set WebsocketRedirect Exception for redirect cases, and added several lines of code in headers_received function to save the target_location for `finish`.

* A wrapper is added upon the original `websocket_connect` to handle WebsocketRedirect Exception
 