### PR TITLE
Fix no reproducible date on docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,7 @@ project = "Tornado"
 
 year_copyright = time.gmtime(
     int(os.environ.get(
-        'SOURCE_DATE_EPOCH', time.time()))
-    ).tm_year
+        'SOURCE_DATE_EPOCH', time.time()))).tm_year
 
 copyright = "2009-%d, The Tornado Authors" % year_copyright
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,13 @@ import tornado
 master_doc = "index"
 
 project = "Tornado"
-copyright = "2009-%s, The Tornado Authors" % time.strftime("%Y")
+
+year_copyright = time.gmtime(
+    int(os.environ.get(
+        'SOURCE_DATE_EPOCH', time.time()))
+    ).tm_year
+
+copyright = "2009-%d, The Tornado Authors" % year_copyright
 
 version = release = tornado.version
 


### PR DESCRIPTION
This is the applied patch mentioned on https://github.com/tornadoweb/tornado/issues/2558

On `docs/conf.py` use `SOURCE_DATE_EPOCH` if is on `os.environ`, either use `time.time()` (UTC)
