### PR TITLE
added imports on structure docs

### DIFF
--- a/docs/guide/structure.rst
+++ b/docs/guide/structure.rst
@@ -59,6 +59,8 @@ are mapped to ``StoryHandler``.  That number is passed (as a string) to
 ``StoryHandler.get``.
 
 ::
+import tornado.ioloop
+from tornado.web import Application, RequestHandler, url
 
     class MainHandler(RequestHandler):
         def get(self):
@@ -76,6 +78,10 @@ are mapped to ``StoryHandler``.  That number is passed (as a string) to
         url(r"/", MainHandler),
         url(r"/story/([0-9]+)", StoryHandler, dict(db=db), name="story")
         ])
+
+if __name__ == "__main__":
+    app.listen(8888)
+    tornado.ioloop.IOLoop.current().start()
 
 The `.Application` constructor takes many keyword arguments that
 can be used to customize the behavior of the application and enable


### PR DESCRIPTION
I was looking the docs and [this example](http://www.tornadoweb.org/en/stable/guide/structure.html#the-application-object) had no imports and the final loop. Since I'm new on tornado, I thought that it would be better to have this so beginners such as me wouldn't be lost. I added the imports and the app loop.

Also, since there is no really use for the db, I would suggest to take it off, to make it workable with a simple copy-and-paste. However, since I didnt't know the purpose of this, I didn't take the db off it. 