### PR TITLE
Add server_hostname kwarg to `TCPClient.connect`

### DIFF
--- a/docs/releases/v6.0.0.rst
+++ b/docs/releases/v6.0.0.rst
@@ -120,6 +120,12 @@ General changes
 - `.TCPServer.start` now supports a ``max_restarts`` argument (same as
   `.fork_processes`).
 
+`tornado.tcpclient`
+~~~~~~~~~~~~~~~~~~~
+
+- `.TCPClient.connect` now supports a ``server_hostname`` argument (forwarded
+  to `.IOStream.start_tls`).
+
 `tornado.testing`
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Allows overriding the `server_hostname` when connecting via TLS. This
can be useful when connecting to a server that hosts multiple SSL-based
services with distinct certificates, as the SNI (set by
`server_hostname` is used to determine which service to connect to.  If
unset, `server_hostname` still defaults to `host`.