### PR TITLE
websocket: Catch errors in async open() correctly (5.1 backport)

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -751,10 +751,14 @@ class WebSocketProtocol13(WebSocketProtocol):
         self.stream = self.handler.stream
 
         self.start_pinging()
-        open_result = self._run_callback(self.handler.open, *self.handler.open_args,
-                                         **self.handler.open_kwargs)
-        if open_result is not None:
-            yield open_result
+        try:
+            open_result = self.handler.open(*self.handler.open_args, **self.handler.open_kwargs)
+            if open_result is not None:
+                yield open_result
+        except Exception:
+            self.handler.log_exception(*sys.exc_info())
+            self._abort()
+
         yield self._receive_frame_loop()
 
     def _parse_extensions_header(self, headers):


### PR DESCRIPTION
Previously if open() was a coroutine and raised an error, the
connection would be left open.

Fixes #2570
backport of dc354c57adac to 5.1

Since the cherry-pick has conflicts and needed adapting to a pre-async-await world, I figured I would do the backport, in the hope it makes maintenance a bit easier.

cc @heybuddy