### PR TITLE
websocket: Fix set_nodelay

### DIFF
--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -198,6 +198,12 @@ class ErrorInAsyncOpenHandler(TestWebSocketHandler):
         raise Exception("boom")
 
 
+class NoDelayHandler(TestWebSocketHandler):
+    def open(self):
+        self.set_nodelay(True)
+        self.write_message("hello")
+
+
 class WebSocketBaseTestCase(AsyncHTTPTestCase):
     @gen.coroutine
     def ws_connect(self, path, **kwargs):
@@ -258,6 +264,7 @@ class WebSocketTest(WebSocketBaseTestCase):
                 ),
                 ("/error_in_open", ErrorInOpenHandler),
                 ("/error_in_async_open", ErrorInAsyncOpenHandler),
+                ("/nodelay", NoDelayHandler),
             ],
             template_loader=DictLoader({"message.html": "<b>{{ message }}</b>"}),
         )
@@ -561,6 +568,12 @@ class WebSocketTest(WebSocketBaseTestCase):
             ws = yield self.ws_connect("/error_in_async_open")
             res = yield ws.read_message()
         self.assertIsNone(res)
+
+    @gen_test
+    def test_nodelay(self):
+        ws = yield self.ws_connect("/nodelay")
+        res = yield ws.read_message()
+        self.assertEqual(res, "hello")
 
 
 class NativeCoroutineOnMessageHandler(TestWebSocketHandler):

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -558,8 +558,8 @@ class WebSocketHandler(tornado.web.RequestHandler):
 
         .. versionadded:: 3.1
         """
-        assert self.stream is not None
-        self.stream.set_nodelay(value)
+        assert self.ws_connection is not None
+        self.ws_connection.set_nodelay(value)
 
     def on_connection_close(self) -> None:
         if self.ws_connection:
@@ -712,6 +712,10 @@ class WebSocketProtocol(abc.ABC):
 
     @abc.abstractmethod
     async def _receive_frame_loop(self) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def set_nodelay(self, x: bool) -> None:
         raise NotImplementedError()
 
 
@@ -1344,6 +1348,9 @@ class WebSocketProtocol13(WebSocketProtocol):
 
         self.write_ping(b"")
         self.last_ping = now
+
+    def set_nodelay(self, x: bool) -> None:
+        self.stream.set_nodelay(x)
 
 
 class WebSocketClientConnection(simple_httpclient._HTTPConnection):


### PR DESCRIPTION
This method was untested and broken in 6.0.0.

Fixes #2611