### PR TITLE
httpclient: HTTPResponse.body returns empty string instead of raising

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -665,7 +665,7 @@ class HTTPResponse(object):
     @property
     def body(self) -> bytes:
         if self.buffer is None:
-            raise ValueError("body not set")
+            return b""
         elif self._body is None:
             self._body = self.buffer.getvalue()
 


### PR DESCRIPTION
In tornado 5, HTTPResponse.body would return None if there was no body
buffer (which included errors like timeouts and socket errors, but not
HTTP errors like 404). In tornado 6 this was changed to never return
None (to make it easier to work with type annotations) and raise an
error instead. This turned out to be disruptive, so change it back to
returning a value without raising (but now it's an empty byte string
instead of None).

Fixes #2626