### PR TITLE
twisted: Restore the install() function

### DIFF
--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -104,6 +104,30 @@ class TwistedResolver(Resolver):
         return result
 
 
+def install() -> None:
+    """Install ``AsyncioSelectorReactor`` as the default Twisted reactor.
+
+    .. deprecated:: 5.1
+
+       This function is provided for backwards compatibility; code
+       that does not require compatibility with older versions of
+       Tornado should use
+       ``twisted.internet.asyncioreactor.install()`` directly.
+
+    .. versionchanged:: 6.0.3
+
+       In Tornado 5.x and before, this function installed a reactor
+       based on the Tornado ``IOLoop``. When that reactor
+       implementation was removed in Tornado 6.0.0, this function was
+       removed as well. It was restored in Tornado 6.0.3 using the
+       ``asyncio`` reactor instead.
+
+    """
+    from twisted.internet.asyncioreactor import install
+
+    install()
+
+
 if hasattr(gen.convert_yielded, "register"):
 
     @gen.convert_yielded.register(Deferred)  # type: ignore


### PR DESCRIPTION
This function had more usage than I was aware of and we can preserve
the old behavior by making it an alias for asyncioreactor.install.

Fixes #2636