### PR TITLE
docs: conflict between sphinx-2.1, sphinxcontrib-asyncio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: xenial
 language: python
 matrix:
     fast_finish: true
+    allow_failures:
+      - python: nightly
 addons:
   apt: 
     packages:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinxcontrib.asyncio",
 ]
 
 primary_domain = "py"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
-    "sphinxcontrib.asyncio",
 ]
 
 primary_domain = "py"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-sphinx>=2.1
+sphinx>1.8.2,<2.1
+sphinxcontrib-asyncio
 sphinx_rtd_theme
 Twisted

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>1.8.2
+sphinx>1.8.2,<2.1
 sphinxcontrib-asyncio
 sphinx_rtd_theme
 Twisted

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-sphinx>1.8.2,<2.1
-sphinxcontrib-asyncio
+sphinx>=2.1
 sphinx_rtd_theme
 Twisted


### PR DESCRIPTION
Two ways to do this: downgrade sphinx, or get rid of sphinxcontrib-asyncio. I'll push up commits for both.

-----

example docs build error:

```
.../tornado/tornado/auth.py:docstring of tornado.auth.OpenIdMixin.get_authenticated_user:1:Error in "py:comethod" directive:
unknown option: "async".

.. py:comethod:: OpenIdMixin.get_authenticated_user(http_client: tornado.httpclient.AsyncHTTPClient = None) -> Dict[str, Any]
   :module: tornado.auth
   :async:

   Fetches the authenticated user data upon redirect.
   ...
```

where does that stuff come from? let's see:

```
$ ag comethod
venv/lib/python3.6/site-packages/sphinxcontrib/asyncio.py
100:class CoMethodDocumenter(MethodDocumenter):
104:    objtype = "comethod"
125:        self.directivetype = "comethod"
149:    app.add_directive_to_domain('py', 'comethod', PyCoroutineMethod)
152:    app.add_autodocumenter(CoMethodDocumenter)
(venv) [pierce@plo-mbp15 tornado]$ ag :async:
venv/lib/python3.6/site-packages/sphinx/ext/autodoc/__init__.py
1060:            self.add_line('   :async:', sourcename)
1362:            self.add_line('   :async:', sourcename)
```