### PR TITLE
Add Optional for types on expires/expires_days

### DIFF
--- a/docs/httpserver.rst
+++ b/docs/httpserver.rst
@@ -5,7 +5,7 @@
 
    HTTP Server
    -----------
-   .. autoclass:: HTTPServer(request_callback: Union[httputil.HTTPServerConnectionDelegate, Callable[[httputil.HTTPServerRequest], None]], no_keep_alive: bool = False, xheaders: bool = False, ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None, protocol: str = None, decompress_request: bool = False, chunk_size: int = None, max_header_size: int = None, idle_connection_timeout: float = None, body_timeout: float = None, max_body_size: int = None, max_buffer_size: int = None, trusted_downstream: List[str] = None)
+   .. autoclass:: HTTPServer(request_callback: Union[httputil.HTTPServerConnectionDelegate, Callable[[httputil.HTTPServerRequest], None]], no_keep_alive: bool = False, xheaders: bool = False, ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None, protocol: Optional[str] = None, decompress_request: bool = False, chunk_size: Optional[int] = None, max_header_size: Optional[int] = None, idle_connection_timeout: Optional[float] = None, body_timeout: Optional[float] = None, max_body_size: Optional[int] = None, max_buffer_size: Optional[int] = None, trusted_downstream: Optional[List[str]] = None)
       :members:
 
       The public interface of this class is mostly inherited from

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -161,7 +161,7 @@
    Application configuration
    -------------------------
 
-   .. autoclass:: Application(handlers: List[Union[Rule, Tuple]] = None, default_host: str = None, transforms: List[Type[OutputTransform]] = None, **settings)
+   .. autoclass:: Application(handlers: Optional[List[Union[Rule, Tuple]]] = None, default_host: Optional[str] = None, transforms: Optional[List[Type[OutputTransform]]] = None, **settings)
 
       .. attribute:: settings
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ license_file = LICENSE
 
 [mypy]
 python_version = 3.5
+no_implicit_optional = True
 
 [mypy-tornado.*,tornado.platform.*]
 disallow_untyped_defs = True

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -87,7 +87,7 @@ class OpenIdMixin(object):
 
     def authenticate_redirect(
         self,
-        callback_uri: str = None,
+        callback_uri: Optional[str] = None,
         ax_attrs: List[str] = ["name", "email", "language", "username"],
     ) -> None:
         """Redirects to the authentication URL for this service.
@@ -114,7 +114,7 @@ class OpenIdMixin(object):
         handler.redirect(endpoint + "?" + urllib.parse.urlencode(args))
 
     async def get_authenticated_user(
-        self, http_client: httpclient.AsyncHTTPClient = None
+        self, http_client: Optional[httpclient.AsyncHTTPClient] = None
     ) -> Dict[str, Any]:
         """Fetches the authenticated user data upon redirect.
 
@@ -146,7 +146,7 @@ class OpenIdMixin(object):
         return self._on_authentication_verified(resp)
 
     def _openid_args(
-        self, callback_uri: str, ax_attrs: Iterable[str] = [], oauth_scope: str = None
+        self, callback_uri: str, ax_attrs: Iterable[str] = [], oauth_scope: Optional[str] = None
     ) -> Dict[str, str]:
         handler = cast(RequestHandler, self)
         url = urllib.parse.urljoin(handler.request.full_url(), callback_uri)
@@ -286,9 +286,9 @@ class OAuthMixin(object):
 
     async def authorize_redirect(
         self,
-        callback_uri: str = None,
-        extra_params: Dict[str, Any] = None,
-        http_client: httpclient.AsyncHTTPClient = None,
+        callback_uri: Optional[str] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
+        http_client: Optional[httpclient.AsyncHTTPClient] = None,
     ) -> None:
         """Redirects the user to obtain OAuth authorization for this service.
 
@@ -334,7 +334,7 @@ class OAuthMixin(object):
         self._on_request_token(url, callback_uri, response)
 
     async def get_authenticated_user(
-        self, http_client: httpclient.AsyncHTTPClient = None
+        self, http_client: Optional[httpclient.AsyncHTTPClient] = None
     ) -> Dict[str, Any]:
         """Gets the OAuth authorized user and access token.
 
@@ -380,7 +380,7 @@ class OAuthMixin(object):
         return user
 
     def _oauth_request_token_url(
-        self, callback_uri: str = None, extra_params: Dict[str, Any] = None
+        self, callback_uri: Optional[str] = None, extra_params: Optional[Dict[str, Any]] = None
     ) -> str:
         handler = cast(RequestHandler, self)
         consumer_token = self._oauth_consumer_token()
@@ -547,11 +547,11 @@ class OAuth2Mixin(object):
 
     def authorize_redirect(
         self,
-        redirect_uri: str = None,
-        client_id: str = None,
-        client_secret: str = None,
-        extra_params: Dict[str, Any] = None,
-        scope: str = None,
+        redirect_uri: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
+        scope: Optional[str] = None,
         response_type: str = "code",
     ) -> None:
         """Redirects the user to obtain OAuth authorization for this service.
@@ -582,11 +582,11 @@ class OAuth2Mixin(object):
 
     def _oauth_request_token_url(
         self,
-        redirect_uri: str = None,
-        client_id: str = None,
-        client_secret: str = None,
-        code: str = None,
-        extra_params: Dict[str, Any] = None,
+        redirect_uri: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        code: Optional[str] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         url = self._OAUTH_ACCESS_TOKEN_URL  # type: ignore
         args = {}  # type: Dict[str, str]
@@ -605,8 +605,8 @@ class OAuth2Mixin(object):
     async def oauth2_request(
         self,
         url: str,
-        access_token: str = None,
-        post_args: Dict[str, Any] = None,
+        access_token: Optional[str] = None,
+        post_args: Optional[Dict[str, Any]] = None,
         **args: Any
     ) -> Any:
         """Fetches the given URL auth an OAuth2 access token.
@@ -709,7 +709,7 @@ class TwitterMixin(OAuthMixin):
     _OAUTH_NO_CALLBACKS = False
     _TWITTER_BASE_URL = "https://api.twitter.com/1.1"
 
-    async def authenticate_redirect(self, callback_uri: str = None) -> None:
+    async def authenticate_redirect(self, callback_uri: Optional[str] = None) -> None:
         """Just like `~OAuthMixin.authorize_redirect`, but
         auto-redirects if authorized.
 
@@ -735,7 +735,7 @@ class TwitterMixin(OAuthMixin):
         self,
         path: str,
         access_token: Dict[str, Any],
-        post_args: Dict[str, Any] = None,
+        post_args: Optional[Dict[str, Any]] = None,
         **args: Any
     ) -> Any:
         """Fetches the given API path, e.g., ``statuses/user_timeline/btaylor``
@@ -930,7 +930,7 @@ class FacebookGraphMixin(OAuth2Mixin):
         client_id: str,
         client_secret: str,
         code: str,
-        extra_fields: Dict[str, Any] = None,
+        extra_fields: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
         """Handles the login for the Facebook user, returning a user object.
 
@@ -1034,8 +1034,8 @@ class FacebookGraphMixin(OAuth2Mixin):
     async def facebook_request(
         self,
         path: str,
-        access_token: str = None,
-        post_args: Dict[str, Any] = None,
+        access_token: Optional[str] = None,
+        post_args: Optional[Dict[str, Any]] = None,
         **args: Any
     ) -> Any:
         """Fetches the given relative API path, e.g., "/btaylor/picture"
@@ -1099,7 +1099,7 @@ def _oauth_signature(
     method: str,
     url: str,
     parameters: Dict[str, Any] = {},
-    token: Dict[str, Any] = None,
+    token: Optional[Dict[str, Any]] = None,
 ) -> bytes:
     """Calculates the HMAC-SHA1 OAuth signature for the given request.
 
@@ -1132,7 +1132,7 @@ def _oauth10a_signature(
     method: str,
     url: str,
     parameters: Dict[str, Any] = {},
-    token: Dict[str, Any] = None,
+    token: Optional[Dict[str, Any]] = None,
 ) -> bytes:
     """Calculates the HMAC-SHA1 OAuth 1.0a signature for the given request.
 

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -146,7 +146,10 @@ class OpenIdMixin(object):
         return self._on_authentication_verified(resp)
 
     def _openid_args(
-        self, callback_uri: str, ax_attrs: Iterable[str] = [], oauth_scope: Optional[str] = None
+        self,
+        callback_uri: str,
+        ax_attrs: Iterable[str] = [],
+        oauth_scope: Optional[str] = None,
     ) -> Dict[str, str]:
         handler = cast(RequestHandler, self)
         url = urllib.parse.urljoin(handler.request.full_url(), callback_uri)
@@ -380,7 +383,9 @@ class OAuthMixin(object):
         return user
 
     def _oauth_request_token_url(
-        self, callback_uri: Optional[str] = None, extra_params: Optional[Dict[str, Any]] = None
+        self,
+        callback_uri: Optional[str] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         handler = cast(RequestHandler, self)
         consumer_token = self._oauth_consumer_token()

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -251,7 +251,10 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
                 break
 
     def _finish(
-        self, curl: pycurl.Curl, curl_error: Optional[int] = None, curl_message: Optional[str] = None
+        self,
+        curl: pycurl.Curl,
+        curl_error: Optional[int] = None,
+        curl_message: Optional[str] = None,
     ) -> None:
         info = curl.info  # type: ignore
         curl.info = None  # type: ignore

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -36,7 +36,11 @@ from tornado.httpclient import (
 )
 from tornado.log import app_log
 
-from typing import Dict, Any, Callable, Union, Deque, Tuple, Optional
+from typing import Dict, Any, Callable, Union, Tuple, Optional
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Deque  # noqa: F401
 
 curl_log = logging.getLogger("tornado.curl_httpclient")
 

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -36,18 +36,14 @@ from tornado.httpclient import (
 )
 from tornado.log import app_log
 
-from typing import Dict, Any, Callable, Union
-import typing
-
-if typing.TYPE_CHECKING:
-    from typing import Deque, Tuple, Optional  # noqa: F401
+from typing import Dict, Any, Callable, Union, Deque, Tuple, Optional
 
 curl_log = logging.getLogger("tornado.curl_httpclient")
 
 
 class CurlAsyncHTTPClient(AsyncHTTPClient):
     def initialize(  # type: ignore
-        self, max_clients: int = 10, defaults: Dict[str, Any] = None
+        self, max_clients: int = 10, defaults: Optional[Dict[str, Any]] = None
     ) -> None:
         super(CurlAsyncHTTPClient, self).initialize(defaults=defaults)
         # Typeshed is incomplete for CurlMulti, so just use Any for now.
@@ -255,7 +251,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
                 break
 
     def _finish(
-        self, curl: pycurl.Curl, curl_error: int = None, curl_message: str = None
+        self, curl: pycurl.Curl, curl_error: Optional[int] = None, curl_message: Optional[str] = None
     ) -> None:
         info = curl.info  # type: ignore
         curl.info = None  # type: ignore

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -75,11 +75,11 @@ class HTTP1ConnectionParameters(object):
     def __init__(
         self,
         no_keep_alive: bool = False,
-        chunk_size: int = None,
-        max_header_size: int = None,
-        header_timeout: float = None,
-        max_body_size: int = None,
-        body_timeout: float = None,
+        chunk_size: Optional[int] = None,
+        max_header_size: Optional[int] = None,
+        header_timeout: Optional[float] = None,
+        max_body_size: Optional[int] = None,
+        body_timeout: Optional[float] = None,
         decompress: bool = False,
     ) -> None:
         """
@@ -113,8 +113,8 @@ class HTTP1Connection(httputil.HTTPConnection):
         self,
         stream: iostream.IOStream,
         is_client: bool,
-        params: HTTP1ConnectionParameters = None,
-        context: object = None,
+        params: Optional[HTTP1ConnectionParameters] = None,
+        context: Optional[object] = None,
     ) -> None:
         """
         :arg stream: an `.IOStream`
@@ -377,7 +377,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         self,
         start_line: Union[httputil.RequestStartLine, httputil.ResponseStartLine],
         headers: httputil.HTTPHeaders,
-        chunk: bytes = None,
+        chunk: Optional[bytes] = None,
     ) -> "Future[None]":
         """Implements `.HTTPConnection.write_headers`."""
         lines = []
@@ -765,8 +765,8 @@ class HTTP1ServerConnection(object):
     def __init__(
         self,
         stream: iostream.IOStream,
-        params: HTTP1ConnectionParameters = None,
-        context: object = None,
+        params: Optional[HTTP1ConnectionParameters] = None,
+        context: Optional[object] = None,
     ) -> None:
         """
         :arg stream: an `.IOStream`

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -88,7 +88,7 @@ class HTTPClient(object):
 
     def __init__(
         self,
-        async_client_class: Union[Type["AsyncHTTPClient"], None] = None,
+        async_client_class: "Optional[Type[AsyncHTTPClient]]" = None,
         **kwargs: Any
     ) -> None:
         # Initialize self._closed at the beginning of the constructor

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -87,7 +87,9 @@ class HTTPClient(object):
     """
 
     def __init__(
-        self, async_client_class: Optional[Type["AsyncHTTPClient"]] = None, **kwargs: Any
+        self,
+        async_client_class: Optional[Type["AsyncHTTPClient"]] = None,
+        **kwargs: Any
     ) -> None:
         # Initialize self._closed at the beginning of the constructor
         # so that an exception raised here doesn't lead to confusing
@@ -384,7 +386,9 @@ class HTTPRequest(object):
         allow_ipv6: Optional[bool] = None,
         client_key: Optional[str] = None,
         client_cert: Optional[str] = None,
-        body_producer: Optional[Callable[[Callable[[bytes], None]], "Future[None]"]] = None,
+        body_producer: Optional[
+            Callable[[Callable[[bytes], None]], "Future[None]"]
+        ] = None,
         expect_100_continue: bool = False,
         decompress_response: Optional[bool] = None,
         ssl_options: Optional[Union[Dict[str, Any], ssl.SSLContext]] = None,
@@ -703,7 +707,10 @@ class HTTPClientError(Exception):
     """
 
     def __init__(
-        self, code: int, message: Optional[str] = None, response: Optional[HTTPResponse] = None
+        self,
+        code: int,
+        message: Optional[str] = None,
+        response: Optional[HTTPResponse] = None,
     ) -> None:
         self.code = code
         self.message = message or httputil.responses.get(code, "Unknown")

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -88,7 +88,7 @@ class HTTPClient(object):
 
     def __init__(
         self,
-        async_client_class: Optional[Type["AsyncHTTPClient"]] = None,
+        async_client_class: Union[Type["AsyncHTTPClient"], None] = None,
         **kwargs: Any
     ) -> None:
         # Initialize self._closed at the beginning of the constructor

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -87,7 +87,7 @@ class HTTPClient(object):
     """
 
     def __init__(
-        self, async_client_class: Type["AsyncHTTPClient"] = None, **kwargs: Any
+        self, async_client_class: Optional[Type["AsyncHTTPClient"]] = None, **kwargs: Any
     ) -> None:
         # Initialize self._closed at the beginning of the constructor
         # so that an exception raised here doesn't lead to confusing
@@ -211,7 +211,7 @@ class AsyncHTTPClient(Configurable):
             instance_cache[instance.io_loop] = instance
         return instance
 
-    def initialize(self, defaults: Dict[str, Any] = None) -> None:
+    def initialize(self, defaults: Optional[Dict[str, Any]] = None) -> None:
         self.io_loop = IOLoop.current()
         self.defaults = dict(HTTPRequest._DEFAULTS)
         if defaults is not None:
@@ -357,37 +357,37 @@ class HTTPRequest(object):
         self,
         url: str,
         method: str = "GET",
-        headers: Union[Dict[str, str], httputil.HTTPHeaders] = None,
-        body: Union[bytes, str] = None,
-        auth_username: str = None,
-        auth_password: str = None,
-        auth_mode: str = None,
-        connect_timeout: float = None,
-        request_timeout: float = None,
-        if_modified_since: Union[float, datetime.datetime] = None,
-        follow_redirects: bool = None,
-        max_redirects: int = None,
-        user_agent: str = None,
-        use_gzip: bool = None,
-        network_interface: str = None,
-        streaming_callback: Callable[[bytes], None] = None,
-        header_callback: Callable[[str], None] = None,
-        prepare_curl_callback: Callable[[Any], None] = None,
-        proxy_host: str = None,
-        proxy_port: int = None,
-        proxy_username: str = None,
-        proxy_password: str = None,
-        proxy_auth_mode: str = None,
-        allow_nonstandard_methods: bool = None,
-        validate_cert: bool = None,
-        ca_certs: str = None,
-        allow_ipv6: bool = None,
-        client_key: str = None,
-        client_cert: str = None,
-        body_producer: Callable[[Callable[[bytes], None]], "Future[None]"] = None,
+        headers: Optional[Union[Dict[str, str], httputil.HTTPHeaders]] = None,
+        body: Optional[Union[bytes, str]] = None,
+        auth_username: Optional[str] = None,
+        auth_password: Optional[str] = None,
+        auth_mode: Optional[str] = None,
+        connect_timeout: Optional[float] = None,
+        request_timeout: Optional[float] = None,
+        if_modified_since: Optional[Union[float, datetime.datetime]] = None,
+        follow_redirects: Optional[bool] = None,
+        max_redirects: Optional[int] = None,
+        user_agent: Optional[str] = None,
+        use_gzip: Optional[bool] = None,
+        network_interface: Optional[str] = None,
+        streaming_callback: Optional[Callable[[bytes], None]] = None,
+        header_callback: Optional[Callable[[str], None]] = None,
+        prepare_curl_callback: Optional[Callable[[Any], None]] = None,
+        proxy_host: Optional[str] = None,
+        proxy_port: Optional[int] = None,
+        proxy_username: Optional[str] = None,
+        proxy_password: Optional[str] = None,
+        proxy_auth_mode: Optional[str] = None,
+        allow_nonstandard_methods: Optional[bool] = None,
+        validate_cert: Optional[bool] = None,
+        ca_certs: Optional[str] = None,
+        allow_ipv6: Optional[bool] = None,
+        client_key: Optional[str] = None,
+        client_cert: Optional[str] = None,
+        body_producer: Optional[Callable[[Callable[[bytes], None]], "Future[None]"]] = None,
         expect_100_continue: bool = False,
-        decompress_response: bool = None,
-        ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None,
+        decompress_response: Optional[bool] = None,
+        ssl_options: Optional[Union[Dict[str, Any], ssl.SSLContext]] = None,
     ) -> None:
         r"""All parameters except ``url`` are optional.
 
@@ -624,14 +624,14 @@ class HTTPResponse(object):
         self,
         request: HTTPRequest,
         code: int,
-        headers: httputil.HTTPHeaders = None,
-        buffer: BytesIO = None,
-        effective_url: str = None,
-        error: BaseException = None,
-        request_time: float = None,
-        time_info: Dict[str, float] = None,
-        reason: str = None,
-        start_time: float = None,
+        headers: Optional[httputil.HTTPHeaders] = None,
+        buffer: Optional[BytesIO] = None,
+        effective_url: Optional[str] = None,
+        error: Optional[BaseException] = None,
+        request_time: Optional[float] = None,
+        time_info: Optional[Dict[str, float]] = None,
+        reason: Optional[str] = None,
+        start_time: Optional[float] = None,
     ) -> None:
         if isinstance(request, _RequestProxy):
             self.request = request.request
@@ -703,7 +703,7 @@ class HTTPClientError(Exception):
     """
 
     def __init__(
-        self, code: int, message: str = None, response: HTTPResponse = None
+        self, code: int, message: Optional[str] = None, response: Optional[HTTPResponse] = None
     ) -> None:
         self.code = code
         self.message = message or httputil.responses.get(code, "Unknown")

--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -157,16 +157,16 @@ class HTTPServer(TCPServer, Configurable, httputil.HTTPServerConnectionDelegate)
         ],
         no_keep_alive: bool = False,
         xheaders: bool = False,
-        ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None,
-        protocol: str = None,
+        ssl_options: Optional[Union[Dict[str, Any], ssl.SSLContext]] = None,
+        protocol: Optional[str] = None,
         decompress_request: bool = False,
-        chunk_size: int = None,
-        max_header_size: int = None,
-        idle_connection_timeout: float = None,
-        body_timeout: float = None,
-        max_body_size: int = None,
-        max_buffer_size: int = None,
-        trusted_downstream: List[str] = None,
+        chunk_size: Optional[int] = None,
+        max_header_size: Optional[int] = None,
+        idle_connection_timeout: Optional[float] = None,
+        body_timeout: Optional[float] = None,
+        max_body_size: Optional[int] = None,
+        max_buffer_size: Optional[int] = None,
+        trusted_downstream: Optional[List[str]] = None,
     ) -> None:
         # This method's signature is not extracted with autodoc
         # because we want its arguments to appear on the class
@@ -289,7 +289,7 @@ class _HTTPRequestContext(object):
         stream: iostream.IOStream,
         address: Tuple,
         protocol: Optional[str],
-        trusted_downstream: List[str] = None,
+        trusted_downstream: Optional[List[str]] = None,
     ) -> None:
         self.address = address
         # Save the socket's address family now so we know how to

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -367,16 +367,16 @@ class HTTPServerRequest(object):
 
     def __init__(
         self,
-        method: str = None,
-        uri: str = None,
+        method: Optional[str] = None,
+        uri: Optional[str] = None,
         version: str = "HTTP/1.0",
-        headers: HTTPHeaders = None,
-        body: bytes = None,
-        host: str = None,
-        files: Dict[str, List["HTTPFile"]] = None,
-        connection: "HTTPConnection" = None,
-        start_line: "RequestStartLine" = None,
-        server_connection: object = None,
+        headers: Optional[HTTPHeaders] = None,
+        body: Optional[bytes] = None,
+        host: Optional[str] = None,
+        files: Optional[Dict[str, List["HTTPFile"]]] = None,
+        connection: Optional["HTTPConnection"] = None,
+        start_line: Optional["RequestStartLine"] = None,
+        server_connection: Optional[object] = None,
     ) -> None:
         if start_line is not None:
             method, uri, version = start_line
@@ -590,7 +590,7 @@ class HTTPConnection(object):
         self,
         start_line: Union["RequestStartLine", "ResponseStartLine"],
         headers: HTTPHeaders,
-        chunk: bytes = None,
+        chunk: Optional[bytes] = None,
     ) -> "Future[None]":
         """Write an HTTP header block.
 
@@ -766,7 +766,7 @@ def parse_body_arguments(
     body: bytes,
     arguments: Dict[str, List[bytes]],
     files: Dict[str, List[HTTPFile]],
-    headers: HTTPHeaders = None,
+    headers: Optional[HTTPHeaders] = None,
 ) -> None:
     """Parses a form request body.
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -329,7 +329,7 @@ class IOLoop(Configurable):
 
         return AsyncIOLoop
 
-    def initialize(self, make_current: bool = None) -> None:
+    def initialize(self, make_current: Optional[bool] = None) -> None:
         if make_current is None:
             if IOLoop.current(instance=False) is None:
                 self.make_current()
@@ -457,7 +457,7 @@ class IOLoop(Configurable):
         """
         raise NotImplementedError()
 
-    def run_sync(self, func: Callable, timeout: float = None) -> Any:
+    def run_sync(self, func: Callable, timeout: Optional[float] = None) -> Any:
         """Starts the `IOLoop`, runs the given function, and stops the loop.
 
         The function must return either an awaitable object or

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -346,7 +346,9 @@ class BaseIOStream(object):
         """
         return None
 
-    def read_until_regex(self, regex: bytes, max_bytes: Optional[int] = None) -> Awaitable[bytes]:
+    def read_until_regex(
+        self, regex: bytes, max_bytes: Optional[int] = None
+    ) -> Awaitable[bytes]:
         """Asynchronously read until we have matched the given regex.
 
         The result includes the data that matches the regex and anything
@@ -383,7 +385,9 @@ class BaseIOStream(object):
             raise
         return future
 
-    def read_until(self, delimiter: bytes, max_bytes: Optional[int] = None) -> Awaitable[bytes]:
+    def read_until(
+        self, delimiter: bytes, max_bytes: Optional[int] = None
+    ) -> Awaitable[bytes]:
         """Asynchronously read until we have found the given delimiter.
 
         The result includes all the data read including the delimiter.

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -114,7 +114,7 @@ class StreamClosedError(IOError):
        Added the ``real_error`` attribute.
     """
 
-    def __init__(self, real_error: BaseException = None) -> None:
+    def __init__(self, real_error: Optional[BaseException] = None) -> None:
         super(StreamClosedError, self).__init__("Stream is closed")
         self.real_error = real_error
 
@@ -246,9 +246,9 @@ class BaseIOStream(object):
 
     def __init__(
         self,
-        max_buffer_size: int = None,
-        read_chunk_size: int = None,
-        max_write_buffer_size: int = None,
+        max_buffer_size: Optional[int] = None,
+        read_chunk_size: Optional[int] = None,
+        max_write_buffer_size: Optional[int] = None,
     ) -> None:
         """`BaseIOStream` constructor.
 
@@ -346,7 +346,7 @@ class BaseIOStream(object):
         """
         return None
 
-    def read_until_regex(self, regex: bytes, max_bytes: int = None) -> Awaitable[bytes]:
+    def read_until_regex(self, regex: bytes, max_bytes: Optional[int] = None) -> Awaitable[bytes]:
         """Asynchronously read until we have matched the given regex.
 
         The result includes the data that matches the regex and anything
@@ -383,7 +383,7 @@ class BaseIOStream(object):
             raise
         return future
 
-    def read_until(self, delimiter: bytes, max_bytes: int = None) -> Awaitable[bytes]:
+    def read_until(self, delimiter: bytes, max_bytes: Optional[int] = None) -> Awaitable[bytes]:
         """Asynchronously read until we have found the given delimiter.
 
         The result includes all the data read including the delimiter.
@@ -1147,7 +1147,7 @@ class IOStream(BaseIOStream):
             del data
 
     def connect(
-        self: _IOStreamType, address: tuple, server_hostname: str = None
+        self: _IOStreamType, address: tuple, server_hostname: Optional[str] = None
     ) -> "Future[_IOStreamType]":
         """Connects the socket to a remote address without blocking.
 
@@ -1222,8 +1222,8 @@ class IOStream(BaseIOStream):
     def start_tls(
         self,
         server_side: bool,
-        ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None,
-        server_hostname: str = None,
+        ssl_options: Optional[Union[Dict[str, Any], ssl.SSLContext]] = None,
+        server_hostname: Optional[str] = None,
     ) -> Awaitable["SSLIOStream"]:
         """Convert this `IOStream` to an `SSLIOStream`.
 
@@ -1480,7 +1480,7 @@ class SSLIOStream(IOStream):
         super(SSLIOStream, self)._handle_write()
 
     def connect(
-        self, address: Tuple, server_hostname: str = None
+        self, address: Tuple, server_hostname: Optional[str] = None
     ) -> "Future[SSLIOStream]":
         self._server_hostname = server_hostname
         # Ignore the result of connect(). If it fails,

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -304,7 +304,10 @@ class Locale(object):
         ]
 
     def translate(
-        self, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
+        self,
+        message: str,
+        plural_message: Optional[str] = None,
+        count: Optional[int] = None,
     ) -> str:
         """Returns the translation for the given message for this locale.
 
@@ -316,7 +319,11 @@ class Locale(object):
         raise NotImplementedError()
 
     def pgettext(
-        self, context: str, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
+        self,
+        context: str,
+        message: str,
+        plural_message: Optional[str] = None,
+        count: Optional[int] = None,
     ) -> str:
         raise NotImplementedError()
 
@@ -479,7 +486,10 @@ class CSVLocale(Locale):
         super(CSVLocale, self).__init__(code)
 
     def translate(
-        self, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
+        self,
+        message: str,
+        plural_message: Optional[str] = None,
+        count: Optional[int] = None,
     ) -> str:
         if plural_message is not None:
             assert count is not None
@@ -493,7 +503,11 @@ class CSVLocale(Locale):
         return message_dict.get(message, message)
 
     def pgettext(
-        self, context: str, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
+        self,
+        context: str,
+        message: str,
+        plural_message: Optional[str] = None,
+        count: Optional[int] = None,
     ) -> str:
         if self.translations:
             gen_log.warning("pgettext is not supported by CSVLocale")
@@ -511,7 +525,10 @@ class GettextLocale(Locale):
         super(GettextLocale, self).__init__(code)
 
     def translate(
-        self, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
+        self,
+        message: str,
+        plural_message: Optional[str] = None,
+        count: Optional[int] = None,
     ) -> str:
         if plural_message is not None:
             assert count is not None
@@ -520,7 +537,11 @@ class GettextLocale(Locale):
             return self.gettext(message)
 
     def pgettext(
-        self, context: str, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
+        self,
+        context: str,
+        message: str,
+        plural_message: Optional[str] = None,
+        count: Optional[int] = None,
     ) -> str:
         """Allows to set context for translation, accepts plural forms.
 

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -51,7 +51,7 @@ from tornado.log import gen_log
 
 from tornado._locale_data import LOCALE_NAMES
 
-from typing import Iterable, Any, Union, Dict
+from typing import Iterable, Any, Union, Dict, Optional
 
 _default_locale = "en_US"
 _translations = {}  # type: Dict[str, Any]
@@ -88,7 +88,7 @@ def set_default_locale(code: str) -> None:
     _supported_locales = frozenset(list(_translations.keys()) + [_default_locale])
 
 
-def load_translations(directory: str, encoding: str = None) -> None:
+def load_translations(directory: str, encoding: Optional[str] = None) -> None:
     """Loads translations from CSV files in a directory.
 
     Translations are strings with optional Python-style named placeholders
@@ -304,7 +304,7 @@ class Locale(object):
         ]
 
     def translate(
-        self, message: str, plural_message: str = None, count: int = None
+        self, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
     ) -> str:
         """Returns the translation for the given message for this locale.
 
@@ -316,7 +316,7 @@ class Locale(object):
         raise NotImplementedError()
 
     def pgettext(
-        self, context: str, message: str, plural_message: str = None, count: int = None
+        self, context: str, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
     ) -> str:
         raise NotImplementedError()
 
@@ -479,7 +479,7 @@ class CSVLocale(Locale):
         super(CSVLocale, self).__init__(code)
 
     def translate(
-        self, message: str, plural_message: str = None, count: int = None
+        self, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
     ) -> str:
         if plural_message is not None:
             assert count is not None
@@ -493,7 +493,7 @@ class CSVLocale(Locale):
         return message_dict.get(message, message)
 
     def pgettext(
-        self, context: str, message: str, plural_message: str = None, count: int = None
+        self, context: str, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
     ) -> str:
         if self.translations:
             gen_log.warning("pgettext is not supported by CSVLocale")
@@ -511,7 +511,7 @@ class GettextLocale(Locale):
         super(GettextLocale, self).__init__(code)
 
     def translate(
-        self, message: str, plural_message: str = None, count: int = None
+        self, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
     ) -> str:
         if plural_message is not None:
             assert count is not None
@@ -520,7 +520,7 @@ class GettextLocale(Locale):
             return self.gettext(message)
 
     def pgettext(
-        self, context: str, message: str, plural_message: str = None, count: int = None
+        self, context: str, message: str, plural_message: Optional[str] = None, count: Optional[int] = None
     ) -> str:
         """Allows to set context for translation, accepts plural forms.
 

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -121,7 +121,7 @@ class Condition(_TimeoutGarbageCollector):
             result += " waiters[%s]" % len(self._waiters)
         return result + ">"
 
-    def wait(self, timeout: Union[float, datetime.timedelta] = None) -> Awaitable[bool]:
+    def wait(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[bool]:
         """Wait for `.notify`.
 
         Returns a `.Future` that resolves ``True`` if the condition is notified,
@@ -231,7 +231,7 @@ class Event(object):
         """
         self._value = False
 
-    def wait(self, timeout: Union[float, datetime.timedelta] = None) -> Awaitable[None]:
+    def wait(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[None]:
         """Block until the internal flag is true.
 
         Returns an awaitable, which raises `tornado.util.TimeoutError` after a
@@ -412,7 +412,7 @@ class Semaphore(_TimeoutGarbageCollector):
                 break
 
     def acquire(
-        self, timeout: Union[float, datetime.timedelta] = None
+        self, timeout: Optional[Union[float, datetime.timedelta]] = None
     ) -> Awaitable[_ReleasingContextManager]:
         """Decrement the counter. Returns an awaitable.
 
@@ -526,7 +526,7 @@ class Lock(object):
         return "<%s _block=%s>" % (self.__class__.__name__, self._block)
 
     def acquire(
-        self, timeout: Union[float, datetime.timedelta] = None
+        self, timeout: Optional[Union[float, datetime.timedelta]] = None
     ) -> Awaitable[_ReleasingContextManager]:
         """Attempt to lock. Returns an awaitable.
 

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -121,7 +121,9 @@ class Condition(_TimeoutGarbageCollector):
             result += " waiters[%s]" % len(self._waiters)
         return result + ">"
 
-    def wait(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[bool]:
+    def wait(
+        self, timeout: Optional[Union[float, datetime.timedelta]] = None
+    ) -> Awaitable[bool]:
         """Wait for `.notify`.
 
         Returns a `.Future` that resolves ``True`` if the condition is notified,
@@ -231,7 +233,9 @@ class Event(object):
         """
         self._value = False
 
-    def wait(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[None]:
+    def wait(
+        self, timeout: Optional[Union[float, datetime.timedelta]] = None
+    ) -> Awaitable[None]:
         """Block until the internal flag is true.
 
         Returns an awaitable, which raises `tornado.util.TimeoutError` after a

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -208,7 +208,9 @@ class LogFormatter(logging.Formatter):
         return formatted.replace("\n", "\n    ")
 
 
-def enable_pretty_logging(options: Any = None, logger: Optional[logging.Logger] = None) -> None:
+def enable_pretty_logging(
+    options: Any = None, logger: Optional[logging.Logger] = None
+) -> None:
     """Turns on formatted logging output as configured.
 
     This is called automatically by `tornado.options.parse_command_line`

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     curses = None  # type: ignore
 
-from typing import Dict, Any, cast
+from typing import Dict, Any, cast, Optional
 
 # Logger objects for internal tornado use
 access_log = logging.getLogger("tornado.access")
@@ -208,7 +208,7 @@ class LogFormatter(logging.Formatter):
         return formatted.replace("\n", "\n    ")
 
 
-def enable_pretty_logging(options: Any = None, logger: logging.Logger = None) -> None:
+def enable_pretty_logging(options: Any = None, logger: Optional[logging.Logger] = None) -> None:
     """Turns on formatted logging output as configured.
 
     This is called automatically by `tornado.options.parse_command_line`

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -28,7 +28,6 @@ from tornado.ioloop import IOLoop
 from tornado.platform.auto import set_close_exec
 from tornado.util import Configurable, errno_from_exception
 
-import typing
 from typing import List, Callable, Any, Type, Dict, Union, Tuple, Awaitable, Optional
 
 # Note that the naming of ssl.Purpose is confusing; the purpose

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -29,10 +29,7 @@ from tornado.platform.auto import set_close_exec
 from tornado.util import Configurable, errno_from_exception
 
 import typing
-from typing import List, Callable, Any, Type, Dict, Union, Tuple, Awaitable
-
-if typing.TYPE_CHECKING:
-    from asyncio import Future  # noqa: F401
+from typing import List, Callable, Any, Type, Dict, Union, Tuple, Awaitable, Optional
 
 # Note that the naming of ssl.Purpose is confusing; the purpose
 # of a context is to authentiate the opposite side of the connection.
@@ -67,10 +64,10 @@ _DEFAULT_BACKLOG = 128
 
 def bind_sockets(
     port: int,
-    address: str = None,
+    address: Optional[str] = None,
     family: socket.AddressFamily = socket.AF_UNSPEC,
     backlog: int = _DEFAULT_BACKLOG,
-    flags: int = None,
+    flags: Optional[int] = None,
     reuse_port: bool = False,
 ) -> List[socket.socket]:
     """Creates listening sockets bound to the given port and address.
@@ -417,7 +414,7 @@ class ExecutorResolver(Resolver):
     """
 
     def initialize(
-        self, executor: concurrent.futures.Executor = None, close_executor: bool = True
+        self, executor: Optional[concurrent.futures.Executor] = None, close_executor: bool = True
     ) -> None:
         self.io_loop = IOLoop.current()
         if executor is not None:
@@ -591,7 +588,7 @@ def ssl_options_to_context(
 def ssl_wrap_socket(
     socket: socket.socket,
     ssl_options: Union[Dict[str, Any], ssl.SSLContext],
-    server_hostname: str = None,
+    server_hostname: Optional[str] = None,
     **kwargs: Any
 ) -> ssl.SSLSocket:
     """Returns an ``ssl.SSLSocket`` wrapping the given socket.

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -414,7 +414,9 @@ class ExecutorResolver(Resolver):
     """
 
     def initialize(
-        self, executor: Optional[concurrent.futures.Executor] = None, close_executor: bool = True
+        self,
+        executor: Optional[concurrent.futures.Executor] = None,
+        close_executor: bool = True,
     ) -> None:
         self.io_loop = IOLoop.current()
         if executor is not None:

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -104,7 +104,18 @@ from tornado.escape import _unicode, native_str
 from tornado.log import define_logging_options
 from tornado.util import basestring_type, exec_in
 
-from typing import Any, Iterator, Iterable, Tuple, Set, Dict, Callable, List, TextIO, Optional
+from typing import (
+    Any,
+    Iterator,
+    Iterable,
+    Tuple,
+    Set,
+    Dict,
+    Callable,
+    List,
+    TextIO,
+    Optional,
+)
 
 
 class Error(Exception):
@@ -686,7 +697,9 @@ def define(
     )
 
 
-def parse_command_line(args: Optional[List[str]] = None, final: bool = True) -> List[str]:
+def parse_command_line(
+    args: Optional[List[str]] = None, final: bool = True
+) -> List[str]:
     """Parses global options from the command line.
 
     See `OptionParser.parse_command_line`.

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -104,11 +104,7 @@ from tornado.escape import _unicode, native_str
 from tornado.log import define_logging_options
 from tornado.util import basestring_type, exec_in
 
-import typing
-from typing import Any, Iterator, Iterable, Tuple, Set, Dict, Callable, List, TextIO
-
-if typing.TYPE_CHECKING:
-    from typing import Optional  # noqa: F401
+from typing import Any, Iterator, Iterable, Tuple, Set, Dict, Callable, List, TextIO, Optional
 
 
 class Error(Exception):
@@ -211,12 +207,12 @@ class OptionParser(object):
         self,
         name: str,
         default: Any = None,
-        type: type = None,
-        help: str = None,
-        metavar: str = None,
+        type: Optional[type] = None,
+        help: Optional[str] = None,
+        metavar: Optional[str] = None,
         multiple: bool = False,
-        group: str = None,
-        callback: Callable[[Any], None] = None,
+        group: Optional[str] = None,
+        callback: Optional[Callable[[Any], None]] = None,
     ) -> None:
         """Defines a new command line option.
 
@@ -295,7 +291,7 @@ class OptionParser(object):
         self._options[normalized] = option
 
     def parse_command_line(
-        self, args: List[str] = None, final: bool = True
+        self, args: Optional[List[str]] = None, final: bool = True
     ) -> List[str]:
         """Parses all options given on the command line (defaults to
         `sys.argv`).
@@ -417,7 +413,7 @@ class OptionParser(object):
         if final:
             self.run_parse_callbacks()
 
-    def print_help(self, file: TextIO = None) -> None:
+    def print_help(self, file: Optional[TextIO] = None) -> None:
         """Prints all the command line options to stderr (or another file)."""
         if file is None:
             file = sys.stderr
@@ -518,13 +514,13 @@ class _Option(object):
         self,
         name: str,
         default: Any = None,
-        type: type = None,
-        help: str = None,
-        metavar: str = None,
+        type: Optional[type] = None,
+        help: Optional[str] = None,
+        metavar: Optional[str] = None,
         multiple: bool = False,
-        file_name: str = None,
-        group_name: str = None,
-        callback: Callable[[Any], None] = None,
+        file_name: Optional[str] = None,
+        group_name: Optional[str] = None,
+        callback: Optional[Callable[[Any], None]] = None,
     ) -> None:
         if default is None and multiple:
             default = []
@@ -667,12 +663,12 @@ All defined options are available as attributes on this object.
 def define(
     name: str,
     default: Any = None,
-    type: type = None,
-    help: str = None,
-    metavar: str = None,
+    type: Optional[type] = None,
+    help: Optional[str] = None,
+    metavar: Optional[str] = None,
     multiple: bool = False,
-    group: str = None,
-    callback: Callable[[Any], None] = None,
+    group: Optional[str] = None,
+    callback: Optional[Callable[[Any], None]] = None,
 ) -> None:
     """Defines an option in the global namespace.
 
@@ -690,7 +686,7 @@ def define(
     )
 
 
-def parse_command_line(args: List[str] = None, final: bool = True) -> List[str]:
+def parse_command_line(args: Optional[List[str]] = None, final: bool = True) -> List[str]:
     """Parses global options from the command line.
 
     See `OptionParser.parse_command_line`.
@@ -706,7 +702,7 @@ def parse_config_file(path: str, final: bool = True) -> None:
     return options.parse_config_file(path, final=final)
 
 
-def print_help(file: TextIO = None) -> None:
+def print_help(file: Optional[TextIO] = None) -> None:
     """Prints all the command line options to stderr (or another file).
 
     See `OptionParser.print_help`.

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -89,7 +89,7 @@ def _pipe_cloexec() -> Tuple[int, int]:
 _task_id = None
 
 
-def fork_processes(num_processes: Optional[int], max_restarts: int = None) -> int:
+def fork_processes(num_processes: Optional[int], max_restarts: Optional[int] = None) -> int:
     """Starts multiple worker processes.
 
     If ``num_processes`` is None or <= 0, we detect the number of cores

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -89,7 +89,9 @@ def _pipe_cloexec() -> Tuple[int, int]:
 _task_id = None
 
 
-def fork_processes(num_processes: Optional[int], max_restarts: Optional[int] = None) -> int:
+def fork_processes(
+    num_processes: Optional[int], max_restarts: Optional[int] = None
+) -> int:
     """Starts multiple worker processes.
 
     If ``num_processes`` is None or <= 0, we detect the number of cores

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -222,7 +222,9 @@ class Queue(Generic[_T]):
         else:
             self.__put_internal(item)
 
-    def get(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[_T]:
+    def get(
+        self, timeout: Optional[Union[float, datetime.timedelta]] = None
+    ) -> Awaitable[_T]:
         """Remove and return an item from the queue.
 
         Returns an awaitable which resolves once an item is available, or raises
@@ -287,7 +289,9 @@ class Queue(Generic[_T]):
         if self._unfinished_tasks == 0:
             self._finished.set()
 
-    def join(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[None]:
+    def join(
+        self, timeout: Optional[Union[float, datetime.timedelta]] = None
+    ) -> Awaitable[None]:
         """Block until all items in the queue are processed.
 
         Returns an awaitable, which raises `tornado.util.TimeoutError` after a

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -33,11 +33,11 @@ from tornado import gen, ioloop
 from tornado.concurrent import Future, future_set_result_unless_cancelled
 from tornado.locks import Event
 
-from typing import Union, TypeVar, Generic, Awaitable
+from typing import Union, TypeVar, Generic, Awaitable, Optional
 import typing
 
 if typing.TYPE_CHECKING:
-    from typing import Deque, Tuple, List, Any  # noqa: F401
+    from typing import Deque, Tuple, Any  # noqa: F401
 
 _T = TypeVar("_T")
 
@@ -184,7 +184,7 @@ class Queue(Generic[_T]):
             return self.qsize() >= self.maxsize
 
     def put(
-        self, item: _T, timeout: Union[float, datetime.timedelta] = None
+        self, item: _T, timeout: Optional[Union[float, datetime.timedelta]] = None
     ) -> "Future[None]":
         """Put an item into the queue, perhaps waiting until there is room.
 
@@ -222,7 +222,7 @@ class Queue(Generic[_T]):
         else:
             self.__put_internal(item)
 
-    def get(self, timeout: Union[float, datetime.timedelta] = None) -> Awaitable[_T]:
+    def get(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[_T]:
         """Remove and return an item from the queue.
 
         Returns an awaitable which resolves once an item is available, or raises
@@ -287,7 +287,7 @@ class Queue(Generic[_T]):
         if self._unfinished_tasks == 0:
             self._finished.set()
 
-    def join(self, timeout: Union[float, datetime.timedelta] = None) -> Awaitable[None]:
+    def join(self, timeout: Optional[Union[float, datetime.timedelta]] = None) -> Awaitable[None]:
         """Block until all items in the queue are processed.
 
         Returns an awaitable, which raises `tornado.util.TimeoutError` after a

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -300,7 +300,7 @@ _RuleList = List[
 class RuleRouter(Router):
     """Rule-based router implementation."""
 
-    def __init__(self, rules: _RuleList = None) -> None:
+    def __init__(self, rules: Optional[_RuleList] = None) -> None:
         """Constructs a router from an ordered list of rules::
 
             RuleRouter([
@@ -409,7 +409,7 @@ class ReversibleRuleRouter(ReversibleRouter, RuleRouter):
     in a rule's matcher (see `Matcher.reverse`).
     """
 
-    def __init__(self, rules: _RuleList = None) -> None:
+    def __init__(self, rules: Optional[_RuleList] = None) -> None:
         self.named_rules = {}  # type: Dict[str, Any]
         super(ReversibleRuleRouter, self).__init__(rules)
 
@@ -445,8 +445,8 @@ class Rule(object):
         self,
         matcher: "Matcher",
         target: Any,
-        target_kwargs: Dict[str, Any] = None,
-        name: str = None,
+        target_kwargs: Optional[Dict[str, Any]] = None,
+        name: Optional[str] = None,
     ) -> None:
         """Constructs a Rule instance.
 
@@ -652,8 +652,8 @@ class URLSpec(Rule):
         self,
         pattern: Union[str, Pattern],
         handler: Any,
-        kwargs: Dict[str, Any] = None,
-        name: str = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+        name: Optional[str] = None,
     ) -> None:
         """Parameters:
 

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -89,12 +89,12 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
     def initialize(  # type: ignore
         self,
         max_clients: int = 10,
-        hostname_mapping: Dict[str, str] = None,
+        hostname_mapping: Optional[Dict[str, str]] = None,
         max_buffer_size: int = 104857600,
-        resolver: Resolver = None,
-        defaults: Dict[str, Any] = None,
-        max_header_size: int = None,
-        max_body_size: int = None,
+        resolver: Optional[Resolver] = None,
+        defaults: Optional[Dict[str, Any]] = None,
+        max_header_size: Optional[int] = None,
+        max_body_size: Optional[int] = None,
     ) -> None:
         """Creates a AsyncHTTPClient.
 
@@ -226,7 +226,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
                 self.io_loop.remove_timeout(timeout_handle)
             del self.waiting[key]
 
-    def _on_timeout(self, key: object, info: str = None) -> None:
+    def _on_timeout(self, key: object, info: Optional[str] = None) -> None:
         """Timeout callback of request.
 
         Construct a timeout HTTPResponse when a timeout occurs.
@@ -471,7 +471,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             return ssl_ctx
         return None
 
-    def _on_timeout(self, info: str = None) -> None:
+    def _on_timeout(self, info: Optional[str] = None) -> None:
         """Timeout callback of _HTTPConnection instance.
 
         Raise a `HTTPTimeoutError` when a timeout occurs.

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -30,11 +30,7 @@ from tornado.netutil import Resolver
 from tornado.platform.auto import set_close_exec
 from tornado.gen import TimeoutError
 
-import typing
-from typing import Any, Union, Dict, Tuple, List, Callable, Iterator
-
-if typing.TYPE_CHECKING:
-    from typing import Optional, Set  # noqa: F401
+from typing import Any, Union, Dict, Tuple, List, Callable, Iterator, Optional, Set
 
 _INITIAL_CONNECT_TIMEOUT = 0.3
 
@@ -105,7 +101,7 @@ class _Connector(object):
     def start(
         self,
         timeout: float = _INITIAL_CONNECT_TIMEOUT,
-        connect_timeout: Union[float, datetime.timedelta] = None,
+        connect_timeout: Optional[Union[float, datetime.timedelta]] = None,
     ) -> "Future[Tuple[socket.AddressFamily, Any, IOStream]]":
         self.try_connect(iter(self.primary_addrs))
         self.set_timeout(timeout)
@@ -207,7 +203,7 @@ class TCPClient(object):
        The ``io_loop`` argument (deprecated since version 4.1) has been removed.
     """
 
-    def __init__(self, resolver: Resolver = None) -> None:
+    def __init__(self, resolver: Optional[Resolver] = None) -> None:
         if resolver is not None:
             self.resolver = resolver
             self._own_resolver = False
@@ -224,11 +220,11 @@ class TCPClient(object):
         host: str,
         port: int,
         af: socket.AddressFamily = socket.AF_UNSPEC,
-        ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None,
-        max_buffer_size: int = None,
-        source_ip: str = None,
-        source_port: int = None,
-        timeout: Union[float, datetime.timedelta] = None,
+        ssl_options: Optional[Union[Dict[str, Any], ssl.SSLContext]] = None,
+        max_buffer_size: Optional[int] = None,
+        source_ip: Optional[str] = None,
+        source_port: Optional[int] = None,
+        timeout: Optional[Union[float, datetime.timedelta]] = None,
     ) -> IOStream:
         """Connect to the given host and port.
 
@@ -300,8 +296,8 @@ class TCPClient(object):
         max_buffer_size: int,
         af: socket.AddressFamily,
         addr: Tuple,
-        source_ip: str = None,
-        source_port: int = None,
+        source_ip: Optional[str] = None,
+        source_port: Optional[int] = None,
     ) -> Tuple[IOStream, "Future[IOStream]"]:
         # Always connect in plaintext; we'll convert to ssl if necessary
         # after one connection has completed.

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -107,9 +107,9 @@ class TCPServer(object):
 
     def __init__(
         self,
-        ssl_options: Union[Dict[str, Any], ssl.SSLContext] = None,
-        max_buffer_size: int = None,
-        read_chunk_size: int = None,
+        ssl_options: Optional[Union[Dict[str, Any], ssl.SSLContext]] = None,
+        max_buffer_size: Optional[int] = None,
+        read_chunk_size: Optional[int] = None,
     ) -> None:
         self.ssl_options = ssl_options
         self._sockets = {}  # type: Dict[int, socket.socket]
@@ -173,7 +173,7 @@ class TCPServer(object):
     def bind(
         self,
         port: int,
-        address: str = None,
+        address: Optional[str] = None,
         family: socket.AddressFamily = socket.AF_UNSPEC,
         backlog: int = 128,
         reuse_port: bool = False,
@@ -209,7 +209,7 @@ class TCPServer(object):
         else:
             self._pending_sockets.extend(sockets)
 
-    def start(self, num_processes: Optional[int] = 1, max_restarts: int = None) -> None:
+    def start(self, num_processes: Optional[int] = 1, max_restarts: Optional[int] = None) -> None:
         """Starts this server in the `.IOLoop`.
 
         By default, we run the server in this process and do not fork any

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -209,7 +209,9 @@ class TCPServer(object):
         else:
             self._pending_sockets.extend(sockets)
 
-    def start(self, num_processes: Optional[int] = 1, max_restarts: Optional[int] = None) -> None:
+    def start(
+        self, num_processes: Optional[int] = 1, max_restarts: Optional[int] = None
+    ) -> None:
         """Starts this server in the `.IOLoop`.
 
         By default, we run the server in this process and do not fork any

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -262,10 +262,10 @@ class Template(object):
         self,
         template_string: Union[str, bytes],
         name: str = "<string>",
-        loader: "BaseLoader" = None,
+        loader: Optional["BaseLoader"] = None,
         compress_whitespace: Union[bool, _UnsetMarker] = _UNSET,
         autoescape: Union[str, _UnsetMarker] = _UNSET,
-        whitespace: str = None,
+        whitespace: Optional[str] = None,
     ) -> None:
         """Construct a Template.
 
@@ -399,8 +399,8 @@ class BaseLoader(object):
     def __init__(
         self,
         autoescape: str = _DEFAULT_AUTOESCAPE,
-        namespace: Dict[str, Any] = None,
-        whitespace: str = None,
+        namespace: Optional[Dict[str, Any]] = None,
+        whitespace: Optional[str] = None,
     ) -> None:
         """Construct a template loader.
 
@@ -433,11 +433,11 @@ class BaseLoader(object):
         with self.lock:
             self.templates = {}
 
-    def resolve_path(self, name: str, parent_path: str = None) -> str:
+    def resolve_path(self, name: str, parent_path: Optional[str] = None) -> str:
         """Converts a possibly-relative path to absolute (used internally)."""
         raise NotImplementedError()
 
-    def load(self, name: str, parent_path: str = None) -> Template:
+    def load(self, name: str, parent_path: Optional[str] = None) -> Template:
         """Loads a template."""
         name = self.resolve_path(name, parent_path=parent_path)
         with self.lock:
@@ -457,7 +457,7 @@ class Loader(BaseLoader):
         super(Loader, self).__init__(**kwargs)
         self.root = os.path.abspath(root_directory)
 
-    def resolve_path(self, name: str, parent_path: str = None) -> str:
+    def resolve_path(self, name: str, parent_path: Optional[str] = None) -> str:
         if (
             parent_path
             and not parent_path.startswith("<")
@@ -485,7 +485,7 @@ class DictLoader(BaseLoader):
         super(DictLoader, self).__init__(**kwargs)
         self.dict = dict
 
-    def resolve_path(self, name: str, parent_path: str = None) -> str:
+    def resolve_path(self, name: str, parent_path: Optional[str] = None) -> str:
         if (
             parent_path
             and not parent_path.startswith("<")
@@ -707,7 +707,7 @@ class ParseError(Exception):
        Added ``filename`` and ``lineno`` attributes.
     """
 
-    def __init__(self, message: str, filename: str = None, lineno: int = 0) -> None:
+    def __init__(self, message: str, filename: Optional[str] = None, lineno: int = 0) -> None:
         self.message = message
         # The names "filename" and "lineno" are chosen for consistency
         # with python SyntaxError.
@@ -762,7 +762,7 @@ class _CodeWriter(object):
 
         return IncludeTemplate()
 
-    def write_line(self, line: str, line_number: int, indent: int = None) -> None:
+    def write_line(self, line: str, line_number: int, indent: Optional[int] = None) -> None:
         if indent is None:
             indent = self._indent
         line_comment = "  # %s:%d" % (self.current_template.name, line_number)
@@ -782,7 +782,7 @@ class _TemplateReader(object):
         self.line = 1
         self.pos = 0
 
-    def find(self, needle: str, start: int = 0, end: int = None) -> int:
+    def find(self, needle: str, start: int = 0, end: Optional[int] = None) -> int:
         assert start >= 0, start
         pos = self.pos
         start += pos
@@ -796,7 +796,7 @@ class _TemplateReader(object):
             index -= pos
         return index
 
-    def consume(self, count: int = None) -> str:
+    def consume(self, count: Optional[int] = None) -> str:
         if count is None:
             count = len(self.text) - self.pos
         newpos = self.pos + count
@@ -843,8 +843,8 @@ def _format_code(code: str) -> str:
 def _parse(
     reader: _TemplateReader,
     template: Template,
-    in_block: str = None,
-    in_loop: str = None,
+    in_block: Optional[str] = None,
+    in_loop: Optional[str] = None,
 ) -> _ChunkList:
     body = _ChunkList([])
     while True:

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -707,7 +707,9 @@ class ParseError(Exception):
        Added ``filename`` and ``lineno`` attributes.
     """
 
-    def __init__(self, message: str, filename: Optional[str] = None, lineno: int = 0) -> None:
+    def __init__(
+        self, message: str, filename: Optional[str] = None, lineno: int = 0
+    ) -> None:
         self.message = message
         # The names "filename" and "lineno" are chosen for consistency
         # with python SyntaxError.
@@ -762,7 +764,9 @@ class _CodeWriter(object):
 
         return IncludeTemplate()
 
-    def write_line(self, line: str, line_number: int, indent: Optional[int] = None) -> None:
+    def write_line(
+        self, line: str, line_number: int, indent: Optional[int] = None
+    ) -> None:
         if indent is None:
             indent = self._indent
         line_comment = "  # %s:%d" % (self.current_template.name, line_number)

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -260,7 +260,9 @@ class AsyncTestCase(unittest.TestCase):
             self.__failure = None
             raise_exc_info(failure)
 
-    def run(self, result: Optional[unittest.TestResult] = None) -> Optional[unittest.TestResult]:
+    def run(
+        self, result: Optional[unittest.TestResult] = None
+    ) -> Optional[unittest.TestResult]:
         ret = super(AsyncTestCase, self).run(result)
         # As a last resort, if an exception escaped super.run() and wasn't
         # re-raised in tearDown, raise it here.  This will cause the
@@ -288,7 +290,9 @@ class AsyncTestCase(unittest.TestCase):
         self.__stopped = True
 
     def wait(
-        self, condition: Optional[Callable[..., bool]] = None, timeout: Optional[float] = None
+        self,
+        condition: Optional[Callable[..., bool]] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         """Runs the `.IOLoop` until stop is called or timeout has passed.
 
@@ -519,7 +523,8 @@ def gen_test(func: Callable[..., Union[Generator, "Coroutine"]]) -> Callable[...
 
 
 def gen_test(  # noqa: F811
-    func: Optional[Callable[..., Union[Generator, "Coroutine"]]] = None, timeout: Optional[float] = None
+    func: Optional[Callable[..., Union[Generator, "Coroutine"]]] = None,
+    timeout: Optional[float] = None,
 ) -> Union[
     Callable[..., None],
     Callable[[Callable[..., Union[Generator, "Coroutine"]]], Callable[..., None]],

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -260,7 +260,7 @@ class AsyncTestCase(unittest.TestCase):
             self.__failure = None
             raise_exc_info(failure)
 
-    def run(self, result: unittest.TestResult = None) -> Optional[unittest.TestResult]:
+    def run(self, result: Optional[unittest.TestResult] = None) -> Optional[unittest.TestResult]:
         ret = super(AsyncTestCase, self).run(result)
         # As a last resort, if an exception escaped super.run() and wasn't
         # re-raised in tearDown, raise it here.  This will cause the
@@ -288,7 +288,7 @@ class AsyncTestCase(unittest.TestCase):
         self.__stopped = True
 
     def wait(
-        self, condition: Callable[..., bool] = None, timeout: float = None
+        self, condition: Optional[Callable[..., bool]] = None, timeout: Optional[float] = None
     ) -> None:
         """Runs the `.IOLoop` until stop is called or timeout has passed.
 
@@ -508,7 +508,7 @@ class AsyncHTTPSTestCase(AsyncHTTPTestCase):
 
 @typing.overload
 def gen_test(
-    *, timeout: float = None
+    *, timeout: Optional[float] = None
 ) -> Callable[[Callable[..., Union[Generator, "Coroutine"]]], Callable[..., None]]:
     pass
 
@@ -519,7 +519,7 @@ def gen_test(func: Callable[..., Union[Generator, "Coroutine"]]) -> Callable[...
 
 
 def gen_test(  # noqa: F811
-    func: Callable[..., Union[Generator, "Coroutine"]] = None, timeout: float = None
+    func: Optional[Callable[..., Union[Generator, "Coroutine"]]] = None, timeout: Optional[float] = None
 ) -> Union[
     Callable[..., None],
     Callable[[Callable[..., Union[Generator, "Coroutine"]]], Callable[..., None]],

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -157,7 +157,9 @@ def import_object(name: str) -> Any:
         raise ImportError("No module named %s" % parts[-1])
 
 
-def exec_in(code: Any, glob: Dict[str, Any], loc: Optional[Optional[Mapping[str, Any]]] = None) -> None:
+def exec_in(
+    code: Any, glob: Dict[str, Any], loc: Optional[Optional[Mapping[str, Any]]] = None
+) -> None:
     if isinstance(code, str):
         # exec(string) inherits the caller's future imports; compile
         # the string first to prevent that.

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -157,7 +157,7 @@ def import_object(name: str) -> Any:
         raise ImportError("No module named %s" % parts[-1])
 
 
-def exec_in(code: Any, glob: Dict[str, Any], loc: Mapping[str, Any] = None) -> None:
+def exec_in(code: Any, glob: Dict[str, Any], loc: Optional[Optional[Mapping[str, Any]]] = None) -> None:
     if isinstance(code, str):
         # exec(string) inherits the caller's future imports; compile
         # the string first to prevent that.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -598,9 +598,9 @@ class RequestHandler(object):
         name: str,
         value: Union[str, bytes],
         domain: str = None,
-        expires: Union[float, Tuple, datetime.datetime] = None,
+        expires: Optional[Union[float, Tuple, datetime.datetime]] = None,
         path: str = "/",
-        expires_days: int = None,
+        expires_days: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """Sets an outgoing cookie name/value with the given options.
@@ -682,7 +682,7 @@ class RequestHandler(object):
         self,
         name: str,
         value: Union[str, bytes],
-        expires_days: int = 30,
+        expires_days: Optional[int] = 30,
         version: int = None,
         **kwargs: Any
     ) -> None:
@@ -697,6 +697,7 @@ class RequestHandler(object):
         Note that the ``expires_days`` parameter sets the lifetime of the
         cookie in the browser, but is independent of the ``max_age_days``
         parameter to `get_secure_cookie`.
+        A value of None limits the lifetime to the current browser session.
 
         Secure cookies may contain arbitrary byte values, not just unicode
         strings (unlike regular cookies)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -648,7 +648,9 @@ class RequestHandler(object):
 
             morsel[k] = v
 
-    def clear_cookie(self, name: str, path: str = "/", domain: Optional[str] = None) -> None:
+    def clear_cookie(
+        self, name: str, path: str = "/", domain: Optional[str] = None
+    ) -> None:
         """Deletes the cookie with the given name.
 
         Due to limitations of the cookie protocol, you must pass the same
@@ -789,7 +791,9 @@ class RequestHandler(object):
             return None
         return get_signature_key_version(value)
 
-    def redirect(self, url: str, permanent: bool = False, status: Optional[int] = None) -> None:
+    def redirect(
+        self, url: str, permanent: bool = False, status: Optional[int] = None
+    ) -> None:
         """Sends a redirect to the given (optionally relative) URL.
 
         If the ``status`` argument is specified, that value is used as the
@@ -1541,7 +1545,9 @@ class RequestHandler(object):
             + '"/>'
         )
 
-    def static_url(self, path: str, include_host: Optional[bool] = None, **kwargs: Any) -> str:
+    def static_url(
+        self, path: str, include_host: Optional[bool] = None, **kwargs: Any
+    ) -> str:
         """Returns a static URL for the given relative static file path.
 
         This method requires you set the ``static_path`` setting in your
@@ -1922,7 +1928,9 @@ class _ApplicationRouter(ReversibleRuleRouter):
         `_ApplicationRouter` instance.
     """
 
-    def __init__(self, application: "Application", rules: Optional[_RuleList] = None) -> None:
+    def __init__(
+        self, application: "Application", rules: Optional[_RuleList] = None
+    ) -> None:
         assert isinstance(application, Application)
         self.application = application
         super(_ApplicationRouter, self).__init__(rules)
@@ -2358,7 +2366,11 @@ class HTTPError(Exception):
     """
 
     def __init__(
-        self, status_code: int = 500, log_message: Optional[str] = None, *args: Any, **kwargs: Any
+        self,
+        status_code: int = 500,
+        log_message: Optional[str] = None,
+        *args: Any,
+        **kwargs: Any
     ) -> None:
         self.status_code = status_code
         self.log_message = log_message

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -340,7 +340,7 @@ class RequestHandler(object):
         """
         pass
 
-    def set_status(self, status_code: int, reason: str = None) -> None:
+    def set_status(self, status_code: int, reason: Optional[str] = None) -> None:
         """Sets the status code for our response.
 
         :arg int status_code: Response status code.
@@ -554,7 +554,7 @@ class RequestHandler(object):
             values.append(s)
         return values
 
-    def decode_argument(self, value: bytes, name: str = None) -> str:
+    def decode_argument(self, value: bytes, name: Optional[str] = None) -> str:
         """Decodes an argument from the request.
 
         The argument has been percent-decoded and is now a byte string.
@@ -580,7 +580,7 @@ class RequestHandler(object):
         `self.request.cookies <.httputil.HTTPServerRequest.cookies>`."""
         return self.request.cookies
 
-    def get_cookie(self, name: str, default: str = None) -> Optional[str]:
+    def get_cookie(self, name: str, default: Optional[str] = None) -> Optional[str]:
         """Returns the value of the request cookie with the given name.
 
         If the named cookie is not present, returns ``default``.
@@ -597,7 +597,7 @@ class RequestHandler(object):
         self,
         name: str,
         value: Union[str, bytes],
-        domain: str = None,
+        domain: Optional[str] = None,
         expires: Optional[Union[float, Tuple, datetime.datetime]] = None,
         path: str = "/",
         expires_days: Optional[int] = None,
@@ -648,7 +648,7 @@ class RequestHandler(object):
 
             morsel[k] = v
 
-    def clear_cookie(self, name: str, path: str = "/", domain: str = None) -> None:
+    def clear_cookie(self, name: str, path: str = "/", domain: Optional[str] = None) -> None:
         """Deletes the cookie with the given name.
 
         Due to limitations of the cookie protocol, you must pass the same
@@ -662,7 +662,7 @@ class RequestHandler(object):
         expires = datetime.datetime.utcnow() - datetime.timedelta(days=365)
         self.set_cookie(name, value="", path=path, expires=expires, domain=domain)
 
-    def clear_all_cookies(self, path: str = "/", domain: str = None) -> None:
+    def clear_all_cookies(self, path: str = "/", domain: Optional[str] = None) -> None:
         """Deletes all the cookies the user sent with this request.
 
         See `clear_cookie` for more information on the path and domain
@@ -683,7 +683,7 @@ class RequestHandler(object):
         name: str,
         value: Union[str, bytes],
         expires_days: Optional[int] = 30,
-        version: int = None,
+        version: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """Signs and timestamps a cookie so it cannot be forged.
@@ -718,7 +718,7 @@ class RequestHandler(object):
         )
 
     def create_signed_value(
-        self, name: str, value: Union[str, bytes], version: int = None
+        self, name: str, value: Union[str, bytes], version: Optional[int] = None
     ) -> bytes:
         """Signs and timestamps a string so it cannot be forged.
 
@@ -746,9 +746,9 @@ class RequestHandler(object):
     def get_secure_cookie(
         self,
         name: str,
-        value: str = None,
+        value: Optional[str] = None,
         max_age_days: int = 31,
-        min_version: int = None,
+        min_version: Optional[int] = None,
     ) -> Optional[bytes]:
         """Returns the given signed cookie if it validates, or None.
 
@@ -776,7 +776,7 @@ class RequestHandler(object):
         )
 
     def get_secure_cookie_key_version(
-        self, name: str, value: str = None
+        self, name: str, value: Optional[str] = None
     ) -> Optional[int]:
         """Returns the signing key version of the secure cookie.
 
@@ -789,7 +789,7 @@ class RequestHandler(object):
             return None
         return get_signature_key_version(value)
 
-    def redirect(self, url: str, permanent: bool = False, status: int = None) -> None:
+    def redirect(self, url: str, permanent: bool = False, status: Optional[int] = None) -> None:
         """Sends a redirect to the given (optionally relative) URL.
 
         If the ``status`` argument is specified, that value is used as the
@@ -1101,7 +1101,7 @@ class RequestHandler(object):
                 future.set_result(None)
                 return future
 
-    def finish(self, chunk: Union[str, bytes, dict] = None) -> "Future[None]":
+    def finish(self, chunk: Optional[Union[str, bytes, dict]] = None) -> "Future[None]":
         """Finishes this response, ending the HTTP request.
 
         Passing a ``chunk`` to ``finish()`` is equivalent to passing that
@@ -1541,7 +1541,7 @@ class RequestHandler(object):
             + '"/>'
         )
 
-    def static_url(self, path: str, include_host: bool = None, **kwargs: Any) -> str:
+    def static_url(self, path: str, include_host: Optional[bool] = None, **kwargs: Any) -> str:
         """Returns a static URL for the given relative static file path.
 
         This method requires you set the ``static_path`` setting in your
@@ -1922,7 +1922,7 @@ class _ApplicationRouter(ReversibleRuleRouter):
         `_ApplicationRouter` instance.
     """
 
-    def __init__(self, application: "Application", rules: _RuleList = None) -> None:
+    def __init__(self, application: "Application", rules: Optional[_RuleList] = None) -> None:
         assert isinstance(application, Application)
         self.application = application
         super(_ApplicationRouter, self).__init__(rules)
@@ -2036,9 +2036,9 @@ class Application(ReversibleRouter):
 
     def __init__(
         self,
-        handlers: _RuleList = None,
-        default_host: str = None,
-        transforms: List[Type["OutputTransform"]] = None,
+        handlers: Optional[_RuleList] = None,
+        default_host: Optional[str] = None,
+        transforms: Optional[List[Type["OutputTransform"]]] = None,
         **settings: Any
     ) -> None:
         if transforms is None:
@@ -2189,9 +2189,9 @@ class Application(ReversibleRouter):
         self,
         request: httputil.HTTPServerRequest,
         target_class: Type[RequestHandler],
-        target_kwargs: Dict[str, Any] = None,
-        path_args: List[bytes] = None,
-        path_kwargs: Dict[str, bytes] = None,
+        target_kwargs: Optional[Dict[str, Any]] = None,
+        path_args: Optional[List[bytes]] = None,
+        path_kwargs: Optional[Dict[str, bytes]] = None,
     ) -> "_HandlerDelegate":
         """Returns `~.httputil.HTTPMessageDelegate` that can serve a request
         for application and `RequestHandler` subclass.
@@ -2358,7 +2358,7 @@ class HTTPError(Exception):
     """
 
     def __init__(
-        self, status_code: int = 500, log_message: str = None, *args: Any, **kwargs: Any
+        self, status_code: int = 500, log_message: Optional[str] = None, *args: Any, **kwargs: Any
     ) -> None:
         self.status_code = status_code
         self.log_message = log_message
@@ -2558,7 +2558,7 @@ class StaticFileHandler(RequestHandler):
     _static_hashes = {}  # type: Dict[str, Optional[str]]
     _lock = threading.Lock()  # protects _static_hashes
 
-    def initialize(self, path: str, default_filename: str = None) -> None:
+    def initialize(self, path: str, default_filename: Optional[str] = None) -> None:
         self.root = path
         self.default_filename = default_filename
 
@@ -2784,7 +2784,7 @@ class StaticFileHandler(RequestHandler):
 
     @classmethod
     def get_content(
-        cls, abspath: str, start: int = None, end: int = None
+        cls, abspath: str, start: Optional[int] = None, end: Optional[int] = None
     ) -> Generator[bytes, None, None]:
         """Retrieve the content of the requested resource which is located
         at the given absolute path.
@@ -3348,9 +3348,9 @@ def create_signed_value(
     secret: _CookieSecretTypes,
     name: str,
     value: Union[str, bytes],
-    version: int = None,
-    clock: Callable[[], float] = None,
-    key_version: int = None,
+    version: Optional[int] = None,
+    clock: Optional[Callable[[], float]] = None,
+    key_version: Optional[int] = None,
 ) -> bytes:
     if version is None:
         version = DEFAULT_SIGNED_VALUE_VERSION
@@ -3439,8 +3439,8 @@ def decode_signed_value(
     name: str,
     value: Union[None, str, bytes],
     max_age_days: int = 31,
-    clock: Callable[[], float] = None,
-    min_version: int = None,
+    clock: Optional[Callable[[], float]] = None,
+    min_version: Optional[int] = None,
 ) -> Optional[bytes]:
     if clock is None:
         clock = time.time

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
         # the server side and WebSocketClientConnection on the client
         # side.
         def on_ws_connection_close(
-            self, close_code: int = None, close_reason: str = None
+            self, close_code: Optional[int] = None, close_reason: Optional[str] = None
         ) -> None:
             pass
 
@@ -122,10 +122,10 @@ class _DecompressTooLargeError(Exception):
 class _WebSocketParams(object):
     def __init__(
         self,
-        ping_interval: float = None,
-        ping_timeout: float = None,
+        ping_interval: Optional[float] = None,
+        ping_timeout: Optional[float] = None,
         max_message_size: int = _default_max_message_size,
-        compression_options: Dict[str, Any] = None,
+        compression_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.ping_interval = ping_interval
         self.ping_timeout = ping_timeout
@@ -468,7 +468,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
         """
         pass
 
-    def close(self, code: int = None, reason: str = None) -> None:
+    def close(self, code: Optional[int] = None, reason: Optional[str] = None) -> None:
         """Closes this Web Socket.
 
         Once the close handshake is successful the socket will be closed.
@@ -571,7 +571,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
             self._break_cycles()
 
     def on_ws_connection_close(
-        self, close_code: int = None, close_reason: str = None
+        self, close_code: Optional[int] = None, close_reason: Optional[str] = None
     ) -> None:
         self.close_code = close_code
         self.close_reason = close_reason
@@ -670,7 +670,7 @@ class WebSocketProtocol(abc.ABC):
         self.close()  # let the subclass cleanup
 
     @abc.abstractmethod
-    def close(self, code: int = None, reason: str = None) -> None:
+    def close(self, code: Optional[int] = None, reason: Optional[str] = None) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -724,7 +724,7 @@ class _PerMessageDeflateCompressor(object):
         self,
         persistent: bool,
         max_wbits: Optional[int],
-        compression_options: Dict[str, Any] = None,
+        compression_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         if max_wbits is None:
             max_wbits = zlib.MAX_WBITS
@@ -773,7 +773,7 @@ class _PerMessageDeflateDecompressor(object):
         persistent: bool,
         max_wbits: Optional[int],
         max_message_size: int,
-        compression_options: Dict[str, Any] = None,
+        compression_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._max_message_size = max_message_size
         if max_wbits is None:
@@ -996,7 +996,7 @@ class WebSocketProtocol13(WebSocketProtocol):
         self,
         side: str,
         agreed_parameters: Dict[str, Any],
-        compression_options: Dict[str, Any] = None,
+        compression_options: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Converts a websocket agreed_parameters set to keyword arguments
         for our compressor objects.
@@ -1016,7 +1016,7 @@ class WebSocketProtocol13(WebSocketProtocol):
         self,
         side: str,
         agreed_parameters: Dict[str, Any],
-        compression_options: Dict[str, Any] = None,
+        compression_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         # TODO: handle invalid parameters gracefully
         allowed_keys = set(
@@ -1259,7 +1259,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             self._abort()
         return None
 
-    def close(self, code: int = None, reason: str = None) -> None:
+    def close(self, code: Optional[int] = None, reason: Optional[str] = None) -> None:
         """Closes the WebSocket connection."""
         if not self.server_terminated:
             if not self.stream.closed():
@@ -1365,10 +1365,10 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
     def __init__(
         self,
         request: httpclient.HTTPRequest,
-        on_message_callback: Callable[[Union[None, str, bytes]], None] = None,
-        compression_options: Dict[str, Any] = None,
-        ping_interval: float = None,
-        ping_timeout: float = None,
+        on_message_callback: Optional[Callable[[Union[None, str, bytes]], None]] = None,
+        compression_options: Optional[Dict[str, Any]] = None,
+        ping_interval: Optional[float] = None,
+        ping_timeout: Optional[float] = None,
         max_message_size: int = _default_max_message_size,
         subprotocols: Optional[List[str]] = [],
     ) -> None:
@@ -1420,7 +1420,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
             104857600,
         )
 
-    def close(self, code: int = None, reason: str = None) -> None:
+    def close(self, code: Optional[int] = None, reason: Optional[str] = None) -> None:
         """Closes the websocket connection.
 
         ``code`` and ``reason`` are documented under
@@ -1444,7 +1444,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         super(WebSocketClientConnection, self).on_connection_close()
 
     def on_ws_connection_close(
-        self, close_code: int = None, close_reason: str = None
+        self, close_code: Optional[int] = None, close_reason: Optional[str] = None
     ) -> None:
         self.close_code = close_code
         self.close_reason = close_reason
@@ -1506,7 +1506,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         return self.protocol.write_message(message, binary=binary)
 
     def read_message(
-        self, callback: Callable[["Future[Union[None, str, bytes]]"], None] = None
+        self, callback: Optional[Callable[["Future[Union[None, str, bytes]]"], None]] = None
     ) -> Awaitable[Union[None, str, bytes]]:
         """Reads a message from the WebSocket server.
 
@@ -1585,14 +1585,14 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
 
 def websocket_connect(
     url: Union[str, httpclient.HTTPRequest],
-    callback: Callable[["Future[WebSocketClientConnection]"], None] = None,
-    connect_timeout: float = None,
-    on_message_callback: Callable[[Union[None, str, bytes]], None] = None,
-    compression_options: Dict[str, Any] = None,
-    ping_interval: float = None,
-    ping_timeout: float = None,
+    callback: Optional[Callable[["Future[WebSocketClientConnection]"], None]] = None,
+    connect_timeout: Optional[float] = None,
+    on_message_callback: Optional[Callable[[Union[None, str, bytes]], None]] = None,
+    compression_options: Optional[Dict[str, Any]] = None,
+    ping_interval: Optional[float] = None,
+    ping_timeout: Optional[float] = None,
     max_message_size: int = _default_max_message_size,
-    subprotocols: List[str] = None,
+    subprotocols: Optional[List[str]] = None,
 ) -> "Awaitable[WebSocketClientConnection]":
     """Client-side websocket support.
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1506,7 +1506,8 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         return self.protocol.write_message(message, binary=binary)
 
     def read_message(
-        self, callback: Optional[Callable[["Future[Union[None, str, bytes]]"], None]] = None
+        self,
+        callback: Optional[Callable[["Future[Union[None, str, bytes]]"], None]] = None,
     ) -> Awaitable[Union[None, str, bytes]]:
         """Reads a message from the WebSocket server.
 


### PR DESCRIPTION
The runtime already allows and deal with `None` values here. Adding `Optional` improves the type checking and (since this is public API) allows users to run their type checker with strict-optional.