### PR TITLE
gen.with_timeout: Don't log CancelledError after timeout

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -559,7 +559,7 @@ def with_timeout(
     If the wrapped `.Future` fails after it has timed out, the exception
     will be logged unless it is either of a type contained in
     ``quiet_exceptions`` (which may be an exception type or a sequence of
-    types), or a `CancelledError`.
+    types), or a ``CancelledError``.
 
     The wrapped `.Future` is not canceled when the timeout expires,
     permitting it to be reused. `asyncio.wait_for` is similar to this


### PR DESCRIPTION
Hello!
I'm not very familiar with Tornado, but I'm investigating the failure on Python 3.8 (#2677).
From commit a237a995a1d54ad6e07c1ecdf5103ff8f45073b5, it seems that CancelledError should also be ignored in `tornado.gen.with_timeout`'s `error_callback`. Is that right?

This fixed tests on Python 3.8.0b1 for me.
