### PR TITLE
gen: Adapt to py38 CancelledError changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ dist: xenial
 language: python
 matrix:
     fast_finish: true
-    allow_failures:
-      - python: nightly
 addons:
   apt: 
     packages:

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -559,7 +559,7 @@ def with_timeout(
     If the wrapped `.Future` fails after it has timed out, the exception
     will be logged unless it is either of a type contained in
     ``quiet_exceptions`` (which may be an exception type or a sequence of
-    types), or a ``CancelledError``.
+    types), or an ``asyncio.CancelledError``.
 
     The wrapped `.Future` is not canceled when the timeout expires,
     permitting it to be reused. `asyncio.wait_for` is similar to this
@@ -574,8 +574,8 @@ def with_timeout(
     .. versionchanged:: 4.4
        Added support for yieldable objects other than `.Future`.
 
-    .. versionchanged:: 6.1
-       Do not log CancelledError after timeout.
+    .. versionchanged:: 6.0.3
+       ``asyncio.CancelledError`` is now always considered "quiet".
 
     """
     # It's tempting to optimize this by cancelling the input future on timeout

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -13,7 +13,6 @@
 # under the License.
 
 import collections
-from concurrent.futures import CancelledError
 import datetime
 import types
 
@@ -250,9 +249,7 @@ class Event(object):
         if timeout is None:
             return fut
         else:
-            timeout_fut = gen.with_timeout(
-                timeout, fut, quiet_exceptions=(CancelledError,)
-            )
+            timeout_fut = gen.with_timeout(timeout, fut)
             # This is a slightly clumsy workaround for the fact that
             # gen.with_timeout doesn't cancel its futures. Cancelling
             # fut will remove it from the waiters list.


### PR DESCRIPTION
python/cpython#13528 broke us in two ways: asyncio.CancelledError is
no longer an alias for concurrent.futures.CancelledError and it's now
a BaseException.

Fixes #2677
Closes #2681

cc @1st1