### PR TITLE
netutil: Ignore EADDRNOTAVAIL when binding to localhost ipv6

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -101,9 +101,7 @@ class IOLoop(Configurable):
             while True:
                 try:
                     connection, address = sock.accept()
-                except socket.error as e:
-                    if e.args[0] not in (errno.EWOULDBLOCK, errno.EAGAIN):
-                        raise
+                except BlockingIOError:
                     return
                 connection.setblocking(0)
                 io_loop = tornado.ioloop.IOLoop.current()

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -49,14 +49,6 @@ u"foo".encode("idna")
 # For undiagnosed reasons, 'latin1' codec may also need to be preloaded.
 u"foo".encode("latin1")
 
-# These errnos indicate that a non-blocking operation must be retried
-# at a later time.  On most platforms they're the same value, but on
-# some they differ.
-_ERRNO_WOULDBLOCK = (errno.EWOULDBLOCK, errno.EAGAIN)
-
-if hasattr(errno, "WSAEWOULDBLOCK"):
-    _ERRNO_WOULDBLOCK += (errno.WSAEWOULDBLOCK,)  # type: ignore
-
 # Default backlog used when calling sock.listen()
 _DEFAULT_BACKLOG = 128
 
@@ -199,9 +191,8 @@ if hasattr(socket, "AF_UNIX"):
         sock.setblocking(False)
         try:
             st = os.stat(file)
-        except OSError as err:
-            if errno_from_exception(err) != errno.ENOENT:
-                raise
+        except FileNotFoundError:
+            pass
         else:
             if stat.S_ISSOCK(st.st_mode):
                 os.remove(file)
@@ -254,17 +245,15 @@ def add_accept_handler(
                 return
             try:
                 connection, address = sock.accept()
-            except socket.error as e:
-                # _ERRNO_WOULDBLOCK indicate we have accepted every
+            except BlockingIOError:
+                # EWOULDBLOCK indicates we have accepted every
                 # connection that is available.
-                if errno_from_exception(e) in _ERRNO_WOULDBLOCK:
-                    return
+                return
+            except ConnectionAbortedError:
                 # ECONNABORTED indicates that there was a connection
                 # but it was closed while still in the accept queue.
                 # (observed on FreeBSD).
-                if errno_from_exception(e) == errno.ECONNABORTED:
-                    continue
-                raise
+                continue
             set_close_exec(connection.fileno())
             callback(connection, address)
 

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -30,7 +30,6 @@ import platform
 import random
 import socket
 import ssl
-import sys
 from unittest import mock
 import unittest
 
@@ -694,13 +693,7 @@ class TestIOStreamMixin(TestReadWriteMixin):
             with self.assertRaises(StreamClosedError):
                 yield stream.connect(("127.0.0.1", port))
 
-        self.assertTrue(isinstance(stream.error, socket.error), stream.error)
-        if sys.platform != "cygwin":
-            _ERRNO_CONNREFUSED = [errno.ECONNREFUSED]
-            if hasattr(errno, "WSAECONNREFUSED"):
-                _ERRNO_CONNREFUSED.append(errno.WSAECONNREFUSED)  # type: ignore
-            # cygwin's errnos don't match those used on native windows python
-            self.assertTrue(stream.error.args[0] in _ERRNO_CONNREFUSED)  # type: ignore
+        self.assertTrue(isinstance(stream.error, ConnectionRefusedError), stream.error)
 
     @gen_test
     def test_gaierror(self):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from contextlib import closing
+import getpass
 import os
 import socket
 import unittest
@@ -135,8 +136,7 @@ class TCPClientTest(AsyncTestCase):
             yield self.client.connect("127.0.0.1", port)
 
     def test_source_ip_fail(self):
-        """
-        Fail when trying to use the source IP Address '8.8.8.8'.
+        """Fail when trying to use the source IP Address '8.8.8.8'.
         """
         self.assertRaises(
             socket.error,
@@ -147,16 +147,18 @@ class TCPClientTest(AsyncTestCase):
         )
 
     def test_source_ip_success(self):
-        """
-        Success when trying to use the source IP Address '127.0.0.1'
+        """Success when trying to use the source IP Address '127.0.0.1'.
         """
         self.do_test_connect(socket.AF_INET, "127.0.0.1", source_ip="127.0.0.1")
 
     @skipIfNonUnix
     def test_source_port_fail(self):
+        """Fail when trying to use source port 1.
         """
-        Fail when trying to use source port 1.
-        """
+        if getpass.getuser() == "root":
+            # Root can use any port so we can't easily force this to fail.
+            # This is mainly relevant for docker.
+            self.skipTest("running as root")
         self.assertRaises(
             socket.error,
             self.do_test_connect,


### PR DESCRIPTION
This happens in docker with default configurations and is generally
harmless.

Fixes #2274

The first commit turns out to be unrelated; I thought it would streamline the second commit but there's no exception type for EADDRNOTAVAIL. With the third commit, the tests run cleanly in docker. 