### PR TITLE
SSLIOStream: Handle CertificateErrors like other errors

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1387,6 +1387,10 @@ class SSLIOStream(IOStream):
                 )
                 return self.close(exc_info=err)
             raise
+        except ssl.CertificateError as err:
+            # CertificateError can happen during handshake (hostname
+            # verification) and should be passed to user
+            return self.close(exc_info=err)
         except socket.error as err:
             # Some port scans (e.g. nmap in -sT mode) have been known
             # to cause do_handshake to raise EBADF and ENOTCONN, so make


### PR DESCRIPTION
The SSL module has CertificateErrors which are not thrown by the ssl module, and so also need to be handled.

Fixes: tornadoweb/tornado#2689