### PR TITLE
Strip documentation about removed argument

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1056,12 +1056,6 @@ class RequestHandler(object):
     def flush(self, include_footers: bool = False) -> "Future[None]":
         """Flushes the current output buffer to the network.
 
-        The ``callback`` argument, if given, can be used for flow control:
-        it will be run when all flushed data has been written to the socket.
-        Note that only one flush callback can be outstanding at a time;
-        if another flush occurs before the previous flush's callback
-        has been run, the previous callback will be discarded.
-
         .. versionchanged:: 4.0
            Now returns a `.Future` if no callback is given.
 


### PR DESCRIPTION
Now that the `callback` argument has been removed, the docstring for the method should not be all about it.

This could be replaced with some doc about how the returned future works, though really there shouldn't be concurrent writers.