### PR TITLE
Resolve pending reads on stream close

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -789,8 +789,11 @@ class BaseIOStream(object):
             self._read_from_buffer(pos)
 
     def _start_read(self) -> Future:
-        self._check_closed()  # Before reading, check that stream is not closed.
-        assert self._read_future is None, "Already reading"
+        if self._read_future is not None:
+            # raise StreamClosedError instead of assert
+            # in case of starting a second read after the stream is closed
+            self._check_closed()
+            assert self._read_future is None, "Already reading"
         self._read_future = Future()
         return self._read_future
 

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -601,9 +601,13 @@ class BaseIOStream(object):
                 self._finish_read(self._read_buffer_size, False)
             elif self._read_future is not None:
                 # resolve reads that are pending and ready to complete
-                pos = self._find_read_pos()
-                if pos is not None:
-                    self._read_from_buffer(pos)
+                try:
+                    pos = self._find_read_pos()
+                except UnsatisfiableReadError:
+                    pass
+                else:
+                    if pos is not None:
+                        self._read_from_buffer(pos)
             if self._state is not None:
                 self.io_loop.remove_handler(self.fileno())
                 self._state = None

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -599,6 +599,11 @@ class BaseIOStream(object):
             if self._read_until_close:
                 self._read_until_close = False
                 self._finish_read(self._read_buffer_size, False)
+            elif self._read_future is not None:
+                # resolve reads that are pending and ready to complete
+                pos = self._find_read_pos()
+                if pos is not None:
+                    self._read_from_buffer(pos)
             if self._state is not None:
                 self.io_loop.remove_handler(self.fileno())
                 self._state = None


### PR DESCRIPTION
- moves early check-for-close in `_start_read` added in #2670 to only the special case affected by #2651 because if the read buffer is not empty, a `try_inline_read` can succeed even if the stream is closed. I think the root cause of #2651 is still out there, because streams are getting closed and allowing a second read to occur.
- resolves reads that can be completed from the buffer during `IOStream.close()`, as is already done when `read_until_close`.

I was able to track down the issue in #2717 to [this optimization](https://github.com/tornadoweb/tornado/blob/v6.0.3/tornado/iostream.py#L775-L779), where `find_read_pos` is not called on every read.

Here's the sequence of events. I can reproduce this 100% of the time running my github oauth login, but cannot for the life of me figure out how to trigger it with a test, so hopefully this info is enough info for someone else to write a test for this:

- first read completes, reading 1370 bytes
- pos is not found, next_find_pos is 2740
- second read completes, reading 410 bytes, reaching the end of the response
- pos is not checked because 1780 < 2740, but if checked, the condition would be met and read completed
- third read completes, reading 0 bytes, indicating EOF

This is where it loos like the code expects the [`break`](https://github.com/tornadoweb/tornado/blob/v6.0.3/tornado/iostream.py#L762) to jump out of the loop and the final `_find_read_pos()` to complete the read. However:

- `_read_to_buffer` [calls `self.close()` when `bytes_read == 0`](https://github.com/tornadoweb/tornado/blob/v6.0.3/tornado/iostream.py#L873), 
- which in turn [starts setting StreamClosedError](https://github.com/tornadoweb/tornado/blob/v6.0.3/tornado/iostream.py#L631) on the read future and clearing state.
- This occurs *before* the `break` and therefore before the [eventual read_from_buffer call](https://github.com/tornadoweb/tornado/blob/v6.0.3/tornado/iostream.py#L831-L833) that would be triggered upon the return from `_read_to_buffer_loop`.

So the root cause is that `.close()` is terminating the read future while everything's in a state for the read future to be resolved, and this is caused by the optimization that checks for the read-end condition on less than every read. There might be a better fix. I haven't dug into the changes in 6.0 that triggered this to see if there's a simpler issue. It's possible that something like not considering a stream to be closed until its buffer has been consumed is a more robust fix for issues like this one and #2651.

closes #2717