### PR TITLE
curl_httpclient: Future.cancel() closes connection

### DIFF
--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -42,6 +42,7 @@ from io import BytesIO
 import ssl
 import time
 import weakref
+import asyncio
 
 from tornado.concurrent import (
     Future,
@@ -303,11 +304,11 @@ class AsyncHTTPClient(Configurable):
                     return
             future_set_result_unless_cancelled(future, response)
 
-        self.fetch_impl(cast(HTTPRequest, request_proxy), handle_response)
+        self.fetch_impl(cast(HTTPRequest, request_proxy), handle_response, future)
         return future
 
     def fetch_impl(
-        self, request: "HTTPRequest", callback: Callable[["HTTPResponse"], None]
+        self, request: "HTTPRequest", callback: Callable[["HTTPResponse"], None], future: asyncio.Future
     ) -> None:
         raise NotImplementedError()
 

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -32,6 +32,7 @@ import sys
 import time
 from io import BytesIO
 import urllib.parse
+import asyncio
 
 from typing import Dict, Any, Callable, Optional, Type, Union
 from types import TracebackType
@@ -163,7 +164,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         self.tcp_client.close()
 
     def fetch_impl(
-        self, request: HTTPRequest, callback: Callable[[HTTPResponse], None]
+        self, request: HTTPRequest, callback: Callable[[HTTPResponse], None], future: asyncio.Future
     ) -> None:
         key = object()
         self.queue.append((key, request, callback))


### PR DESCRIPTION
The user just needs to cancel the Future passed by the fetch() function, and it'll properly close the connection.  This works on curl_httpclient.  Simple_httpclient hasn't been implemented.