### PR TITLE
Fix extra data sending at HEAD response with Transfer-Encoding: Chunked

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -406,6 +406,8 @@ class HTTP1Connection(httputil.HTTPConnection):
                 # self._request_start_line.version or
                 # start_line.version?
                 self._request_start_line.version == "HTTP/1.1"
+                # Omit payload header field for HEAD request.
+                and self._request_start_line.method != "HEAD"
                 # 1xx, 204 and 304 responses have no body (not even a zero-length
                 # body), and so should not have either Content-Length or
                 # Transfer-Encoding headers.
@@ -511,10 +513,7 @@ class HTTP1Connection(httputil.HTTPConnection):
                 % self._expected_content_remaining
             )
         if self._chunking_output:
-            assert self._request_start_line
-            if not self.stream.closed() and (
-                self.is_client or self._request_start_line.method != "HEAD"
-            ):
+            if not self.stream.closed():
                 self._pending_write = self.stream.write(b"0\r\n\r\n")
                 self._pending_write.add_done_callback(self._on_write_complete)
         self._write_finished = True

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -511,7 +511,10 @@ class HTTP1Connection(httputil.HTTPConnection):
                 % self._expected_content_remaining
             )
         if self._chunking_output:
-            if not self.stream.closed():
+            assert self._request_start_line
+            if not self.stream.closed() and (
+                self.is_client or self._request_start_line.method != "HEAD"
+            ):
                 self._pending_write = self.stream.write(b"0\r\n\r\n")
                 self._pending_write.add_done_callback(self._on_write_complete)
         self._write_finished = True


### PR DESCRIPTION
Hi, Tornado send extra data `0\r\n\r\n` at HEAD response with Transfer-Encoding: Chunked.

```zsh
➜  ~ telnet localhost 8888
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
HEAD / HTTP/1.1

HTTP/1.1 200 OK
Server: TornadoServer/6.1.dev1
Content-Type: text/html; charset=UTF-8
Date: Sun, 08 Sep 2019 03:19:09 GMT
Transfer-Encoding: chunked

0

```