### PR TITLE
Supply a default User-Agent for the simple httpclient.

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -392,6 +392,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                     )
                 if self.request.user_agent:
                     self.request.headers["User-Agent"] = self.request.user_agent
+                else:
+                    self.request.headers["User-Agent"] = "Mozilla/5.0 (compatible; tornadoweb)"
                 if not self.request.allow_nonstandard_methods:
                     # Some HTTP methods nearly always have bodies while others
                     # almost never do. Fail in this case unless the user has


### PR DESCRIPTION
I saw a request in #2702 for a default User-Agent for the simple httpclients. This adds that.

I have a few questions:

- Should this be configurable or is passing a custom User-Agent enough?
- Is tornadoweb the correct name?