### PR TITLE
ci: Pin version of black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     # Ideally we'd run the lint stuff on the latest Python
     # version supported. But Python 3.7 requires slower-to-start VMs,
     # so we run it on 3.6 to minimize total CI run time.
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8 mypy==0.701 black; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install flake8 mypy==0.701 black==19.3b0; fi
     # We run docs on py37 because we need some bug fixes for introspection of annotations.
     - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then travis_retry pip install -r docs/requirements.txt; fi
     # On travis the extension should always be built

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ deps =
      {py3,py35,py36,py37}-full: pycares
      sphinx: -r{toxinidir}/docs/requirements.txt
      lint: flake8
-     lint: black
+     lint: black==19.3b0
      mypy: mypy==0.701
 
 setenv =


### PR DESCRIPTION
A new release of black changed the way some of our files are formatted,
so use a fixed version in CI.