### PR TITLE
demos: Fix lint in webspider demo

### DIFF
--- a/demos/webspider/webspider.py
+++ b/demos/webspider/webspider.py
@@ -86,7 +86,7 @@ async def main():
     assert fetching == (fetched | dead)
     print("Done in %d seconds, fetched %s URLs." % (time.time() - start, len(fetched)))
     print("Unable to fetch %s URLS." % len(dead))
-    
+
     # Signal all the workers to exit.
     for _ in range(concurrency):
         await q.put(None)


### PR DESCRIPTION
Updates #2765

The lint failure wasn't entirely caused by the black version change. 