### PR TITLE
Update hashing algorithm in StaticFileHandler

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1052,9 +1052,12 @@ class ErrorResponseTest(WebTestCase):
 
 
 class StaticFileTest(WebTestCase):
-    # The expected SHA1 hash of robots.txt, used in tests that call
+    # The expected SHA-512 hash of robots.txt, used in tests that call
     # StaticFileHandler.get_version
-    robots_txt_hash = b"63657cbb7d7086c56b0cd4e5c6999bb683664868"
+    robots_txt_hash = (
+        b"63a36e950e134b5217e33c763e88840c10a07d80e6057d92b9ac97508de7fb1f"
+        b"a6f0e9b7531e169657165ea764e8963399cb6d921ffe6078425aaafe54c04563"
+    )
     static_dir = os.path.join(os.path.dirname(__file__), "static")
 
     def get_handlers(self):

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1052,9 +1052,9 @@ class ErrorResponseTest(WebTestCase):
 
 
 class StaticFileTest(WebTestCase):
-    # The expected MD5 hash of robots.txt, used in tests that call
+    # The expected SHA1 hash of robots.txt, used in tests that call
     # StaticFileHandler.get_version
-    robots_txt_hash = b"f71d20196d4caf35b6a670db8c70b03d"
+    robots_txt_hash = b"63657cbb7d7086c56b0cd4e5c6999bb683664868"
     static_dir = os.path.join(os.path.dirname(__file__), "static")
 
     def get_handlers(self):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2822,12 +2822,12 @@ class StaticFileHandler(RequestHandler):
         """Returns a version string for the resource at the given path.
 
         This class method may be overridden by subclasses.  The
-        default implementation is a SHA1 hash of the file's contents.
+        default implementation is a SHA-512 hash of the file's contents.
 
         .. versionadded:: 3.1
         """
         data = cls.get_content(abspath)
-        hasher = hashlib.sha1()
+        hasher = hashlib.sha512()
         if isinstance(data, bytes):
             hasher.update(data)
         else:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2822,12 +2822,12 @@ class StaticFileHandler(RequestHandler):
         """Returns a version string for the resource at the given path.
 
         This class method may be overridden by subclasses.  The
-        default implementation is a hash of the file's contents.
+        default implementation is a SHA1 hash of the file's contents.
 
         .. versionadded:: 3.1
         """
         data = cls.get_content(abspath)
-        hasher = hashlib.md5()
+        hasher = hashlib.sha1()
         if isinstance(data, bytes):
             hasher.update(data)
         else:


### PR DESCRIPTION
Addresses #2776.

Some quick testing shows that SHA1 is somewhat faster than MD5 on
newer versions of Python:

```python
import hashlib
import secrets

data = secrets.token_bytes(1024 * 10000)
```

Using Jupyter's `%%timeit` magic:

```
%%timeit
hasher = hashlib.md5()
hasher.update(data)
hasher.hexdigest()
```
Example output: `12.5 ms ± 345 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)`

```
%%timeit
hasher = hashlib.sha1()
hasher.update(data)
hasher.hexdigest()
```
Example output: `8.94 ms ± 306 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)`