### PR TITLE
Fix syntax error in nested routing example

### DIFF
--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -142,7 +142,7 @@ Of course a nested `RuleRouter` or a `~.web.Application` is allowed:
 
     router = RuleRouter([
         Rule(HostMatches("example.com"), RuleRouter([
-            Rule(PathMatches("/app1/.*"), Application([(r"/app1/handler", Handler)]))),
+            Rule(PathMatches("/app1/.*"), Application([(r"/app1/handler", Handler)])),
         ]))
     ])
 


### PR DESCRIPTION
This removes an extra parenthesis in the nested routing documentation example to allow the example to work.