### PR TITLE
Improve tests on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Tests of static file handling assume unix-style line endings.
+tornado/test/static/*.txt text eol=lf
+tornado/test/static/dir/*.html text eol=lf
+tornado/test/templates/*.html text eol=lf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,18 @@ environment:
       TOX_ENV: "py37"
       TOX_ARGS: ""
 
+    - PYTHON: "C:\\Python38"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "32"
+      TOX_ENV: "py38"
+      TOX_ARGS: "tornado.test.websocket_test"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+      TOX_ENV: "py38"
+      TOX_ARGS: ""
+
 install:
   # Make sure the right python version is first on the PATH.
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/tornado/test/__init__.py
+++ b/tornado/test/__init__.py
@@ -1,0 +1,8 @@
+import asyncio
+import sys
+
+# Use the selector event loop on windows. Do this in tornado/test/__init__.py
+# instead of runtests.py so it happens no matter how the test is run (such as
+# through editor integrations).
+if sys.platform == "win32" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -25,6 +25,7 @@ from tornado.test.util import skipIfNonUnix, refusing_port, skipPypy3V58
 from tornado.web import RequestHandler, Application
 import errno
 import hashlib
+import logging
 import os
 import platform
 import random
@@ -366,7 +367,7 @@ class TestReadWriteMixin(object):
 
             # Not enough space, but we don't know it until all we can do is
             # log a warning and close the connection.
-            with ExpectLog(gen_log, "Unsatisfiable read"):
+            with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
                 fut = rs.read_until(b"def", max_bytes=5)
                 ws.write(b"123456")
                 yield closed.wait()
@@ -385,7 +386,7 @@ class TestReadWriteMixin(object):
             # inline.  For consistency with the out-of-line case, we
             # do not raise the error synchronously.
             ws.write(b"123456")
-            with ExpectLog(gen_log, "Unsatisfiable read"):
+            with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
                 with self.assertRaises(StreamClosedError):
                     yield rs.read_until(b"def", max_bytes=5)
             yield closed.wait()
@@ -403,7 +404,7 @@ class TestReadWriteMixin(object):
             # puts us over the limit, we fail the request because it was not
             # found within the limit.
             ws.write(b"abcdef")
-            with ExpectLog(gen_log, "Unsatisfiable read"):
+            with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
                 rs.read_until(b"def", max_bytes=5)
                 yield closed.wait()
         finally:
@@ -430,7 +431,7 @@ class TestReadWriteMixin(object):
 
             # Not enough space, but we don't know it until all we can do is
             # log a warning and close the connection.
-            with ExpectLog(gen_log, "Unsatisfiable read"):
+            with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
                 rs.read_until_regex(b"def", max_bytes=5)
                 ws.write(b"123456")
                 yield closed.wait()
@@ -449,7 +450,7 @@ class TestReadWriteMixin(object):
             # inline.  For consistency with the out-of-line case, we
             # do not raise the error synchronously.
             ws.write(b"123456")
-            with ExpectLog(gen_log, "Unsatisfiable read"):
+            with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
                 rs.read_until_regex(b"def", max_bytes=5)
                 yield closed.wait()
         finally:
@@ -466,7 +467,7 @@ class TestReadWriteMixin(object):
             # puts us over the limit, we fail the request because it was not
             # found within the limit.
             ws.write(b"abcdef")
-            with ExpectLog(gen_log, "Unsatisfiable read"):
+            with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
                 rs.read_until_regex(b"def", max_bytes=5)
                 yield closed.wait()
         finally:

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -163,6 +163,7 @@ class ThreadedResolverImportTest(unittest.TestCase):
 # name with spaces used in this test.
 @skipIfNoNetwork
 @unittest.skipIf(pycares is None, "pycares module not present")
+@unittest.skipIf(sys.platform == "win32", "pycares doesn't return loopback on windows")
 class CaresResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(CaresResolverTest, self).setUp()
@@ -181,6 +182,7 @@ class CaresResolverTest(AsyncTestCase, _ResolverTestMixin):
 @unittest.skipIf(
     getattr(twisted, "__version__", "0.0") < "12.1", "old version of twisted"
 )
+@unittest.skipIf(sys.platform == "win32", "twisted resolver hangs on windows")
 class TwistedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
         super(TwistedResolverTest, self).setUp()

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -316,7 +316,9 @@ class SimpleHTTPClientTestMixin(object):
         response = self.fetch("/content_length?value=2,%202,2")
         self.assertEqual(response.body, b"ok")
 
-        with ExpectLog(gen_log, ".*Multiple unequal Content-Lengths"):
+        with ExpectLog(
+            gen_log, ".*Multiple unequal Content-Lengths", level=logging.INFO
+        ):
             with self.assertRaises(HTTPStreamClosedError):
                 self.fetch("/content_length?value=2,4", raise_error=True)
             with self.assertRaises(HTTPStreamClosedError):
@@ -657,7 +659,9 @@ class HTTP204NoContentTestCase(AsyncHTTPTestCase):
 
     def test_204_invalid_content_length(self):
         # 204 status with non-zero content length is malformed
-        with ExpectLog(gen_log, ".*Response with code 204 should not have body"):
+        with ExpectLog(
+            gen_log, ".*Response with code 204 should not have body", level=logging.INFO
+        ):
             with self.assertRaises(HTTPStreamClosedError):
                 self.fetch("/?error=1", raise_error=True)
                 if not self.http1:
@@ -768,7 +772,9 @@ class MaxBodySizeTest(AsyncHTTPTestCase):
 
     def test_large_body(self):
         with ExpectLog(
-            gen_log, "Malformed HTTP message from None: Content-Length too long"
+            gen_log,
+            "Malformed HTTP message from None: Content-Length too long",
+            level=logging.INFO,
         ):
             with self.assertRaises(HTTPStreamClosedError):
                 self.fetch("/large", raise_error=True)
@@ -815,6 +821,7 @@ class ChunkedWithContentLengthTest(AsyncHTTPTestCase):
                 "Malformed HTTP message from None: Response "
                 "with both Transfer-Encoding and Content-Length"
             ),
+            level=logging.INFO,
         ):
             with self.assertRaises(HTTPStreamClosedError):
                 self.fetch("/chunkwithcl", raise_error=True)

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -51,7 +51,10 @@ skipIfNoTwisted = unittest.skipUnless(have_twisted, "twisted module not present"
 
 def save_signal_handlers():
     saved = {}
-    for sig in [signal.SIGINT, signal.SIGTERM, signal.SIGCHLD]:
+    signals = [signal.SIGINT, signal.SIGTERM]
+    if hasattr(signal, "SIGCHLD"):
+        signals.append(signal.SIGCHLD)
+    for sig in signals:
         saved[sig] = signal.getsignal(sig)
     if "twisted" in repr(saved):
         # This indicates we're not cleaning up after ourselves properly.


### PR DESCRIPTION
Fix various issues with tests on windows (and when running tests outside of runtests.py):
- Add gitattributes file to control line endings
- Force the use of the selector event loop in tests (this may be replaced by a more general solution in the future, but for now this gets the tests working)
- Skip a few tests and add some attribute guards
- Add a level argument to ExpectLog so it doesn't rely on logging configuration from runtests.py