### PR TITLE
iostream: Resolve pending reads on stream close

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -789,8 +789,11 @@ class BaseIOStream(object):
             self._read_from_buffer(pos)
 
     def _start_read(self) -> Future:
-        self._check_closed()  # Before reading, check that stream is not closed.
-        assert self._read_future is None, "Already reading"
+        if self._read_future is not None:
+            # raise StreamClosedError instead of assert
+            # in case of starting a second read after the stream is closed
+            self._check_closed()
+            assert self._read_future is None, "Already reading"
         self._read_future = Future()
         return self._read_future
 

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -601,9 +601,13 @@ class BaseIOStream(object):
                 self._finish_read(self._read_buffer_size, False)
             elif self._read_future is not None:
                 # resolve reads that are pending and ready to complete
-                pos = self._find_read_pos()
-                if pos is not None:
-                    self._read_from_buffer(pos)
+                try:
+                    pos = self._find_read_pos()
+                except UnsatisfiableReadError:
+                    pass
+                else:
+                    if pos is not None:
+                        self._read_from_buffer(pos)
             if self._state is not None:
                 self.io_loop.remove_handler(self.fileno())
                 self._state = None

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -599,6 +599,11 @@ class BaseIOStream(object):
             if self._read_until_close:
                 self._read_until_close = False
                 self._finish_read(self._read_buffer_size, False)
+            elif self._read_future is not None:
+                # resolve reads that are pending and ready to complete
+                pos = self._find_read_pos()
+                if pos is not None:
+                    self._read_from_buffer(pos)
             if self._state is not None:
                 self.io_loop.remove_handler(self.fileno())
                 self._state = None


### PR DESCRIPTION
Includes code from #2719 and tests from #2720. 

Fixes two bugs related to interactions between reads and closes:
- Reads which started before the close can now complete from data read into the buffer before the stream closed.
- Reads which start after the close can also use buffered data instead of immediately raising an error.

Fixing the latter issue narrowed the scope of the change introduced in #2670, so we should watch for a recurrence of #2651. We haven't been able to construct good test cases for #2651 or the second issue fixed here; the timing required is subtle (although we have non-unittest reproductions). 

Closes #2717
Closes #2719 
Closes #2720 
