### PR TITLE
Fix Google OAuth example

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -44,7 +44,7 @@ Example usage for Google OAuth:
                     code=self.get_argument('code'))
                 # Save the user with e.g. set_secure_cookie
             else:
-                await self.authorize_redirect(
+                self.authorize_redirect(
                     redirect_uri='http://your.site.com/auth/google',
                     client_id=self.settings['google_oauth']['key'],
                     scope=['profile', 'email'],
@@ -886,7 +886,7 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
                         # Save the user and access token with
                         # e.g. set_secure_cookie.
                     else:
-                        await self.authorize_redirect(
+                        self.authorize_redirect(
                             redirect_uri='http://your.site.com/auth/google',
                             client_id=self.settings['google_oauth']['key'],
                             scope=['profile', 'email'],


### PR DESCRIPTION
From tornado 6.0 OAuth2Mixin->authorize_redirect is an ordinary synchronous function.
Example returns error when await is used:
```Uncaught exception GET /auth/google (127.0.0.1)
    HTTPServerRequest(protocol='http', host='example.com', method='GET', uri='/auth/google', version='HTTP/1.0', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.6/dist-packages/tornado/web.py", line 1699, in _execute
        result = await result
      File "app.py", line 84, in get
        extra_params = {"approval_prompt": "auto"}
    TypeError: object NoneType can't be used in 'await' expression
```