### PR TITLE
Add Python 3.8 clasifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
I think this is okay as CI is running against Python 3.8

https://github.com/tornadoweb/tornado/blob/f7d94d0e8a57f51ffc0aac5d55ed7bf9f9936b4d/.travis.yml#L28-L29