### PR TITLE
Fix exception causes in web.py

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -569,10 +569,10 @@ class RequestHandler(object):
         """
         try:
             return _unicode(value)
-        except UnicodeDecodeError:
+        except UnicodeDecodeError as e:
             raise HTTPError(
                 400, "Invalid unicode in %s: %r" % (name or "url", value[:40])
-            )
+            ) from e
 
     @property
     def cookies(self) -> Dict[str, http.cookies.Morsel]:
@@ -3343,7 +3343,7 @@ class _UIModuleNamespace(object):
         try:
             return self[key]
         except KeyError as e:
-            raise AttributeError(str(e))
+            raise AttributeError(str(e)) from e
 
 
 def create_signed_value(


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706) and [Pandas](https://github.com/pandas-dev/pandas/pull/32322), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this:

```
During handling of the above exception, another exception occurred:
```

You'll get this:

```
The above exception was the direct cause of the following exception:
```

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think!

