### PR TITLE
Clarify instructions for escaping special character sequences

### DIFF
--- a/tornado/template.py
+++ b/tornado/template.py
@@ -98,7 +98,7 @@ template directives use ``{% %}``.
 To comment out a section so that it is omitted from the output, surround it
 with ``{# ... #}``.
 
-To include a literal ``{{``, ``{%``, or ``{#`` in the output, escape them as 
+To include a literal ``{{``, ``{%``, or ``{#`` in the output, escape them as
 ``{{!``, ``{%!``, and ``{#!``, respectively.
 
 

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -98,8 +98,7 @@ template directives use ``{% %}``.
 To comment out a section so that it is omitted from the output, surround it
 with ``{# ... #}``.
 
-These tags may be escaped as ``{{!``, ``{%!``, and ``{#!``
-if you need to include a literal ``{{``, ``{%``, or ``{#`` in the output.
+To include a literal ``{{``, ``{%``, or ``{#`` in the output, escape them as ``{{!``, ``{%!``, and ``{#!``, respectively.
 
 
 ``{% apply *function* %}...{% end %}``

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -98,7 +98,8 @@ template directives use ``{% %}``.
 To comment out a section so that it is omitted from the output, surround it
 with ``{# ... #}``.
 
-To include a literal ``{{``, ``{%``, or ``{#`` in the output, escape them as ``{{!``, ``{%!``, and ``{#!``, respectively.
+To include a literal ``{{``, ``{%``, or ``{#`` in the output, escape them as 
+``{{!``, ``{%!``, and ``{#!``, respectively.
 
 
 ``{% apply *function* %}...{% end %}``


### PR DESCRIPTION
Makes the sentence a little less confusing. 