### PR TITLE
Fix #1858 - locale closest match

### DIFF
--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -238,7 +238,7 @@ class Locale(object):
         for code in locale_codes:
             if not code:
                 continue
-            code = code.replace("-", "_")
+            code = code.replace("-", "_").split(";")[0]
             parts = code.split("_")
             if len(parts) > 2:
                 continue
@@ -248,6 +248,9 @@ class Locale(object):
                 return cls.get(code)
             if parts[0].lower() in _supported_locales:
                 return cls.get(parts[0].lower())
+            for supported in _supported_locales:
+                if code == supported.split("_")[0]:
+                    return cls.get(supported)
         return cls.get(_default_locale)
 
     @classmethod


### PR DESCRIPTION
This fixes the situation where the browser returns a two character locale, such as de, but the supported_locales includes de_DE.  Prior to this fix, it would return en_US (default) as it would not match the two character Acceptable Language value against the prefix of supported_locales.  It only did the reverse.

Currently Tornado does this:
| header | supported | match |
| ------- | ---------- | ------ |
| de_DE | de_DE | True |
| de_DE | de | True |
| de | de | True |
| de | de_DE | False |

This change will fix that last one to:
| header | supported | match |
| ------- | ---------- | ------ |
| de | de_DE | True |

Also, the Acceptable Language Header was returning `de,en-US;q=0.7,en;q=0.3` in my test, so I included a split of `;` to remove the `q=` assuming locale_codes returns that.  