### PR TITLE
Revert "docs: Use python 3.7 via conda for readthedocs builds"

### DIFF
--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -1,9 +1,0 @@
-# TODO: remove when RTD supports python 3.7 without conda
-name: tornado-docs
-dependencies:
-  - python=3.7
-  - pip:
-    - sphinx
-    - sphinx-rtd-theme
-    - sphinxcontrib-asyncio
-    - Twisted

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,0 @@
-# TODO: remove when RTD supports Python 3.7 without conda.
-# https://github.com/rtfd/readthedocs-docker-images/pull/73
-conda:
-  file: docs/conda.yml


### PR DESCRIPTION
This reverts commit e7e31e5642ae56da3f768d9829036eab99f0c988.

We were using conda to get access to python 3.7 before rtd supported
it in their regular builds, but this led to problems pinning a
specific version of sphinx. See
https://github.com/readthedocs/readthedocs.org/issues/6870