### PR TITLE
fix new E741 detected cases

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -448,7 +448,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         header_lines = (
             native_str(n) + ": " + native_str(v) for n, v in headers.get_all()
         )
-        lines.extend(l.encode("latin1") for l in header_lines)
+        lines.extend(line.encode("latin1") for line in header_lines)
         for line in lines:
             if b"\n" in line:
                 raise ValueError("Newline in header: " + repr(line))

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1300,7 +1300,7 @@ class RequestHandler(object):
                 locales.append((parts[0], score))
             if locales:
                 locales.sort(key=lambda pair: pair[1], reverse=True)
-                codes = [l[0] for l in locales]
+                codes = [loc[0] for loc in locales]
                 return locale.get(*codes)
         return locale.get(default)
 


### PR DESCRIPTION
In my last PR (https://github.com/tornadoweb/tornado/pull/2859), the travis pipeline failed. It is because in the new released `flake8` version, the E741 detection was improved inside comprehensions. This PR should fix both cases.