### PR TITLE
fix infinite loop hang with invalid gzip data

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -737,6 +737,10 @@ class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
                     if ret is not None:
                         await ret
                 compressed_data = self._decompressor.unconsumed_tail
+                if compressed_data and not decompressed:
+                    raise httputil.HTTPInputError(
+                        "encountered unconsumed gzip data without making progress"
+                    )
         else:
             ret = self._delegate.data_received(chunk)
             if ret is not None:


### PR DESCRIPTION
As reported in #2714, if Tornado encounters invalid gzip data while decoding an HTTP response, it can result in an infinite loop. This pull request adds a sanity check and raises an exception to break out of the infinite loop.

Invalid gzip data is rare (I've only encountered it once in years of using Tornado), but when it happens the consequences are severe, as Tornado hangs completely.