### PR TITLE
test: Add a sleep to deflake a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       env: TOX_ENV=lint
 
 install:
-    - travis_retry pip install tox tox-venv
+    - travis_retry pip install tox
     - python -VV
     - curl-config --version; pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ jobs:
       env: TOX_ENV=docs
     - python: '3.8'
       env: TOX_ENV=lint
+  allow_failures:
+    # Currently failing due to https://foss.heptapod.net/pypy/cffi/issues/458
+    - python: nightly
 
 install:
     - travis_retry pip install tox

--- a/tornado/test/process_test.py
+++ b/tornado/test/process_test.py
@@ -4,6 +4,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 import unittest
 
 from tornado.httpclient import HTTPClient, HTTPError
@@ -224,6 +225,14 @@ class SubprocessTest(AsyncTestCase):
         )
         self.addCleanup(subproc.stdout.close)
         subproc.set_exit_callback(self.stop)
+
+        # For unclear reasons, killing a process too soon after
+        # creating it can result in an exit status corresponding to
+        # SIGKILL instead of the actual signal involved. This has been
+        # observed on macOS 10.15 with Python 3.8 installed via brew,
+        # but not with the system-installed Python 3.7.
+        time.sleep(0.1)
+
         os.kill(subproc.pid, signal.SIGTERM)
         try:
             ret = self.wait(timeout=1.0)

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,6 @@
 # 'port install curl +universal' to get both 32- and 64-bit versions of
 # libcurl.
 [tox]
-# When tox is run from a venv (instead of a virtualenv), it can get confused
-# unless tox-venv is also installed.
-requires = tox-venv
 envlist =
         # Basic configurations: Run the tests for each python version.
         py35-full,py36-full,py37-full,py38-full,pypy3-full


### PR DESCRIPTION
Not sure why this has recently started happening in some environments,
but killing a process too soon causes the wrong exit status in some
python builds on macOS.