### PR TITLE
Update docs related to websocket_ping_timeout

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -207,7 +207,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
     value, a ping will be sent periodically and the connection will be
     closed if a response is not received before the ``websocket_ping_timeout``.
     Setting ``websocket_ping_timeout`` to a lower value than
-    ``websocket_ping_interval`` will result in the websocket connection being 
+    ``websocket_ping_interval`` will result in the websocket connection being
     closed after ``websocket_ping_interval``.
 
     Messages larger than the ``websocket_max_message_size`` application setting

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -204,8 +204,11 @@ class WebSocketHandler(tornado.web.RequestHandler):
     to accept it before the websocket connection will succeed.
 
     If the application setting ``websocket_ping_interval`` has a non-zero
-    value, a ping will be sent periodically, and the connection will be
+    value, a ping will be sent periodically and the connection will be
     closed if a response is not received before the ``websocket_ping_timeout``.
+    Setting ``websocket_ping_timeout`` to a lower value than
+    ``websocket_ping_interval`` will result in the websocket connection being 
+    closed after ``websocket_ping_interval``.
 
     Messages larger than the ``websocket_max_message_size`` application setting
     (default 10MiB) will not be accepted.


### PR DESCRIPTION
This change should add some clarification regarding the behaviour of  `websocket_ping_timeout`.

The following sentence seems a bit confusing:
```
If the application setting websocket_ping_interval has a non-zero value, a ping will be sent periodically, and the connection will be closed if a response is not received before the websocket_ping_timeout.
```

By setting websocket_ping_interval=30 and websocket_ping_timeout=5 I would expect that a ping is sent after 30s after the websocket connection is opened and if a reply is not received after 5 more seconds then the connection will be closed.
The actual behaviour is that the connection will be closed after 30s from the moment is was opened, and not 35s as expected and as the docs would imply.

I hope that nobody else has to waste time debugging issues related to this, that is why I think a clarification is necessary.

There current wording in this PR might not be ideal, so feel free to add alternatives.
