### PR TITLE
Remove text about callback (removed) in run_on_executor

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -74,8 +74,7 @@ dummy_executor = DummyExecutor()
 def run_on_executor(*args: Any, **kwargs: Any) -> Callable:
     """Decorator to run a synchronous method asynchronously on an executor.
 
-    The decorated method may be called with a ``callback`` keyword
-    argument and returns a future.
+    Returns a future.
 
     The executor to be used is determined by the ``executor``
     attributes of ``self``. To use a different attribute name, pass a


### PR DESCRIPTION
Hi,

The `callback` argument was removed in [this commit](https://github.com/tornadoweb/tornado/commit/09267029aaf188deee2bc6b39a91b0fc42814466). So I think the text at the top of the function documentation can be updated too.

Thanks
Bruno