### PR TITLE
Update links on home page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,12 +9,12 @@
 .. |Tornado Web Server| image:: tornado.png
     :alt: Tornado Web Server
 
-`Tornado <http://www.tornadoweb.org>`_ is a Python web framework and
+`Tornado <https://www.tornadoweb.org>`_ is a Python web framework and
 asynchronous networking library, originally developed at `FriendFeed
-<http://friendfeed.com>`_.  By using non-blocking network I/O, Tornado
+<https://en.wikipedia.org/wiki/FriendFeed>`_.  By using non-blocking network I/O, Tornado
 can scale to tens of thousands of open connections, making it ideal for
-`long polling <http://en.wikipedia.org/wiki/Push_technology#Long_polling>`_,
-`WebSockets <http://en.wikipedia.org/wiki/WebSocket>`_, and other
+`long polling <https://en.wikipedia.org/wiki/Push_technology#Long_polling>`_,
+`WebSockets <https://en.wikipedia.org/wiki/WebSocket>`_, and other
 applications that require a long-lived connection to each user.
 
 Quick links
@@ -22,8 +22,8 @@ Quick links
 
 * Current version: |version| (`download from PyPI <https://pypi.python.org/pypi/tornado>`_, :doc:`release notes <releases>`)
 * `Source (GitHub) <https://github.com/tornadoweb/tornado>`_
-* Mailing lists: `discussion <http://groups.google.com/group/python-tornado>`_ and `announcements <http://groups.google.com/group/python-tornado-announce>`_
-* `Stack Overflow <http://stackoverflow.com/questions/tagged/tornado>`_
+* Mailing lists: `discussion <https://groups.google.com/forum/#!forum/python-tornado>`_ and `announcements <https://groups.google.com/forum/#!forum/python-tornado-announce>`_
+* `Stack Overflow <https://stackoverflow.com/questions/tagged/tornado>`_
 * `Wiki <https://github.com/tornadoweb/tornado/wiki/Links>`_
 
 Hello, world
@@ -89,7 +89,7 @@ Installation
 
     pip install tornado
 
-Tornado is listed in `PyPI <http://pypi.python.org/pypi/tornado>`_ and
+Tornado is listed in `PyPI <https://pypi.org/project/tornado/>`_ and
 can be installed with ``pip``. Note that the source distribution
 includes demo applications that are not present when Tornado is
 installed in this way, so you may wish to download a copy of the
@@ -101,11 +101,11 @@ source tarball or clone the `git repository
 compatibility with Python 2.7 is required). The following optional
 packages may be useful:
 
-* `pycurl <http://pycurl.sourceforge.net>`_ is used by the optional
+* `pycurl <http://pycurl.io/>`_ is used by the optional
   ``tornado.curl_httpclient``.  Libcurl version 7.22 or higher is required.
-* `Twisted <http://www.twistedmatrix.com>`_ may be used with the classes in
+* `Twisted <https://www.twistedmatrix.com/>`_ may be used with the classes in
   `tornado.platform.twisted`.
-* `pycares <https://pypi.python.org/pypi/pycares>`_ is an alternative
+* `pycares <https://pypi.org/project/pycares/>`_ is an alternative
   non-blocking DNS resolver that can be used when threads are not
   appropriate.
 
@@ -154,17 +154,17 @@ Discussion and support
 ----------------------
 
 You can discuss Tornado on `the Tornado developer mailing list
-<http://groups.google.com/group/python-tornado>`_, and report bugs on
+<https://groups.google.com/forum/#!forum/python-tornado>`_, and report bugs on
 the `GitHub issue tracker
 <https://github.com/tornadoweb/tornado/issues>`_.  Links to additional
 resources can be found on the `Tornado wiki
 <https://github.com/tornadoweb/tornado/wiki/Links>`_.  New releases are
 announced on the `announcements mailing list
-<http://groups.google.com/group/python-tornado-announce>`_.
+<https://groups.google.com/forum/#!forum/python-tornado-announce>`_.
 
 Tornado is available under
 the `Apache License, Version 2.0
 <http://www.apache.org/licenses/LICENSE-2.0.html>`_.
 
 This web site and all documentation is licensed under `Creative
-Commons 3.0 <http://creativecommons.org/licenses/by/3.0/>`_.
+Commons 3.0 <https://creativecommons.org/licenses/by/3.0/>`_.


### PR DESCRIPTION
* Updated http links to the https versions when possible.
* Updated links to Google Groups to match their new URL format.
* Updated links to other projects to match their new locations.
* And finally, updated link to FriendFeed to go to the Wikipedia page, because friendfeed.com is just a redirect to facebook.com now :-( :-(