### PR TITLE
curl_httpclient: set CURLOPT_PROXY to NULL if pycurl supports it

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -406,7 +406,10 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
                     "Unsupported proxy_auth_mode %s" % request.proxy_auth_mode
                 )
         else:
-            curl.setopt(pycurl.PROXY, "")
+            try:
+                curl.unsetopt(pycurl.PROXY)
+            except TypeError:  # not supported, disable proxy
+                curl.setopt(pycurl.PROXY, "")
             curl.unsetopt(pycurl.PROXYUSERPWD)
         if request.validate_cert:
             curl.setopt(pycurl.SSL_VERIFYPEER, 1)


### PR DESCRIPTION
This restores curl's default behaviour: use environment variables.

This option was set to "" to disable proxy in
905a215a286041c986005859c378c0445c127cbb but curl uses environment
variables by default.

pycurl has supported this on master with https://github.com/pycurl/pycurl/pull/640.