### PR TITLE
docs: Pin version of sphinxcontrib-asyncio

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>1.8.2,<2.1
-sphinxcontrib-asyncio
+sphinxcontrib-asyncio==0.2.0
 sphinx_rtd_theme
 Twisted


### PR DESCRIPTION
The just-released version 0.3.0 is incompatible with our older pinned
version of sphinx.