### PR TITLE
Allow non-yielding functions in `tornado.gen.coroutine`'s type hint

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -91,7 +91,7 @@ from tornado.log import app_log
 from tornado.util import TimeoutError
 
 import typing
-from typing import Union, Any, Callable, List, Type, Tuple, Awaitable, Dict
+from typing import Union, Any, Callable, List, Type, Tuple, Awaitable, Dict, overload
 
 if typing.TYPE_CHECKING:
     from typing import Sequence, Deque, Optional, Set, Iterable  # noqa: F401
@@ -151,6 +151,16 @@ def _create_future() -> Future:
         else:
             break
     return future
+
+
+@overload
+def coroutine(func: Callable[..., "Generator[Any, Any, _T]"]) -> _T:
+    ...
+
+
+@overload
+def coroutine(func: Callable[..., _T]) -> _T:
+    ...
 
 
 def coroutine(

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -154,7 +154,7 @@ def _create_future() -> Future:
 
 
 def coroutine(
-    func: Callable[..., "Generator[Any, Any, _T]"]
+    func: Callable[..., "Union[Generator[Any, Any, _T], _T]"]
 ) -> Callable[..., "Future[_T]"]:
     """Decorator for asynchronous generators.
 

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -154,7 +154,7 @@ def _create_future() -> Future:
 
 
 def coroutine(
-    func: Callable[..., "Union[Generator[Any, Any, _T], _T]"]
+    func: Union[Callable[..., "Generator[Any, Any, _T]"], Callable[..., _T]]
 ) -> Callable[..., "Future[_T]"]:
     """Decorator for asynchronous generators.
 

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -154,12 +154,14 @@ def _create_future() -> Future:
 
 
 @overload
-def coroutine(func: Callable[..., "Generator[Any, Any, _T]"]) -> _T:
+def coroutine(
+    func: Callable[..., "Generator[Any, Any, _T]"]
+) -> Callable[..., "Future[_T]"]:
     ...
 
 
 @overload
-def coroutine(func: Callable[..., _T]) -> _T:
+def coroutine(func: Callable[..., _T]) -> Callable[..., "Future[_T]"]:
     ...
 
 


### PR DESCRIPTION
`@gen.coroutine` deco allows non-yielding functions, so I reflected that in the type hint.

Requires usage of `@typing.overload` due to https://github.com/python/mypy/issues/9435