### PR TITLE
Saving response

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -844,6 +844,7 @@ class RequestHandler(object):
             self.set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = utf8(chunk)
         self._write_buffer.append(chunk)
+        self.chunk = chunk
 
     def render(self, template_name: str, **kwargs: Any) -> "Future[None]":
         """Renders the template with the given arguments as the response.


### PR DESCRIPTION
Saving the response allows a high level flow for api traces, for example if you want to make a collection of requests/ api / response. 
if your RequestHandler has several self.write due to error handling, its not clean to save in every self.write the response. Its better if self.write saves automatically
this output for a use with on_finish() method.

Example:
```
class MainHandler(RequestHandler):
    def on_finish(self):
        model = ModelDocument()
        model.requests = self.body
        model.api_name = self.uri 
       # it would be unclean reading the variable `var` from post method
       model.response = self.chunks    # here we got the output of api call 
      ModelDocument.objects.insert(**model, load_bulk=False)
    def post(self,a,b):
        if a == b:
            self.write("Same numbers")  # it's unclean make `var = message` for first time
        self.write("Differents)  # it's unclean make `var = message` for second time
```
