### PR TITLE
Update super usage

### DIFF
--- a/demos/blog/blog.py
+++ b/demos/blog/blog.py
@@ -77,7 +77,7 @@ class Application(tornado.web.Application):
             login_url="/auth/login",
             debug=True,
         )
-        super(Application, self).__init__(handlers, **settings)
+        super().__init__(handlers, **settings)
 
 
 class BaseHandler(tornado.web.RequestHandler):

--- a/demos/websocket/chatdemo.py
+++ b/demos/websocket/chatdemo.py
@@ -41,7 +41,7 @@ class Application(tornado.web.Application):
             static_path=os.path.join(os.path.dirname(__file__), "static"),
             xsrf_cookies=True,
         )
-        super(Application, self).__init__(handlers, **settings)
+        super().__init__(handlers, **settings)
 
 
 class MainHandler(tornado.web.RequestHandler):

--- a/maint/test/redbot/red_test.py
+++ b/maint/test/redbot/red_test.py
@@ -248,7 +248,7 @@ class GzipHTTPTest(AsyncHTTPTestCase, TestMixin):
         return Application(self.get_handlers(), gzip=True, **self.get_app_kwargs())
 
     def get_allowed_errors(self):
-        return super(GzipHTTPTest, self).get_allowed_errors() + [
+        return super().get_allowed_errors() + [
             # TODO: The Etag is supposed to change when Content-Encoding is
             # used.  This should be fixed, but it's difficult to do with the
             # way GZipContentEncoding fits into the pipeline, and in practice

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -49,7 +49,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
     def initialize(  # type: ignore
         self, max_clients: int = 10, defaults: Optional[Dict[str, Any]] = None
     ) -> None:
-        super(CurlAsyncHTTPClient, self).initialize(defaults=defaults)
+        super().initialize(defaults=defaults)
         # Typeshed is incomplete for CurlMulti, so just use Any for now.
         self._multi = pycurl.CurlMulti()  # type: Any
         self._multi.setopt(pycurl.M_TIMERFUNCTION, self._set_timeout)
@@ -87,7 +87,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         for curl in self._curls:
             curl.close()
         self._multi.close()
-        super(CurlAsyncHTTPClient, self).close()
+        super().close()
 
         # Set below properties to None to reduce the reference count of current
         # instance, because those properties hold some methods of current

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -276,7 +276,7 @@ class Return(Exception):
     """
 
     def __init__(self, value: Any = None) -> None:
-        super(Return, self).__init__()
+        super().__init__()
         self.value = value
         # Cython recognizes subclasses of StopIteration with a .args tuple.
         self.args = (value,)

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -717,7 +717,7 @@ class HTTPClientError(Exception):
         self.code = code
         self.message = message or httputil.responses.get(code, "Unknown")
         self.response = response
-        super(HTTPClientError, self).__init__(code, message, response)
+        super().__init__(code, message, response)
 
     def __str__(self) -> str:
         return "HTTP %d: %s" % (self.code, self.message)

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -96,7 +96,7 @@ class StreamClosedError(IOError):
     """
 
     def __init__(self, real_error: Optional[BaseException] = None) -> None:
-        super(StreamClosedError, self).__init__("Stream is closed")
+        super().__init__("Stream is closed")
         self.real_error = real_error
 
 
@@ -1122,7 +1122,7 @@ class IOStream(BaseIOStream):
     def __init__(self, socket: socket.socket, *args: Any, **kwargs: Any) -> None:
         self.socket = socket
         self.socket.setblocking(False)
-        super(IOStream, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def fileno(self) -> Union[int, ioloop._Selectable]:
         return self.socket
@@ -1360,7 +1360,7 @@ class SSLIOStream(IOStream):
         for `ssl.wrap_socket`
         """
         self._ssl_options = kwargs.pop("ssl_options", _client_ssl_defaults)
-        super(SSLIOStream, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._ssl_accepting = True
         self._handshake_reading = False
         self._handshake_writing = False
@@ -1378,10 +1378,10 @@ class SSLIOStream(IOStream):
             self._add_io_state(self.io_loop.WRITE)
 
     def reading(self) -> bool:
-        return self._handshake_reading or super(SSLIOStream, self).reading()
+        return self._handshake_reading or super().reading()
 
     def writing(self) -> bool:
-        return self._handshake_writing or super(SSLIOStream, self).writing()
+        return self._handshake_writing or super().writing()
 
     def _do_ssl_handshake(self) -> None:
         # Based on code from test_ssl.py in the python stdlib
@@ -1477,13 +1477,13 @@ class SSLIOStream(IOStream):
         if self._ssl_accepting:
             self._do_ssl_handshake()
             return
-        super(SSLIOStream, self)._handle_read()
+        super()._handle_read()
 
     def _handle_write(self) -> None:
         if self._ssl_accepting:
             self._do_ssl_handshake()
             return
-        super(SSLIOStream, self)._handle_write()
+        super()._handle_write()
 
     def connect(
         self, address: Tuple, server_hostname: Optional[str] = None
@@ -1500,13 +1500,13 @@ class SSLIOStream(IOStream):
         # (There's a test for it, but I think in practice users
         # either wait for the connect before performing a write or
         # they don't care about the connect Future at all)
-        fut = super(SSLIOStream, self).connect(address)
+        fut = super().connect(address)
         fut.add_done_callback(lambda f: f.exception())
         return self.wait_for_handshake()
 
     def _handle_connect(self) -> None:
         # Call the superclass method to check for errors.
-        super(SSLIOStream, self)._handle_connect()
+        super()._handle_connect()
         if self.closed():
             return
         # When the connection is complete, wrap the socket for SSL
@@ -1605,7 +1605,7 @@ class SSLIOStream(IOStream):
     def _is_connreset(self, e: BaseException) -> bool:
         if isinstance(e, ssl.SSLError) and e.args[0] == ssl.SSL_ERROR_EOF:
             return True
-        return super(SSLIOStream, self)._is_connreset(e)
+        return super()._is_connreset(e)
 
 
 class PipeIOStream(BaseIOStream):
@@ -1623,7 +1623,7 @@ class PipeIOStream(BaseIOStream):
         self.fd = fd
         self._fio = io.FileIO(self.fd, "r+")
         os.set_blocking(fd, False)
-        super(PipeIOStream, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def fileno(self) -> int:
         return self.fd

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -483,7 +483,7 @@ class CSVLocale(Locale):
 
     def __init__(self, code: str, translations: Dict[str, Dict[str, str]]) -> None:
         self.translations = translations
-        super(CSVLocale, self).__init__(code)
+        super().__init__(code)
 
     def translate(
         self,
@@ -522,7 +522,7 @@ class GettextLocale(Locale):
         self.gettext = translations.gettext
         # self.gettext must exist before __init__ is called, since it
         # calls into self.translate
-        super(GettextLocale, self).__init__(code)
+        super().__init__(code)
 
     def translate(
         self,

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -111,7 +111,7 @@ class Condition(_TimeoutGarbageCollector):
     """
 
     def __init__(self) -> None:
-        super(Condition, self).__init__()
+        super().__init__()
         self.io_loop = ioloop.IOLoop.current()
 
     def __repr__(self) -> str:
@@ -380,14 +380,14 @@ class Semaphore(_TimeoutGarbageCollector):
     """
 
     def __init__(self, value: int = 1) -> None:
-        super(Semaphore, self).__init__()
+        super().__init__()
         if value < 0:
             raise ValueError("semaphore initial value must be >= 0")
 
         self._value = value
 
     def __repr__(self) -> str:
-        res = super(Semaphore, self).__repr__()
+        res = super().__repr__()
         extra = (
             "locked" if self._value == 0 else "unlocked,value:{0}".format(self._value)
         )
@@ -473,14 +473,14 @@ class BoundedSemaphore(Semaphore):
     """
 
     def __init__(self, value: int = 1) -> None:
-        super(BoundedSemaphore, self).__init__(value=value)
+        super().__init__(value=value)
         self._initial_value = value
 
     def release(self) -> None:
         """Increment the counter and wake one waiter."""
         if self._value >= self._initial_value:
             raise ValueError("Semaphore released too many times")
-        super(BoundedSemaphore, self).release()
+        super().release()
 
 
 class Lock(object):

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -456,7 +456,7 @@ class BlockingResolver(ExecutorResolver):
     """
 
     def initialize(self) -> None:  # type: ignore
-        super(BlockingResolver, self).initialize()
+        super().initialize()
 
 
 class ThreadedResolver(ExecutorResolver):
@@ -485,9 +485,7 @@ class ThreadedResolver(ExecutorResolver):
 
     def initialize(self, num_threads: int = 10) -> None:  # type: ignore
         threadpool = ThreadedResolver._create_threadpool(num_threads)
-        super(ThreadedResolver, self).initialize(
-            executor=threadpool, close_executor=False
-        )
+        super().initialize(executor=threadpool, close_executor=False)
 
     @classmethod
     def _create_threadpool(

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -67,7 +67,7 @@ class BaseAsyncIOLoop(IOLoop):
 
         self._thread_identity = 0
 
-        super(BaseAsyncIOLoop, self).initialize(**kwargs)
+        super().initialize(**kwargs)
 
         def assign_thread_identity() -> None:
             self._thread_identity = get_ident()
@@ -221,7 +221,7 @@ class AsyncIOMainLoop(BaseAsyncIOLoop):
     """
 
     def initialize(self, **kwargs: Any) -> None:  # type: ignore
-        super(AsyncIOMainLoop, self).initialize(asyncio.get_event_loop(), **kwargs)
+        super().initialize(asyncio.get_event_loop(), **kwargs)
 
     def make_current(self) -> None:
         # AsyncIOMainLoop already refers to the current asyncio loop so
@@ -253,7 +253,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
         self.is_current = False
         loop = asyncio.new_event_loop()
         try:
-            super(AsyncIOLoop, self).initialize(loop, **kwargs)
+            super().initialize(loop, **kwargs)
         except Exception:
             # If initialize() does not succeed (taking ownership of the loop),
             # we have to close it.
@@ -263,7 +263,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
     def close(self, all_fds: bool = False) -> None:
         if self.is_current:
             self.clear_current()
-        super(AsyncIOLoop, self).close(all_fds=all_fds)
+        super().close(all_fds=all_fds)
 
     def make_current(self) -> None:
         if not self.is_current:

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -411,10 +411,10 @@ class ReversibleRuleRouter(ReversibleRouter, RuleRouter):
 
     def __init__(self, rules: Optional[_RuleList] = None) -> None:
         self.named_rules = {}  # type: Dict[str, Any]
-        super(ReversibleRuleRouter, self).__init__(rules)
+        super().__init__(rules)
 
     def process_rule(self, rule: "Rule") -> "Rule":
-        rule = super(ReversibleRuleRouter, self).process_rule(rule)
+        rule = super().process_rule(rule)
 
         if rule.name:
             if rule.name in self.named_rules:
@@ -679,7 +679,7 @@ class URLSpec(Rule):
 
         """
         matcher = PathMatches(pattern)
-        super(URLSpec, self).__init__(matcher, handler, kwargs, name)
+        super().__init__(matcher, handler, kwargs, name)
 
         self.regex = matcher.regex
         self.handler_class = self.target

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -51,7 +51,7 @@ class HTTPTimeoutError(HTTPError):
     """
 
     def __init__(self, message: str) -> None:
-        super(HTTPTimeoutError, self).__init__(599, message=message)
+        super().__init__(599, message=message)
 
     def __str__(self) -> str:
         return self.message or "Timeout"
@@ -70,7 +70,7 @@ class HTTPStreamClosedError(HTTPError):
     """
 
     def __init__(self, message: str) -> None:
-        super(HTTPStreamClosedError, self).__init__(599, message=message)
+        super().__init__(599, message=message)
 
     def __str__(self) -> str:
         return self.message or "Stream closed"
@@ -128,7 +128,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         .. versionchanged:: 4.2
            Added the ``max_body_size`` argument.
         """
-        super(SimpleAsyncHTTPClient, self).initialize(defaults=defaults)
+        super().initialize(defaults=defaults)
         self.max_clients = max_clients
         self.queue = (
             collections.deque()
@@ -157,7 +157,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         self.tcp_client = TCPClient(resolver=self.resolver)
 
     def close(self) -> None:
-        super(SimpleAsyncHTTPClient, self).close()
+        super().close()
         if self.own_resolver:
             self.resolver.close()
         self.tcp_client.close()

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -455,7 +455,7 @@ class Loader(BaseLoader):
     """
 
     def __init__(self, root_directory: str, **kwargs: Any) -> None:
-        super(Loader, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.root = os.path.abspath(root_directory)
 
     def resolve_path(self, name: str, parent_path: Optional[str] = None) -> str:
@@ -483,7 +483,7 @@ class DictLoader(BaseLoader):
     """A template loader that loads from a dictionary."""
 
     def __init__(self, dict: Dict[str, str], **kwargs: Any) -> None:
-        super(DictLoader, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.dict = dict
 
     def resolve_path(self, name: str, parent_path: Optional[str] = None) -> str:
@@ -677,7 +677,7 @@ class _Expression(_Node):
 
 class _Module(_Expression):
     def __init__(self, expression: str, line: int) -> None:
-        super(_Module, self).__init__("_tt_modules." + expression, line, raw=True)
+        super().__init__("_tt_modules." + expression, line, raw=True)
 
 
 class _Text(_Node):

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -102,7 +102,7 @@ class ClientTestMixin(object):
     client_class = None  # type: typing.Callable
 
     def setUp(self):
-        super(ClientTestMixin, self).setUp()  # type: ignore
+        super().setUp()  # type: ignore
         self.server = CapServer()
         sock, port = bind_unused_port()
         self.server.add_sockets([sock])
@@ -110,7 +110,7 @@ class ClientTestMixin(object):
 
     def tearDown(self):
         self.server.stop()
-        super(ClientTestMixin, self).tearDown()  # type: ignore
+        super().tearDown()  # type: ignore
 
     def test_future(self: typing.Any):
         future = self.client.capitalize("hello")

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -84,7 +84,7 @@ class CustomFailReasonHandler(RequestHandler):
 @unittest.skipIf(pycurl is None, "pycurl module not present")
 class CurlHTTPClientTestCase(AsyncHTTPTestCase):
     def setUp(self):
-        super(CurlHTTPClientTestCase, self).setUp()
+        super().setUp()
         self.http_client = self.create_client()
 
     def get_app(self):

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -285,10 +285,10 @@ class GenCoroutineTest(AsyncTestCase):
         # so we need explicit checks here to make sure the tests run all
         # the way through.
         self.finished = False
-        super(GenCoroutineTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
-        super(GenCoroutineTest, self).tearDown()
+        super().tearDown()
         assert self.finished
 
     def test_attributes(self):

--- a/tornado/test/http1connection_test.py
+++ b/tornado/test/http1connection_test.py
@@ -13,7 +13,7 @@ class HTTP1ConnectionTest(AsyncTestCase):
     code = None  # type: typing.Optional[int]
 
     def setUp(self):
-        super(HTTP1ConnectionTest, self).setUp()
+        super().setUp()
         self.asyncSetUp()
 
     @gen_test

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -465,7 +465,7 @@ class HTTPServerRawTest(AsyncHTTPTestCase):
         return Application([("/echo", EchoHandler)])
 
     def setUp(self):
-        super(HTTPServerRawTest, self).setUp()
+        super().setUp()
         self.stream = IOStream(socket.socket())
         self.io_loop.run_sync(
             lambda: self.stream.connect(("127.0.0.1", self.get_http_port()))
@@ -473,7 +473,7 @@ class HTTPServerRawTest(AsyncHTTPTestCase):
 
     def tearDown(self):
         self.stream.close()
-        super(HTTPServerRawTest, self).tearDown()
+        super().tearDown()
 
     def test_empty_request(self):
         self.stream.close()
@@ -675,7 +675,7 @@ class SSLXHeaderTest(AsyncHTTPSTestCase, HandlerBaseTestCase):
         return Application([("/", XHeaderTest.Handler)])
 
     def get_httpserver_options(self):
-        output = super(SSLXHeaderTest, self).get_httpserver_options()
+        output = super().get_httpserver_options()
         output["xheaders"] = True
         return output
 
@@ -721,7 +721,7 @@ class UnixSocketTest(AsyncTestCase):
     """
 
     def setUp(self):
-        super(UnixSocketTest, self).setUp()
+        super().setUp()
         self.tmpdir = tempfile.mkdtemp()
         self.sockfile = os.path.join(self.tmpdir, "test.sock")
         sock = netutil.bind_unix_socket(self.sockfile)
@@ -736,7 +736,7 @@ class UnixSocketTest(AsyncTestCase):
         self.io_loop.run_sync(self.server.close_all_connections)
         self.server.stop()
         shutil.rmtree(self.tmpdir)
-        super(UnixSocketTest, self).tearDown()
+        super().tearDown()
 
     @gen_test
     def test_unix_socket(self):
@@ -815,7 +815,7 @@ class KeepAliveTest(AsyncHTTPTestCase):
         )
 
     def setUp(self):
-        super(KeepAliveTest, self).setUp()
+        super().setUp()
         self.http_version = b"HTTP/1.1"
 
     def tearDown(self):
@@ -826,7 +826,7 @@ class KeepAliveTest(AsyncHTTPTestCase):
 
         if hasattr(self, "stream"):
             self.stream.close()
-        super(KeepAliveTest, self).tearDown()
+        super().tearDown()
 
     # The next few methods are a crude manual http client
     @gen.coroutine
@@ -1140,11 +1140,11 @@ class IdleTimeoutTest(AsyncHTTPTestCase):
         return dict(idle_connection_timeout=0.1)
 
     def setUp(self):
-        super(IdleTimeoutTest, self).setUp()
+        super().setUp()
         self.streams = []  # type: List[IOStream]
 
     def tearDown(self):
-        super(IdleTimeoutTest, self).tearDown()
+        super().tearDown()
         for stream in self.streams:
             stream.close()
 

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -535,7 +535,7 @@ class TestIOLoopFutures(AsyncTestCase):
         class MyExecutor(futures.ThreadPoolExecutor):
             def submit(self, func, *args):
                 count[0] += 1
-                return super(MyExecutor, self).submit(func, *args)
+                return super().submit(func, *args)
 
         event = threading.Event()
 

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -920,7 +920,7 @@ class TestIOStreamSSLContext(TestIOStreamMixin, AsyncTestCase):
 class TestIOStreamStartTLS(AsyncTestCase):
     def setUp(self):
         try:
-            super(TestIOStreamStartTLS, self).setUp()
+            super().setUp()
             self.listener, self.port = bind_unused_port()
             self.server_stream = None
             self.server_accepted = Future()  # type: Future[None]
@@ -944,7 +944,7 @@ class TestIOStreamStartTLS(AsyncTestCase):
         if self.client_stream is not None:
             self.client_stream.close()
         self.listener.close()
-        super(TestIOStreamStartTLS, self).tearDown()
+        super().tearDown()
 
     def accept(self, connection, address):
         if self.server_stream is not None:

--- a/tornado/test/locks_test.py
+++ b/tornado/test/locks_test.py
@@ -22,7 +22,7 @@ from tornado.testing import gen_test, AsyncTestCase
 
 class ConditionTest(AsyncTestCase):
     def setUp(self):
-        super(ConditionTest, self).setUp()
+        super().setUp()
         self.history = []  # type: typing.List[typing.Union[int, str]]
 
     def record_done(self, future, key):

--- a/tornado/test/log_test.py
+++ b/tornado/test/log_test.py
@@ -131,7 +131,7 @@ class UnicodeLogFormatterTest(LogFormatterTest):
 
 class EnablePrettyLoggingTest(unittest.TestCase):
     def setUp(self):
-        super(EnablePrettyLoggingTest, self).setUp()
+        super().setUp()
         self.options = OptionParser()
         define_logging_options(self.options)
         self.logger = logging.Logger("tornado.test.log_test.EnablePrettyLoggingTest")

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -66,7 +66,7 @@ def _failing_getaddrinfo(*args):
 @skipIfNoNetwork
 class BlockingResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
-        super(BlockingResolverTest, self).setUp()
+        super().setUp()
         self.resolver = BlockingResolver()
 
 
@@ -75,19 +75,19 @@ class BlockingResolverTest(AsyncTestCase, _ResolverTestMixin):
 # our default timeout.
 class BlockingResolverErrorTest(AsyncTestCase, _ResolverErrorTestMixin):
     def setUp(self):
-        super(BlockingResolverErrorTest, self).setUp()
+        super().setUp()
         self.resolver = BlockingResolver()
         self.real_getaddrinfo = socket.getaddrinfo
         socket.getaddrinfo = _failing_getaddrinfo
 
     def tearDown(self):
         socket.getaddrinfo = self.real_getaddrinfo
-        super(BlockingResolverErrorTest, self).tearDown()
+        super().tearDown()
 
 
 class OverrideResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
-        super(OverrideResolverTest, self).setUp()
+        super().setUp()
         mapping = {
             ("google.com", 80): ("1.2.3.4", 80),
             ("google.com", 80, socket.AF_INET): ("1.2.3.4", 80),
@@ -112,24 +112,24 @@ class OverrideResolverTest(AsyncTestCase, _ResolverTestMixin):
 @skipIfNoNetwork
 class ThreadedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
-        super(ThreadedResolverTest, self).setUp()
+        super().setUp()
         self.resolver = ThreadedResolver()
 
     def tearDown(self):
         self.resolver.close()
-        super(ThreadedResolverTest, self).tearDown()
+        super().tearDown()
 
 
 class ThreadedResolverErrorTest(AsyncTestCase, _ResolverErrorTestMixin):
     def setUp(self):
-        super(ThreadedResolverErrorTest, self).setUp()
+        super().setUp()
         self.resolver = BlockingResolver()
         self.real_getaddrinfo = socket.getaddrinfo
         socket.getaddrinfo = _failing_getaddrinfo
 
     def tearDown(self):
         socket.getaddrinfo = self.real_getaddrinfo
-        super(ThreadedResolverErrorTest, self).tearDown()
+        super().tearDown()
 
 
 @skipIfNoNetwork
@@ -166,7 +166,7 @@ class ThreadedResolverImportTest(unittest.TestCase):
 @unittest.skipIf(sys.platform == "win32", "pycares doesn't return loopback on windows")
 class CaresResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
-        super(CaresResolverTest, self).setUp()
+        super().setUp()
         self.resolver = CaresResolver()
 
 
@@ -185,7 +185,7 @@ class CaresResolverTest(AsyncTestCase, _ResolverTestMixin):
 @unittest.skipIf(sys.platform == "win32", "twisted resolver hangs on windows")
 class TwistedResolverTest(AsyncTestCase, _ResolverTestMixin):
     def setUp(self):
-        super(TwistedResolverTest, self).setUp()
+        super().setUp()
         self.resolver = TwistedResolver()
 
 

--- a/tornado/test/process_test.py
+++ b/tornado/test/process_test.py
@@ -47,7 +47,7 @@ class ProcessTest(unittest.TestCase):
             os._exit(1)
         # In the surviving process, clear the alarm we set earlier
         signal.alarm(0)
-        super(ProcessTest, self).tearDown()
+        super().tearDown()
 
     def test_multi_process(self):
         # This test doesn't work on twisted because we use the global

--- a/tornado/test/routing_test.py
+++ b/tornado/test/routing_test.py
@@ -115,7 +115,7 @@ SecondHandler = _get_named_handler("second_handler")
 
 class CustomRouter(ReversibleRouter):
     def __init__(self):
-        super(CustomRouter, self).__init__()
+        super().__init__()
         self.routes = {}  # type: typing.Dict[str, typing.Any]
 
     def add_routes(self, routes):

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -62,10 +62,10 @@ def test_runner_factory(stderr):
     class TornadoTextTestRunner(unittest.TextTestRunner):
         def __init__(self, *args, **kwargs):
             kwargs["stream"] = stderr
-            super(TornadoTextTestRunner, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
         def run(self, test):
-            result = super(TornadoTextTestRunner, self).run(test)
+            result = super().run(test)
             if result.skipped:
                 skip_reasons = set(reason for (test, reason) in result.skipped)
                 self.stream.write(  # type: ignore
@@ -84,7 +84,7 @@ class LogCounter(logging.Filter):
     """Counts the number of WARNING or higher log records."""
 
     def __init__(self, *args, **kwargs):
-        super(LogCounter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.info_count = self.warning_count = self.error_count = 0
 
     def filter(self, record):

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -519,7 +519,7 @@ class SimpleHTTPClientTestMixin(object):
 
 class SimpleHTTPClientTestCase(SimpleHTTPClientTestMixin, AsyncHTTPTestCase):
     def setUp(self):
-        super(SimpleHTTPClientTestCase, self).setUp()
+        super().setUp()
         self.http_client = self.create_client()
 
     def create_client(self, **kwargs):
@@ -528,7 +528,7 @@ class SimpleHTTPClientTestCase(SimpleHTTPClientTestMixin, AsyncHTTPTestCase):
 
 class SimpleHTTPSClientTestCase(SimpleHTTPClientTestMixin, AsyncHTTPSTestCase):
     def setUp(self):
-        super(SimpleHTTPSClientTestCase, self).setUp()
+        super().setUp()
         self.http_client = self.create_client()
 
     def create_client(self, **kwargs):
@@ -572,12 +572,12 @@ class SimpleHTTPSClientTestCase(SimpleHTTPClientTestMixin, AsyncHTTPSTestCase):
 
 class CreateAsyncHTTPClientTestCase(AsyncTestCase):
     def setUp(self):
-        super(CreateAsyncHTTPClientTestCase, self).setUp()
+        super().setUp()
         self.saved = AsyncHTTPClient._save_configuration()
 
     def tearDown(self):
         AsyncHTTPClient._restore_configuration(self.saved)
-        super(CreateAsyncHTTPClientTestCase, self).tearDown()
+        super().tearDown()
 
     def test_max_clients(self):
         AsyncHTTPClient.configure(SimpleAsyncHTTPClient)
@@ -679,7 +679,7 @@ class HTTP204NoContentTestCase(AsyncHTTPTestCase):
 
 class HostnameMappingTestCase(AsyncHTTPTestCase):
     def setUp(self):
-        super(HostnameMappingTestCase, self).setUp()
+        super().setUp()
         self.http_client = SimpleAsyncHTTPClient(
             hostname_mapping={
                 "www.example.com": "127.0.0.1",
@@ -714,7 +714,7 @@ class ResolveTimeoutTestCase(AsyncHTTPTestCase):
                 # Return something valid so the test doesn't raise during cleanup.
                 return [(socket.AF_INET, ("127.0.0.1", test.get_http_port()))]
 
-        super(ResolveTimeoutTestCase, self).setUp()
+        super().setUp()
         self.http_client = SimpleAsyncHTTPClient(resolver=BadResolver())
 
     def get_app(self):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -40,7 +40,7 @@ AF1, AF2 = 1, 2
 
 class TestTCPServer(TCPServer):
     def __init__(self, family):
-        super(TestTCPServer, self).__init__()
+        super().__init__()
         self.streams = []  # type: List[IOStream]
         self.queue = Queue()  # type: Queue[IOStream]
         sockets = bind_sockets(0, "localhost", family)
@@ -52,14 +52,14 @@ class TestTCPServer(TCPServer):
         self.queue.put(stream)
 
     def stop(self):
-        super(TestTCPServer, self).stop()
+        super().stop()
         for stream in self.streams:
             stream.close()
 
 
 class TCPClientTest(AsyncTestCase):
     def setUp(self):
-        super(TCPClientTest, self).setUp()
+        super().setUp()
         self.server = None
         self.client = TCPClient()
 
@@ -77,7 +77,7 @@ class TCPClientTest(AsyncTestCase):
     def tearDown(self):
         self.client.close()
         self.stop_server()
-        super(TCPClientTest, self).tearDown()
+        super().tearDown()
 
     def skipIfLocalhostV4(self):
         # The port used here doesn't matter, but some systems require it
@@ -206,7 +206,7 @@ class ConnectorTest(AsyncTestCase):
             self.closed = True
 
     def setUp(self):
-        super(ConnectorTest, self).setUp()
+        super().setUp()
         self.connect_futures = (
             {}
         )  # type: Dict[Tuple[int, typing.Any], Future[ConnectorTest.FakeStream]]
@@ -218,7 +218,7 @@ class ConnectorTest(AsyncTestCase):
         # be closing any streams
         for stream in self.streams.values():
             self.assertFalse(stream.closed)
-        super(ConnectorTest, self).tearDown()
+        super().tearDown()
 
     def create_stream(self, af, addr):
         stream = ConnectorTest.FakeStream()

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -86,7 +86,7 @@ class LeakTest(AsyncTestCase):
 
 class AsyncHTTPTestCaseTest(AsyncHTTPTestCase):
     def setUp(self):
-        super(AsyncHTTPTestCaseTest, self).setUp()
+        super().setUp()
         # Bind a second port.
         sock, port = bind_unused_port()
         app = Application()
@@ -113,7 +113,7 @@ class AsyncHTTPTestCaseTest(AsyncHTTPTestCase):
 
     def tearDown(self):
         self.second_server.stop()
-        super(AsyncHTTPTestCaseTest, self).tearDown()
+        super().tearDown()
 
 
 class AsyncTestCaseWrapperTest(unittest.TestCase):
@@ -221,12 +221,12 @@ class AsyncHTTPTestCaseSetUpTearDownTest(unittest.TestCase):
 
 class GenTest(AsyncTestCase):
     def setUp(self):
-        super(GenTest, self).setUp()
+        super().setUp()
         self.finished = False
 
     def tearDown(self):
         self.assertTrue(self.finished)
-        super(GenTest, self).tearDown()
+        super().tearDown()
 
     @gen_test
     def test_sync(self):
@@ -336,10 +336,10 @@ class GetNewIOLoopTest(AsyncTestCase):
         self.orig_loop = asyncio.get_event_loop()
         self.new_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.new_loop)
-        super(GetNewIOLoopTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
-        super(GetNewIOLoopTest, self).tearDown()
+        super().tearDown()
         # AsyncTestCase must not affect the existing asyncio loop.
         self.assertFalse(asyncio.get_event_loop().is_closed())
         asyncio.set_event_loop(self.orig_loop)

--- a/tornado/test/util_test.py
+++ b/tornado/test/util_test.py
@@ -32,7 +32,7 @@ class RaiseExcInfoTest(unittest.TestCase):
         # doesn't have a "copy constructor"
         class TwoArgException(Exception):
             def __init__(self, a, b):
-                super(TwoArgException, self).__init__()
+                super().__init__()
                 self.a, self.b = a, b
 
         try:

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -744,7 +744,7 @@ class WSGISafeWebTest(WebTestCase):
         )
 
     def tearDown(self):
-        super(WSGISafeWebTest, self).tearDown()
+        super().tearDown()
         RequestHandler._template_loaders.clear()
 
     def get_handlers(self):
@@ -1935,7 +1935,7 @@ class UIMethodUIModuleTest(SimpleHandlerTestCase):
         )
 
     def tearDown(self):
-        super(UIMethodUIModuleTest, self).tearDown()
+        super().tearDown()
         # TODO: fix template loader caching so this isn't necessary.
         RequestHandler._template_loaders.clear()
 
@@ -2014,7 +2014,7 @@ class GetCurrentUserTest(WebTestCase):
         )
 
     def tearDown(self):
-        super(GetCurrentUserTest, self).tearDown()
+        super().tearDown()
         RequestHandler._template_loaders.clear()
 
     def get_handlers(self):
@@ -2262,7 +2262,7 @@ class StreamingRequestBodyTest(WebTestCase):
                 self.test = test
 
             def on_connection_close(self):
-                super(CloseDetectionHandler, self).on_connection_close()
+                super().on_connection_close()
                 self.test.close_future.set_result(None)
 
         return [
@@ -2734,7 +2734,7 @@ class XSRFTest(SimpleHandlerTestCase):
         return dict(xsrf_cookies=True)
 
     def setUp(self):
-        super(XSRFTest, self).setUp()
+        super().setUp()
         self.xsrf_token = self.get_token()
 
     def get_token(self, old_token=None, version=None):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -133,7 +133,7 @@ class PathArgsHandler(TestWebSocketHandler):
 
 class CoroutineOnMessageHandler(TestWebSocketHandler):
     def initialize(self, **kwargs):
-        super(CoroutineOnMessageHandler, self).initialize(**kwargs)
+        super().initialize(**kwargs)
         self.sleeping = 0
 
     @gen.coroutine
@@ -153,7 +153,7 @@ class RenderMessageHandler(TestWebSocketHandler):
 
 class SubprotocolHandler(TestWebSocketHandler):
     def initialize(self, **kwargs):
-        super(SubprotocolHandler, self).initialize(**kwargs)
+        super().initialize(**kwargs)
         self.select_subprotocol_called = False
 
     def select_subprotocol(self, subprotocols):
@@ -172,7 +172,7 @@ class SubprotocolHandler(TestWebSocketHandler):
 
 class OpenCoroutineHandler(TestWebSocketHandler):
     def initialize(self, test, **kwargs):
-        super(OpenCoroutineHandler, self).initialize(**kwargs)
+        super().initialize(**kwargs)
         self.test = test
         self.open_finished = False
 
@@ -275,7 +275,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         return SimpleAsyncHTTPClient()
 
     def tearDown(self):
-        super(WebSocketTest, self).tearDown()
+        super().tearDown()
         RequestHandler._template_loaders.clear()
 
     def test_http_request(self):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -161,7 +161,7 @@ class AsyncTestCase(unittest.TestCase):
     """
 
     def __init__(self, methodName: str = "runTest") -> None:
-        super(AsyncTestCase, self).__init__(methodName)
+        super().__init__(methodName)
         self.__stopped = False
         self.__running = False
         self.__failure = None  # type: Optional[_ExcInfoTuple]
@@ -178,7 +178,7 @@ class AsyncTestCase(unittest.TestCase):
         self._test_generator = None  # type: Optional[Union[Generator, Coroutine]]
 
     def setUp(self) -> None:
-        super(AsyncTestCase, self).setUp()
+        super().setUp()
         self.io_loop = self.get_new_ioloop()
         self.io_loop.make_current()
 
@@ -222,7 +222,7 @@ class AsyncTestCase(unittest.TestCase):
             # in the same process with autoreload (because curl does not
             # set FD_CLOEXEC on its file descriptors)
             self.io_loop.close(all_fds=True)
-        super(AsyncTestCase, self).tearDown()
+        super().tearDown()
         # In case an exception escaped or the StackContext caught an exception
         # when there wasn't a wait() to re-raise it, do so here.
         # This is our last chance to raise an exception in a way that the
@@ -263,7 +263,7 @@ class AsyncTestCase(unittest.TestCase):
     def run(
         self, result: Optional[unittest.TestResult] = None
     ) -> Optional[unittest.TestResult]:
-        ret = super(AsyncTestCase, self).run(result)
+        ret = super().run(result)
         # As a last resort, if an exception escaped super.run() and wasn't
         # re-raised in tearDown, raise it here.  This will cause the
         # unittest run to fail messily, but that's better than silently
@@ -379,7 +379,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
     """
 
     def setUp(self) -> None:
-        super(AsyncHTTPTestCase, self).setUp()
+        super().setUp()
         sock, port = bind_unused_port()
         self.__port = port
 
@@ -473,7 +473,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
         self.http_client.close()
         del self.http_server
         del self._app
-        super(AsyncHTTPTestCase, self).tearDown()
+        super().tearDown()
 
 
 class AsyncHTTPSTestCase(AsyncHTTPTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -206,7 +206,7 @@ class RequestHandler(object):
         request: httputil.HTTPServerRequest,
         **kwargs: Any
     ) -> None:
-        super(RequestHandler, self).__init__()
+        super().__init__()
 
         self.application = application
         self.request = request
@@ -1923,10 +1923,10 @@ class _ApplicationRouter(ReversibleRuleRouter):
     ) -> None:
         assert isinstance(application, Application)
         self.application = application
-        super(_ApplicationRouter, self).__init__(rules)
+        super().__init__(rules)
 
     def process_rule(self, rule: Rule) -> Rule:
-        rule = super(_ApplicationRouter, self).process_rule(rule)
+        rule = super().process_rule(rule)
 
         if isinstance(rule.target, (list, tuple)):
             rule.target = _ApplicationRouter(
@@ -1943,7 +1943,7 @@ class _ApplicationRouter(ReversibleRuleRouter):
                 request, target, **target_params
             )
 
-        return super(_ApplicationRouter, self).get_target_delegate(
+        return super().get_target_delegate(
             target, request, **target_params
         )
 
@@ -2418,7 +2418,7 @@ class MissingArgumentError(HTTPError):
     """
 
     def __init__(self, arg_name: str) -> None:
-        super(MissingArgumentError, self).__init__(
+        super().__init__(
             400, "Missing argument %s" % arg_name
         )
         self.arg_name = arg_name
@@ -3273,7 +3273,7 @@ class TemplateModule(UIModule):
     """
 
     def __init__(self, handler: RequestHandler) -> None:
-        super(TemplateModule, self).__init__(handler)
+        super().__init__(handler)
         # keep resources in both a list and a dict to preserve order
         self._resource_list = []  # type: List[Dict[str, Any]]
         self._resource_dict = {}  # type: Dict[str, Dict[str, Any]]

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1943,9 +1943,7 @@ class _ApplicationRouter(ReversibleRuleRouter):
                 request, target, **target_params
             )
 
-        return super().get_target_delegate(
-            target, request, **target_params
-        )
+        return super().get_target_delegate(target, request, **target_params)
 
 
 class Application(ReversibleRouter):
@@ -2418,9 +2416,7 @@ class MissingArgumentError(HTTPError):
     """
 
     def __init__(self, arg_name: str) -> None:
-        super().__init__(
-            400, "Missing argument %s" % arg_name
-        )
+        super().__init__(400, "Missing argument %s" % arg_name)
         self.arg_name = arg_name
 
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -221,7 +221,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
         request: httputil.HTTPServerRequest,
         **kwargs: Any
     ) -> None:
-        super(WebSocketHandler, self).__init__(application, request, **kwargs)
+        super().__init__(application, request, **kwargs)
         self.ws_connection = None  # type: Optional[WebSocketProtocol]
         self.close_code = None  # type: Optional[int]
         self.close_reason = None  # type: Optional[str]
@@ -582,11 +582,11 @@ class WebSocketHandler(tornado.web.RequestHandler):
         # connection (if it was established in the first place,
         # indicated by status code 101).
         if self.get_status() != 101 or self._on_close_called:
-            super(WebSocketHandler, self)._break_cycles()
+            super()._break_cycles()
 
     def send_error(self, *args: Any, **kwargs: Any) -> None:
         if self.stream is None:
-            super(WebSocketHandler, self).send_error(*args, **kwargs)
+            super().send_error(*args, **kwargs)
         else:
             # If we get an uncaught exception during the handshake,
             # we have no choice but to abruptly close the connection.
@@ -1410,7 +1410,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
             ] = "permessage-deflate; client_max_window_bits"
 
         self.tcp_client = TCPClient()
-        super(WebSocketClientConnection, self).__init__(
+        super().__init__(
             None,
             request,
             lambda: None,
@@ -1442,7 +1442,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
             self.connect_future.set_exception(StreamClosedError())
         self._on_message(None)
         self.tcp_client.close()
-        super(WebSocketClientConnection, self).on_connection_close()
+        super().on_connection_close()
 
     def on_ws_connection_close(
         self, close_code: Optional[int] = None, close_reason: Optional[str] = None
@@ -1467,9 +1467,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
     ) -> None:
         assert isinstance(start_line, httputil.ResponseStartLine)
         if start_line.code != 101:
-            await super(WebSocketClientConnection, self).headers_received(
-                start_line, headers
-            )
+            await super().headers_received(start_line, headers)
             return
 
         if self._timeout is not None:


### PR DESCRIPTION
On Python 3, super does not need to be called with arguments where as on Python 2, super needs to be called with a class object and an instance.

This commit updates the super usage using automated regex-based search and replace. The regex used was `(super)+\(+(\w+)(,)+\s(self)+\)+`. The regex searches for the word "super", followed by the character (, followed by another word, followed by the comma character ,, followed by the word "self", followed by the character ). Note that the regex allows one or more of the characters/words but it works in most cases.

After the automated changes were made, each change was individually checked before committing.

Note to reviewer/maintainer : I am not sure if these changes are welcome as I haven't looked for this need in the github issues. I noticed this and given that the project does not support Python 3 any longer, I thought I would contribute the changes. I fully understand if the maintainers choose to close this PR or optionally break it up into smaller chunks of work.

Ref : https://docs.python.org/3/library/functions.html#super