### PR TITLE
Remove utf-8 coding cookies in source files

### DIFF
--- a/tornado/_locale_data.py
+++ b/tornado/_locale_data.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright 2012 Facebook
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright 2009 Facebook
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from hashlib import md5
 import unittest
 

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 import binascii
 from contextlib import closing

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from tornado.httputil import (
     url_concat,
     parse_multipart_form_data,

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 from io import StringIO
 import os

--- a/tornado/test/util_test.py
+++ b/tornado/test/util_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from io import StringIO
 import re
 import sys


### PR DESCRIPTION
On Python 3, utf-8 is the default python source code encoding so, the coding cookies on files that specify utf-8 are not needed anymore. There are no coding cookies in the package after these changes are made.

Ref : https://docs.python.org/3/tutorial/interpreter.html#source-code-encoding