### PR TITLE
tests: httpclient may turn all methods into GET for 303 redirect

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -634,11 +634,12 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             # redirect, the request method should be preserved.
             # However, browsers implemented this by changing the
             # method to GET, and the behavior stuck. 303 redirects
-            # always specified this POST-to-GET behavior (arguably 303
-            # redirects should change *all* requests to GET, but
-            # libcurl only does this for POST so we follow their
-            # example).
-            if self.code in (301, 302, 303) and self.request.method == "POST":
+            # always specified this POST-to-GET behavior, arguably
+            # for *all* methods, but libcurl < 7.70 only does this
+            # for POST, while libcurl >= 7.70 does it for other methods.
+            if (self.code == 303 and self.request.method != "HEAD") or (
+                self.code in (301, 302) and self.request.method == "POST"
+            ):
                 new_request.method = "GET"
                 new_request.body = None
                 for h in [

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -331,10 +331,14 @@ Transfer-Encoding: chunked
             resp = self.fetch(url, method="POST", body=b"")
             self.assertEqual(b"GET", resp.body)
 
-            # Other methods are left alone.
+            # Other methods are left alone, except for 303 redirect, depending on client
             for method in ["GET", "OPTIONS", "PUT", "DELETE"]:
                 resp = self.fetch(url, method=method, allow_nonstandard_methods=True)
-                self.assertEqual(utf8(method), resp.body)
+                if status in [301, 302]:
+                    self.assertEqual(utf8(method), resp.body)
+                else:
+                    self.assertIn(resp.body, [utf8(method), b"GET"])
+
             # HEAD is different so check it separately.
             resp = self.fetch(url, method="HEAD")
             self.assertEqual(200, resp.code)


### PR DESCRIPTION
fixes #2852 