### PR TITLE
websocket: set follow_redirects to False

### DIFF
--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -111,6 +111,11 @@ class NonWebSocketHandler(RequestHandler):
         self.write("ok")
 
 
+class RedirectHandler(RequestHandler):
+    def get(self):
+        self.redirect("/echo")
+
+
 class CloseReasonHandler(TestWebSocketHandler):
     def open(self):
         self.on_close_called = False
@@ -221,6 +226,7 @@ class WebSocketTest(WebSocketBaseTestCase):
             [
                 ("/echo", EchoHandler, dict(close_future=self.close_future)),
                 ("/non_ws", NonWebSocketHandler),
+                ("/redirect", RedirectHandler),
                 ("/header", HeaderHandler, dict(close_future=self.close_future)),
                 (
                     "/header_echo",
@@ -364,6 +370,11 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_websocket_http_success(self):
         with self.assertRaises(WebSocketError):
             yield self.ws_connect("/non_ws")
+
+    @gen_test
+    def test_websocket_http_redirect(self):
+        with self.assertRaises(HTTPError):
+            yield self.ws_connect("/redirect")
 
     @gen_test
     def test_websocket_network_fail(self):

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1409,6 +1409,9 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
                 "Sec-WebSocket-Extensions"
             ] = "permessage-deflate; client_max_window_bits"
 
+        # Websocket connection is currently unable to follow redirects
+        request.follow_redirects = False
+
         self.tcp_client = TCPClient()
         super().__init__(
             None,


### PR DESCRIPTION
cleanup of #2876 
partial fix for #2405 

It seems like `request.follow_redirects = False` might make more sense in `WebSocketClientConnection.__init__()` next to all the request url and header modification, I could easily move it there if you agree ...