### PR TITLE
simple_httpclient: fix infinite loop hang with invalid gzip data

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -737,6 +737,10 @@ class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
                     if ret is not None:
                         await ret
                 compressed_data = self._decompressor.unconsumed_tail
+                if compressed_data and not decompressed:
+                    raise httputil.HTTPInputError(
+                        "encountered unconsumed gzip data without making progress"
+                    )
         else:
             ret = self._delegate.data_received(chunk)
             if ret is not None:


### PR DESCRIPTION
#2875 plus a unit test

The trigger is indeed just a single extra null byte at the end:

```
$ ls -l bad-response-hangs-tornado.gz 
-rw-rw-rw-@ 1 pierce  staff  31792 Sep 25 00:56 bad-response-hangs-tornado.gz
$ cat bad-response-hangs-tornado.gz | gunzip -c | wc -c
gunzip: (stdin): trailing garbage ignored
  149051
$ head -c 31791 bad-response-hangs-tornado.gz | gunzip -c | wc -c
  149051
$ head -c 31790 bad-response-hangs-tornado.gz | gunzip -c | wc -c
gunzip: truncated input
  149051
$ hexdump -C bad-response-hangs-tornado.gz | tail -n2
00007c20  45 54 a6 3b 4a ff 3f 84  e2 cc 59 3b 46 02 00 00  |ET.;J.?...Y;F...|
00007c30
```

But it wasn't trivially easy to find a response body that triggers the bug - a single gzipped "Hello World", or just 50 times that, doesn't do it. So I tried generating something dumb which is as long as the original un-compressed was, and that did it.

cc @jeffhunter 