### PR TITLE
PeriodicCallback: support async/coroutine callback

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -601,11 +601,7 @@ class IOLoop(Configurable):
         return self.call_at(self.time() + delay, callback, *args, **kwargs)
 
     def call_at(
-        self,
-        when: float,
-        callback: Callable,
-        *args: Any,
-        **kwargs: Any
+        self, when: float, callback: Callable, *args: Any, **kwargs: Any
     ) -> object:
         """Runs the ``callback`` at the absolute time designated by ``when``.
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -586,7 +586,7 @@ class IOLoop(Configurable):
             raise TypeError("Unsupported deadline %r" % deadline)
 
     def call_later(
-        self, delay: float, callback: Callable[..., None], *args: Any, **kwargs: Any
+        self, delay: float, callback: Callable, *args: Any, **kwargs: Any
     ) -> object:
         """Runs the ``callback`` after ``delay`` seconds have passed.
 
@@ -603,7 +603,7 @@ class IOLoop(Configurable):
     def call_at(
         self,
         when: float,
-        callback: Callable[..., Optional[Awaitable]],
+        callback: Callable,
         *args: Any,
         **kwargs: Any
     ) -> object:

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -870,7 +870,10 @@ class PeriodicCallback(object):
        The ``jitter`` argument is added.
 
     .. versionchanged:: 6.2
-       The ``callback`` argument may be a coroutine.
+       If the ``callback`` argument is a coroutine, and a callback runs for
+       longer than ``callback_time``, subsequent invocations will be skipped.
+       Previously this was only true for regular functions, not coroutines,
+       which were "fire-and-forget" for `PeriodicCallback`.
     """
 
     def __init__(

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -204,7 +204,11 @@ class BaseAsyncIOLoop(IOLoop):
         self.asyncio_loop.stop()
 
     def call_at(
-        self, when: float, callback: Callable[..., None], *args: Any, **kwargs: Any
+        self,
+        when: float,
+        callback: Callable[..., Optional[Awaitable]],
+        *args: Any,
+        **kwargs: Any
     ) -> object:
         # asyncio.call_at supports *args but not **kwargs, so bind them here.
         # We do not synchronize self.time and asyncio_loop.time, so

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -694,6 +694,60 @@ class TestPeriodicCallbackMath(unittest.TestCase):
         self.assertEqual(pc.callback_time, expected_callback_time)
 
 
+class TestPeriodicCallbackAsync(AsyncTestCase):
+    def test_periodic_plain(self):
+        count = 0
+
+        def callback() -> None:
+            nonlocal count
+            count += 1
+            if count == 3:
+                self.stop()
+
+        pc = PeriodicCallback(callback, 10)
+        pc.start()
+        self.wait()
+        pc.stop()
+        self.assertEqual(count, 3)
+
+    def test_periodic_coro(self):
+        counts = [0, 0]
+        pc = None
+
+        @gen.coroutine
+        def callback() -> None:
+            counts[0] += 1
+            yield gen.sleep(0.025)
+            counts[1] += 1
+            if counts[1] == 3:
+                pc.stop()
+                self.io_loop.add_callback(self.stop)
+
+        pc = PeriodicCallback(callback, 10)
+        pc.start()
+        self.wait()
+        self.assertEqual(counts[0], 3)
+        self.assertEqual(counts[1], 3)
+
+    def test_periodic_async(self):
+        counts = [0, 0]
+        pc = None
+
+        async def callback() -> None:
+            counts[0] += 1
+            await gen.sleep(0.025)
+            counts[1] += 1
+            if counts[1] == 3:
+                pc.stop()
+                self.io_loop.add_callback(self.stop)
+
+        pc = PeriodicCallback(callback, 10)
+        pc.start()
+        self.wait()
+        self.assertEqual(counts[0], 3)
+        self.assertEqual(counts[1], 3)
+
+
 class TestIOLoopConfiguration(unittest.TestCase):
     def run_python(self, *statements):
         stmt_list = [

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -161,7 +161,7 @@ class TestIOLoop(AsyncTestCase):
 
             self.io_loop.add_handler(client.fileno(), handler, IOLoop.READ)
             self.io_loop.add_timeout(
-                self.io_loop.time() + 0.01, functools.partial(server.send, b"asdf")  # type: ignore
+                self.io_loop.time() + 0.01, functools.partial(server.send, b"asdf")
             )
             self.wait()
             self.io_loop.remove_handler(client.fileno())


### PR DESCRIPTION
#2832 plus some tests

-------

EDIT: nevermind, figured out how to avoid this

ORIGINAL:

I can't quite figure out how to quiet this error log:

```
[E 200927 21:24:05 ioloop:910] Exception in callback <function TestPeriodicCallbackAsync.test_periodic_coro.<locals>.callback at 0x10a2a6c80>
    Traceback (most recent call last):
      File "/Users/pierce/scratch/tornado/tornado/ioloop.py", line 908, in _run
        await val  # type: ignore
    concurrent.futures._base.CancelledError
```

The usual pattern doesn't work:

```python
        with ExpectLog(app_log, "Exception in callback"):
            self.wait()
```

even if I extend it to:

```python
        with ExpectLog(app_log, "Exception in callback"):
            pc = PeriodicCallback(callback, 10)
            pc.start()
            self.wait()
            pc.stop()
```