### PR TITLE
websocket: avoid WebSocketClosedError double/nested exception

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1095,13 +1095,13 @@ class WebSocketProtocol13(WebSocketProtocol):
         try:
             fut = self._write_frame(True, opcode, message, flags=flags)
         except StreamClosedError:
-            raise WebSocketClosedError()
+            raise WebSocketClosedError() from None
 
         async def wrapper() -> None:
             try:
                 await fut
             except StreamClosedError:
-                raise WebSocketClosedError()
+                raise WebSocketClosedError() from None
 
         return asyncio.ensure_future(wrapper())
 


### PR DESCRIPTION
Tracking the exception that was being handled when another exception
was raised is a new feature in Python-3, causing this:

    Traceback (most recent call last):
      File "/...-packages/tornado/websocket.py", line 1104, in wrapper
        await fut
    tornado.iostream.StreamClosedError: Stream is closed

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/...-packages/tornado/websocket.py", line 1106, in wrapper
        raise WebSocketClosedError()
    tornado.websocket.WebSocketClosedError

This can be selectively avoided using the new Python-3 syntax:

    raise WebSocketClosedException from None


I just find the double-exception to be more ugly than it has to be, a matter of taste I guess, so I humbly offer this easy change in case you find it acceptable.