### PR TITLE
Revert "asyncio: AnyThreadEventLoopPolicy should always use selectors"

### DIFF
--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -26,9 +26,9 @@ import errno
 import functools
 import select
 import socket
-import sys
 import threading
 import typing
+
 from tornado.gen import convert_yielded
 from tornado.ioloop import IOLoop, _Selectable
 
@@ -359,15 +359,7 @@ def to_asyncio_future(tornado_future: asyncio.Future) -> asyncio.Future:
     return convert_yielded(tornado_future)
 
 
-if sys.platform == "win32" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
-    # "Any thread" and "selector" should be orthogonal, but there's not a clean
-    # interface for composing policies so pick the right base.
-    _BasePolicy = asyncio.WindowsSelectorEventLoopPolicy  # type: ignore
-else:
-    _BasePolicy = asyncio.DefaultEventLoopPolicy
-
-
-class AnyThreadEventLoopPolicy(_BasePolicy):  # type: ignore
+class AnyThreadEventLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore
     """Event loop policy that allows loop creation on any thread.
 
     The default `asyncio` event loop policy only automatically creates


### PR DESCRIPTION
This reverts commit d2af6a6fbe57a4d3bc06fbde6f4c1f4e8ec06dd3.

This is no longer necessary now that we can wrap proactor event loops.