### PR TITLE
ci,setup: Add python 3.9 to tox, cibuildwheel and setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 
 env:
   global:
-    - CIBW_BUILD="cp3[5678]*"
+    - CIBW_BUILD="cp3[56789]*"
     - CIBW_TEST_COMMAND="python3 -m tornado.test"
     - CIBW_TEST_COMMAND_WINDOWS="python -m tornado.test --fail-if-logs=false"
 
@@ -74,7 +74,7 @@ jobs:
     - python: '3.8'
       env: TOX_ENV=py38-full
     - python: '3.9-dev'
-      env: TOX_ENV=py3-full
+      env: TOX_ENV=py39-full
     - python: nightly
       env: TOX_ENV=py3
     - python: pypy3.6-7.3.1

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 [tox]
 envlist =
         # Basic configurations: Run the tests for each python version.
-        py35-full,py36-full,py37-full,py38-full,pypy3-full
+        py35-full,py36-full,py37-full,py38-full,py39-full,pypy3-full
 
         # Build and test the docs with sphinx.
         docs
@@ -31,6 +31,7 @@ basepython =
            py36: python3.6
            py37: python3.7
            py38: python3.8
+           py39: python3.9
            pypy3: pypy3
            # In theory, it doesn't matter which python version is used here.
            # In practice, things like changes to the ast module can alter
@@ -51,7 +52,7 @@ deps =
 
 setenv =
        # Treat the extension as mandatory in testing (but not on pypy)
-       {py3,py36,py37,py38}: TORNADO_EXTENSION=1
+       {py3,py36,py37,py38,py39}: TORNADO_EXTENSION=1
        # CI workers are often overloaded and can cause our tests to exceed
        # the default timeout of 5s.
        ASYNC_TEST_TIMEOUT=25
@@ -65,7 +66,7 @@ setenv =
        # tox).
        # ResourceWarnings are too noisy on py35 so don't enable 
        # warnings-as-errors there.
-       {py3,py36,py37,py38,pypy3}: PYTHONWARNINGS=error:::tornado
+       {py3,py36,py37,py38,py39,pypy3}: PYTHONWARNINGS=error:::tornado
 
 
 # All non-comment lines but the last must end in a backslash.


### PR DESCRIPTION
Start testing this with the 3.9 pre-releases.