### PR TITLE
asyncio: Manage our own thread instead of an executor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ environment:
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "32"
       TOX_ENV: "py38"
-      TOX_ARGS: "tornado.test.websocket_test"
+      TOX_ARGS: "--fail-if-logs=false tornado.test.websocket_test"
 
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x"

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -836,6 +836,7 @@ class SyncHTTPClientSubprocessTest(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,
+            timeout=5,
         )
         if proc.stdout:
             print("STDOUT:")


### PR DESCRIPTION
Python 3.9 changed the behavior of ThreadPoolExecutor at interpreter
shutdown (after the already-tricky import-order issues around
atexit hooks). Avoid these issues by managing the thread by hand.