### PR TITLE
fix: curl async http client empty-valued header

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -351,6 +351,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             pycurl.HTTPHEADER,
             [
                 "%s: %s" % (native_str(k), native_str(v))
+                if v is not '' else "%s;" % native_str(k)
                 for k, v in request.headers.get_all()
             ],
         )


### PR DESCRIPTION
### Behavior 
I found that some of the requests I sent by tornado would lose part of headers, exactly the empty-valued ones.

For example, when posting a request with headers `{'Content-Type': "application/json", 'Authorization': ""}`, only header `Content-Type` will be sent out actually, with the header `Authorization` dropped because it's empty.

For some requests, header with blank content is indispensable. In my case, I met an odd server must make sure there is an `Authorization` in headers even it is blank.

### Reason
The behavior caused by the way curl-http-client constructing headers, which converting all of headers in "%s: %s" format. The headers having no value, such as 'xxxx: ', would be removed by cURL.

To keep those headers in request, the colon should be replaced with semicolon, such as 'xxxx;'. [libcurl examples](https://curl.se/libcurl/c/httpcustomheader.html)