### PR TITLE
Issue #2954: prevent logging error messages for not existing translation files

### DIFF
--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -41,6 +41,7 @@ import codecs
 import csv
 import datetime
 import gettext
+import glob
 import os
 import re
 
@@ -198,13 +199,10 @@ def load_gettext_translations(directory: str, domain: str) -> None:
     global _supported_locales
     global _use_gettext
     _translations = {}
-    for lang in os.listdir(directory):
-        if lang.startswith("."):
-            continue  # skip .svn, etc
-        if os.path.isfile(os.path.join(directory, lang)):
-            continue
+
+    for filename in glob.glob(os.path.join(directory, '*', 'LC_MESSAGES', domain + '.mo')):
+        lang = os.path.basename(os.path.dirname(os.path.dirname(filename)))
         try:
-            os.stat(os.path.join(directory, lang, "LC_MESSAGES", domain + ".mo"))
             _translations[lang] = gettext.translation(
                 domain, directory, languages=[lang]
             )


### PR DESCRIPTION
Every not existing translation file for the existing locales logged an error message:
Cannot load translation for 'ps': [Errno 2] No such file or directory: '/usr/share/locale/ps/LC_MESSAGES/foo.mo'