### PR TITLE
WaitIterator: don't re-use _running_future

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -400,7 +400,7 @@ class WaitIterator(object):
         self._running_future = Future()
 
         if self._finished:
-            self._return_result(self._finished.popleft())
+            return self._return_result(self._finished.popleft())
 
         return self._running_future
 
@@ -418,8 +418,12 @@ class WaitIterator(object):
             raise Exception("no future is running")
         chain_future(done, self._running_future)
 
+        res = self._running_future
+        self._running_future = None
         self.current_future = done
         self.current_index = self._unfinished.pop(done)
+
+        return res
 
     def __aiter__(self) -> typing.AsyncIterator:
         return self

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -410,7 +410,7 @@ class WaitIterator(object):
         else:
             self._finished.append(done)
 
-    def _return_result(self, done: Future) -> None:
+    def _return_result(self, done: Future) -> Future:
         """Called set the returned future's state that of the future
         we yielded, and set the current future for the iterator.
         """


### PR DESCRIPTION
When used with `asyncio.Future`s, `WaitIterator` may skip indices in some cases. This is caused by multiple `_return_result` calls after another, without having the `chain_future` call finish in between. This is fixed here by not hanging on to the `_running_future` anymore, which forces subsequent `_return_result` calls to add to `_finished`, instead of causing the previous result to be silently dropped.

I couldn't yet figure out a minimal test case, I only got consistent failures as part of a larger program (via [distributed.utils.All](https://github.com/dask/distributed/blob/6fa9b1849a2ed43d123a9ae6221354cb420ce333/distributed/utils.py#L212)) - any help is appreciated!

Fixes #2034