### PR TITLE
Avoid 2GB read limitation on SSLIOStream

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1587,6 +1587,9 @@ class SSLIOStream(IOStream):
                 # to read (attempting to read may or may not raise an exception
                 # depending on the SSL version)
                 return None
+            # clip buffer size at 1GB since SSL sockets only support upto 2GB
+            # this change in behaviour is transparent, since the function is
+            # already expected to (possibly) read less than the provided buffer
             if len(buf) >> 30:
                 buf = memoryview(buf)[: 1 << 30]
             try:

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1587,6 +1587,8 @@ class SSLIOStream(IOStream):
                 # to read (attempting to read may or may not raise an exception
                 # depending on the SSL version)
                 return None
+            if len(buf) >> 30:
+                buf = memoryview(buf)[: 1 << 30] 
             try:
                 return self.socket.recv_into(buf, len(buf))
             except ssl.SSLError as e:

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1588,7 +1588,7 @@ class SSLIOStream(IOStream):
                 # depending on the SSL version)
                 return None
             if len(buf) >> 30:
-                buf = memoryview(buf)[: 1 << 30] 
+                buf = memoryview(buf)[: 1 << 30]
             try:
                 return self.socket.recv_into(buf, len(buf))
             except ssl.SSLError as e:


### PR DESCRIPTION
This PR avoids an 2GB read (at once) limitation for `iostream.SSLIOStream`, by silently capping read attempts to 1GB.
Normal operation (using the internal buffers) or `read_into` attempts with `len` < 1GB will not be affected by this change at all.

This issue can be encountered when using `read_into` e.g. during [`dask`'s data transfers](https://github.com/dask/distributed/blob/master/distributed/comm/tcp.py#L196) (with enabled TLS).

The underlying cause lies in Python's [`ssl.SSLSocket.read`](https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.read), which has a 2GB limitation.
The limitation is caused by an [`int`-type `len`gth  argument](https://github.com/python/cpython/blob/master/Modules/_ssl.c#L2520).
This seems to be intended, albeit undocumented, behavior since an [related issue](https://bugs.python.org/issue18135) did not raise the question of switching to `int64`.

