### PR TITLE
locale: Only try to load locales that exist

### DIFF
--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -200,7 +200,9 @@ def load_gettext_translations(directory: str, domain: str) -> None:
     global _use_gettext
     _translations = {}
 
-    for filename in glob.glob(os.path.join(directory, '*', 'LC_MESSAGES', domain + '.mo')):
+    for filename in glob.glob(
+        os.path.join(directory, "*", "LC_MESSAGES", domain + ".mo")
+    ):
         lang = os.path.basename(os.path.dirname(os.path.dirname(filename)))
         try:
             _translations[lang] = gettext.translation(

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -41,6 +41,7 @@ import codecs
 import csv
 import datetime
 import gettext
+import glob
 import os
 import re
 
@@ -198,13 +199,10 @@ def load_gettext_translations(directory: str, domain: str) -> None:
     global _supported_locales
     global _use_gettext
     _translations = {}
-    for lang in os.listdir(directory):
-        if lang.startswith("."):
-            continue  # skip .svn, etc
-        if os.path.isfile(os.path.join(directory, lang)):
-            continue
+
+    for filename in glob.glob(os.path.join(directory, '*', 'LC_MESSAGES', domain + '.mo')):
+        lang = os.path.basename(os.path.dirname(os.path.dirname(filename)))
         try:
-            os.stat(os.path.join(directory, lang, "LC_MESSAGES", domain + ".mo"))
             _translations[lang] = gettext.translation(
                 domain, directory, languages=[lang]
             )


### PR DESCRIPTION
Prevents errors logged at startup when the translation directory is shared with other projects.

Updates #2956 to fix formatting for CI.

Fixes #2954 
Closes #2956