### PR TITLE
Add asyncSetUp and asyncTearDown to AsyncTestCase

### DIFF
--- a/tornado/test/http1connection_test.py
+++ b/tornado/test/http1connection_test.py
@@ -1,5 +1,4 @@
 import socket
-import typing
 
 from tornado.http1connection import HTTP1Connection
 from tornado.httputil import HTTPMessageDelegate
@@ -10,14 +9,8 @@ from tornado.testing import AsyncTestCase, bind_unused_port, gen_test
 
 
 class HTTP1ConnectionTest(AsyncTestCase):
-    code = None  # type: typing.Optional[int]
-
-    def setUp(self):
-        super().setUp()
-        self.asyncSetUp()
-
-    @gen_test
-    def asyncSetUp(self):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
         listener, port = bind_unused_port()
         event = Event()
 
@@ -29,12 +22,13 @@ class HTTP1ConnectionTest(AsyncTestCase):
         add_accept_handler(listener, accept_callback)
         self.client_stream = IOStream(socket.socket())
         self.addCleanup(self.client_stream.close)
-        yield [self.client_stream.connect(("127.0.0.1", port)), event.wait()]
+        await self.client_stream.connect(("127.0.0.1", port))
+        await event.wait()
         self.io_loop.remove_handler(listener)
         listener.close()
 
     @gen_test
-    def test_http10_no_content_length(self):
+    async def test_http10_no_content_length(self):
         # Regression test for a bug in which can_keep_alive would crash
         # for an HTTP/1.0 (not 1.1) response with no content-length.
         conn = HTTP1Connection(self.client_stream, True)
@@ -42,12 +36,13 @@ class HTTP1ConnectionTest(AsyncTestCase):
         self.server_stream.close()
 
         event = Event()
-        test = self
+        code = None
         body = []
 
         class Delegate(HTTPMessageDelegate):
             def headers_received(self, start_line, headers):
-                test.code = start_line.code
+                nonlocal code
+                code = start_line.code
 
             def data_received(self, data):
                 body.append(data)
@@ -55,7 +50,7 @@ class HTTP1ConnectionTest(AsyncTestCase):
             def finish(self):
                 event.set()
 
-        yield conn.read_response(Delegate())
-        yield event.wait()
-        self.assertEqual(self.code, 200)
+        await conn.read_response(Delegate())
+        await event.wait()
+        self.assertEqual(code, 200)
         self.assertEqual(b"".join(body), b"hello")

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -66,7 +66,8 @@ class LeakTest(AsyncTestCase):
         # Trigger a gc to make warnings more deterministic.
         gc.collect()
 
-    def test_leaked_coroutine(self):
+    @gen_test
+    async def test_leaked_coroutine(self):
         # This test verifies that "leaked" coroutines are shut down
         # without triggering warnings like "task was destroyed but it
         # is pending". If this test were to fail, it would fail
@@ -79,9 +80,7 @@ class LeakTest(AsyncTestCase):
             except asyncio.CancelledError:
                 pass
 
-        self.io_loop.add_callback(callback)
-        self.io_loop.add_callback(self.stop)
-        self.wait()
+        asyncio.ensure_future(callback())
 
 
 class AsyncHTTPTestCaseTest(AsyncHTTPTestCase):


### PR DESCRIPTION
These are coroutine equivalents of setUp and tearDown respectively, same
as found in unittest.IsolatedAsyncioTestCase in Python 3.8.

Use them to slightly simplify AsyncHTTPTestCase. Also add async_fetch to
the latter for use in @gen_test tests.

In addition to convenience, asyncSetUp/asyncTearDown help to avoid a
subtle issue: IOLoop.make_current() has no effect if there is a running
loop (asyncio.get_event_loop is hard-coded to return the running loop if
there is one). This makes setUp/tearDown run with a wrong current IOLoop.
This is not a problem for asyncSetUp/asyncTearDown, because the correct
loop is the running one. (Normally asyncio doesn't allow running multiple
loops, but this can be solved with nest-asyncio package.)