### PR TITLE
Add 'address' keyword control binded address #2969

### DIFF
--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -45,17 +45,17 @@ if typing.TYPE_CHECKING:
 _NON_OWNED_IOLOOPS = AsyncIOMainLoop
 
 
-def bind_unused_port(reuse_port: bool = False) -> Tuple[socket.socket, int]:
+def bind_unused_port(reuse_port: bool = False, address: str = "127.0.0.1") -> Tuple[socket.socket, int]:
     """Binds a server socket to an available port on localhost.
 
     Returns a tuple (socket, port).
 
     .. versionchanged:: 4.4
-       Always binds to ``127.0.0.1`` without resolving the name
+       Default binds to ``127.0.0.1`` without resolving the name
        ``localhost``.
     """
     sock = netutil.bind_sockets(
-        0, "127.0.0.1", family=socket.AF_INET, reuse_port=reuse_port
+        0, address, family=socket.AF_INET, reuse_port=reuse_port
     )[0]
     port = sock.getsockname()[1]
     return sock, port

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -54,6 +54,7 @@ def bind_unused_port(
 
     .. versionchanged:: 4.4
        Always binds to ``127.0.0.1`` without resolving the name
+       ``localhost``.
 
     .. versionchanged:: 6.2
        Added optional ``address`` argument to

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -45,7 +45,9 @@ if typing.TYPE_CHECKING:
 _NON_OWNED_IOLOOPS = AsyncIOMainLoop
 
 
-def bind_unused_port(reuse_port: bool = False, address: str = "127.0.0.1") -> Tuple[socket.socket, int]:
+def bind_unused_port(
+    reuse_port: bool = False, address: str = "127.0.0.1"
+) -> Tuple[socket.socket, int]:
     """Binds a server socket to an available port on localhost.
 
     Returns a tuple (socket, port).

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -52,9 +52,9 @@ def bind_unused_port(
 
     Returns a tuple (socket, port).
 
-    .. versionchanged:: 4.4
-       Default binds to ``127.0.0.1`` without resolving the name
-       ``localhost``.
+    .. versionchanged:: 6.2
+       Added optional ``address`` argument to
+       override the default "127.0.0.1".
     """
     sock = netutil.bind_sockets(
         0, address, family=socket.AF_INET, reuse_port=reuse_port

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -52,6 +52,9 @@ def bind_unused_port(
 
     Returns a tuple (socket, port).
 
+    .. versionchanged:: 4.4
+       Always binds to ``127.0.0.1`` without resolving the name
+
     .. versionchanged:: 6.2
        Added optional ``address`` argument to
        override the default "127.0.0.1".


### PR DESCRIPTION
Specify custom address by "address" keyword when use `tornado.testing.bind_unused_port` function.