### PR TITLE
Add `unsafe_remote_ip` property

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -27,6 +27,7 @@ import email.utils
 from functools import lru_cache
 from http.client import responses
 import http.cookies
+import ipaddress
 import re
 from ssl import SSLError
 import time
@@ -35,6 +36,7 @@ from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
 
 from tornado.escape import native_str, parse_qs_bytes, utf8
 from tornado.log import gen_log
+from tornado.netutil import is_valid_ip
 from tornado.util import ObjectDict, unicode_type
 
 
@@ -382,6 +384,22 @@ class HTTPServerRequest(object):
         self.arguments = parse_qs_bytes(self.query, keep_blank_values=True)
         self.query_arguments = copy.deepcopy(self.arguments)
         self.body_arguments = {}  # type: Dict[str, List[bytes]]
+
+    @property
+    def unsafe_remote_ip(self) -> str:
+        """The IP a client claims to be using.
+
+        This is the first public IP in the X-Forwarded-For header.
+
+        Unlike `remote_ip` this IP is untrustworthy but potentially more
+        representative of the real IP a client is using. Useful for situations
+        like geolocation.
+        """
+        ip = self.headers.get("X-Forwarded-For", self.remote_ip)
+        for ip in (cand.strip() for cand in ip.split(",")):
+            if is_valid_ip(ip) and ipaddress.ip_address(ip).is_global:
+                break
+        return ip
 
     @property
     def cookies(self) -> Dict[str, http.cookies.Morsel]:

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -575,6 +575,40 @@ bar
             yield self.stream.read_until_close()
 
 
+class UnsafeRemoteIPTest(HandlerBaseTestCase):
+    class Handler(RequestHandler):
+        def get(self):
+            self.set_header("request-version", self.request.version)
+            self.write(
+                dict(
+                    remote_ip=self.request.remote_ip,
+                    unsafe_remote_ip=self.request.unsafe_remote_ip,
+                )
+            )
+
+    def get_httpserver_options(self):
+        return dict(xheaders=True, trusted_downstream=["5.5.5.5"])
+
+    def test_unsafe_ip(self):
+        self.assertEqual(self.fetch_json("/")["remote_ip"], "127.0.0.1")
+        self.assertEqual(self.fetch_json("/")["unsafe_remote_ip"], "127.0.0.1")
+
+        valid_ip = {"X-Forwarded-for": "4.4.4.4"}
+        self.assertEqual(
+            self.fetch_json("/", headers=valid_ip)["unsafe_remote_ip"], "4.4.4.4"
+        )
+
+        valid_ip_list = {"X-Forwarded-for": "3.3.3.3, 4.4.4.4"}
+        self.assertEqual(
+            self.fetch_json("/", headers=valid_ip_list)["unsafe_remote_ip"], "3.3.3.3"
+        )
+
+        skip_private_ip = {"X-Forwarded-for": "10.0.0.1, 3.3.3.3, 4.4.4.4"}
+        self.assertEqual(
+            self.fetch_json("/", headers=skip_private_ip)["unsafe_remote_ip"], "3.3.3.3"
+        )
+
+
 class XHeaderTest(HandlerBaseTestCase):
     class Handler(RequestHandler):
         def get(self):


### PR DESCRIPTION
This property represents the IP closest to the user. This means it is
potentially unsafe because clients can fake it but might be more useful for geolocation purposes.

Closes #904

---

Hi 👋!

This is my first attempt at contributing to tornado (long time user via JupyterHub and BinderHub). I picked #904 because it looked interesting and not too hard. However it is a very old issue so maybe thinking has moved on since then about how useful it is?

I thought I'd open this PR already to get some early feedback. I think if things look about right a better/more doc string is needed and maybe some more edge case test. Also need to look at availability of the `ipaddress` module in terms of which versions tornado supports.

I think it is ok to always provide this, not only when `xheaders=True`, as it is always "unsafe" to look at this value/take it at face value.

What do you think of the name of the new property? Is the `HTTPServerRequest` class the right place for this or should it be in the connection class like the `remote_ip` handling?

(should this be a draft PR until it is ready for reviewing?)