### PR TITLE
Update docker composer file version and wait for postgres #2784

### DIFF
--- a/demos/blog/docker-compose.yml
+++ b/demos/blog/docker-compose.yml
@@ -1,15 +1,25 @@
-postgres:
-  image: postgres:10.3
-  environment:
-    POSTGRES_USER: blog
-    POSTGRES_PASSWORD: blog
-    POSTGRES_DB: blog
-  ports:
-    - "3306"
-blog:
-  build: .
-  links:
-    - postgres
-  ports:
-    - "8888:8888"
-  command: --db_host=postgres
+version: "3.8"
+services:
+  postgres:
+    image: postgres:10.3
+    environment:
+      POSTGRES_USER: blog
+      POSTGRES_PASSWORD: blog
+      POSTGRES_DB: blog
+    ports:
+      - "3306"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+  blog:
+    build: .
+    links:
+      - postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8888:8888"
+    command: --db_host=postgres


### PR DESCRIPTION
This is a new approach to avoid Docker image python app initialize first, causing a failure in connection between python app and postgres.

I found this solution on a post in [stackoverflow](https://stackoverflow.com/questions/35069027/docker-wait-for-postgresql-to-be-running)

Signed-off-by: Emory Freitas <emory.rvf@gmail.com>