### PR TITLE
should use python3 unicode in 'blog' demo #2977

### DIFF
--- a/demos/blog/blog.py
+++ b/demos/blog/blog.py
@@ -68,7 +68,7 @@ class Application(tornado.web.Application):
             (r"/auth/logout", AuthLogoutHandler),
         ]
         settings = dict(
-            blog_title=u"Tornado Blog",
+            blog_title="Tornado Blog",
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=os.path.join(os.path.dirname(__file__), "static"),
             ui_modules={"Entry": EntryModule},


### PR DESCRIPTION
change `u"Tornado Blog"` to `"Tornado Blog"`