### PR TITLE
BaseIOStream.write(): support typed memoryviews

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -529,6 +529,9 @@ class BaseIOStream(object):
         """
         self._check_closed()
         if data:
+            if isinstance(data, memoryview):
+                # Make sure that ``len(data) == data.nbytes``
+                data = memoryview(data).cast("B")
             if (
                 self.max_write_buffer_size is not None
                 and len(self._write_buffer) + len(data) > self.max_write_buffer_size

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -1047,6 +1047,17 @@ class TestIOStreamStartTLS(AsyncTestCase):
                 # The server fails to connect, but the exact error is unspecified.
                 yield server_future
 
+    @gen_test
+    def test_typed_memoryview(self):
+        # Test support of memoryviews with an item size greater than 1 byte.
+        buf = memoryview(bytes(80)).cast("L")
+        assert self.server_stream is not None
+        yield self.server_stream.write(buf)
+        assert self.client_stream is not None
+        # This will timeout if the calculation of the buffer size is incorrect
+        recv = yield self.client_stream.read_bytes(buf.nbytes)
+        self.assertEqual(bytes(recv), bytes(buf))
+
 
 class WaitForHandshakeTest(AsyncTestCase):
     @gen.coroutine


### PR DESCRIPTION
This PR implements support of `memoryviews` with an item size greater than 1 byte.

Currently, Tornado uses `len(x)` to retrieve the number of bytes of `x`, which works fine when `x` is `bytes` or a `memoryview` with an item size of 1. However, with an item size greater than 1 we cannot assume that `len(x) == x.nbytes`.