### PR TITLE
is_valid_ip: Do not raise exceptions on too-long input.

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -301,6 +301,12 @@ def is_valid_ip(ip: str) -> bool:
         if e.args[0] == socket.EAI_NONAME:
             return False
         raise
+    except UnicodeError:
+        # `socket.getaddrinfo` will raise a UnicodeError from the
+        # `idna` decoder if the input is longer than 63 characters,
+        # even for socket.AI_NUMERICHOST.  See
+        # https://bugs.python.org/issue32958 for discussion
+        return False
     return True
 
 

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -204,6 +204,7 @@ class IsValidIPTest(unittest.TestCase):
         self.assertTrue(not is_valid_ip(" "))
         self.assertTrue(not is_valid_ip("\n"))
         self.assertTrue(not is_valid_ip("\x00"))
+        self.assertTrue(not is_valid_ip("a" * 100))
 
 
 class TestPortAllocation(unittest.TestCase):


### PR DESCRIPTION
Calling `socket.getaddrinfo` with a potential hostname attempts to
encode the "hostname" with the `idna` encoding.  Per RFC, each part of
the hostname cannot be longer than 63 characters; and `getaddrinfo`
enforces this by raising a UnicodeError if the length is too long.

Catch these UnicodeErrors and return false for too-long names, rather
than raising an exception.