### PR TITLE
Type-hint stream_request_body correctly

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -118,6 +118,7 @@ from typing import (
     Iterable,
     Generator,
     Type,
+    TypeVar,
     cast,
     overload,
 )
@@ -1818,7 +1819,10 @@ class RequestHandler(object):
             self.clear_header(h)
 
 
-def stream_request_body(cls: Type[RequestHandler]) -> Type[RequestHandler]:
+RequestHandlerType = TypeVar("RequestHandlerType", bound=RequestHandler)
+
+
+def stream_request_body(cls: Type[RequestHandlerType]) -> Type[RequestHandlerType]:
     """Apply to `RequestHandler` subclasses to enable streaming body support.
 
     This decorator implies the following changes:


### PR DESCRIPTION
Type-hint stream_request_body so that the type of `stream_request_body(cls)` is the same as the type of `cls`.