### PR TITLE
update WebSocketHandler.ping_timeout __doc__

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -291,7 +291,6 @@ class WebSocketHandler(tornado.web.RequestHandler):
     def ping_timeout(self) -> Optional[float]:
         """If no ping is received in this many seconds,
         close the websocket connection (VPNs, etc. can fail to cleanly close ws connections).
-        Default is max of 3 pings or 30 seconds.
         """
         return self.settings.get("websocket_ping_timeout", None)
 


### PR DESCRIPTION
hi sir

i have a subclass
```python3
class WebsocketHandler(tornado.websocket.WebSocketHandler):

    def open(self):  
        print(999,   self.ping_timeout)
        print("WebSocket opened")
```
I did not set the websocket_ping_timeout arg when the websocket connection was established
and i try to print  default websocket_ping_timeout
![Screenshot from 2021-05-05 19-35-58](https://user-images.githubusercontent.com/33141341/117135285-4e69d800-add9-11eb-8823-4aae547930fd.png)
i did't get anything like __doc__ , that why i make pull-request
![Screenshot from 2021-05-05 19-39-57](https://user-images.githubusercontent.com/33141341/117135608-c6d09900-add9-11eb-96e5-c23d1cb3f0b6.png)
