### PR TITLE
Accept timedelta objects in PeriodicCallback

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -839,9 +839,11 @@ class _Timeout(object):
 class PeriodicCallback(object):
     """Schedules the given callback to be called periodically.
 
-    The callback is called every ``callback_time`` milliseconds.
-    Note that the timeout is given in milliseconds, while most other
-    time-related functions in Tornado use seconds.
+    The callback is called every ``callback_time`` milliseconds when
+    ``callback_time`` is a float. Note that the timeout is given in
+    milliseconds, while most other time-related functions in Tornado use
+    seconds. ``callback_time`` may alternatively be given as a
+    `datetime.timedelta` object.
 
     If ``jitter`` is specified, each callback time will be randomly selected
     within a window of ``jitter * callback_time`` milliseconds.

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -864,12 +864,18 @@ class PeriodicCallback(object):
     """
 
     def __init__(
-        self, callback: Callable[[], None], callback_time: float, jitter: float = 0
+        self,
+        callback: Callable[[], None],
+        callback_time: Union[datetime.timedelta, float],
+        jitter: float = 0,
     ) -> None:
         self.callback = callback
-        if callback_time <= 0:
-            raise ValueError("Periodic callback must have a positive callback_time")
-        self.callback_time = callback_time
+        if isinstance(callback_time, datetime.timedelta):
+            self.callback_time = callback_time / datetime.timedelta(milliseconds=1)
+        else:
+            if callback_time <= 0:
+                raise ValueError("Periodic callback must have a positive callback_time")
+            self.callback_time = callback_time
         self.jitter = jitter
         self._running = False
         self._timeout = None  # type: object

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -688,6 +688,11 @@ class TestPeriodicCallbackMath(unittest.TestCase):
         with mock.patch("random.random", mock_random):
             self.assertEqual(self.simulate_calls(pc, call_durations), expected)
 
+    def test_timedelta(self):
+        pc = PeriodicCallback(lambda: None, datetime.timedelta(minutes=1, seconds=23))
+        expected_callback_time = 83000
+        self.assertEqual(pc.callback_time, expected_callback_time)
+
 
 class TestIOLoopConfiguration(unittest.TestCase):
     def run_python(self, *statements):


### PR DESCRIPTION
Instead of requiring callers to convert their desired callback time to milliseconds, this change allows for passing in `timedelta`s:

```python
from datetime import timedelta
from tornado.ioloop import PeriodicCallback

task = PeriodicCallback(lambda: print("ping"), timedelta(minutes=1, seconds=23))
task.start()
```