### PR TITLE
ioloop: add_timeout() and call_at() take any Callable

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -547,7 +547,7 @@ class IOLoop(Configurable):
     def add_timeout(
         self,
         deadline: Union[float, datetime.timedelta],
-        callback: Callable[..., Optional[Awaitable]],
+        callback: Callable,
         *args: Any,
         **kwargs: Any
     ) -> object:

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -204,11 +204,7 @@ class BaseAsyncIOLoop(IOLoop):
         self.asyncio_loop.stop()
 
     def call_at(
-        self,
-        when: float,
-        callback: Callable[..., Optional[Awaitable]],
-        *args: Any,
-        **kwargs: Any
+        self, when: float, callback: Callable, *args: Any, **kwargs: Any
     ) -> object:
         # asyncio.call_at supports *args but not **kwargs, so bind them here.
         # We do not synchronize self.time and asyncio_loop.time, so


### PR DESCRIPTION
clean-up some methods that were missed in
https://github.com/tornadoweb/tornado/pull/2924