### PR TITLE
Fix case-sensitivity for Content-Encoding: gzip. as per rfc7231 the C…

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -718,7 +718,7 @@ class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
         start_line: Union[httputil.RequestStartLine, httputil.ResponseStartLine],
         headers: httputil.HTTPHeaders,
     ) -> Optional[Awaitable[None]]:
-        if headers.get("Content-Encoding") == "gzip":
+        if headers.get("Content-Encoding", "").lower() == "gzip":
             self._decompressor = GzipDecompressor()
             # Downstream delegates will only see uncompressed data,
             # so rename the content-encoding header.

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -1000,6 +1000,21 @@ class GzipTest(GzipBaseTest, AsyncHTTPTestCase):
         response = self.post_gzip("foo=bar")
         self.assertEqual(json_decode(response.body), {u"foo": [u"bar"]})
 
+    def test_gzip_case_insensitive(self):
+        # https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.1
+        bytesio = BytesIO()
+        gzip_file = gzip.GzipFile(mode="w", fileobj=bytesio)
+        gzip_file.write(utf8("foo=bar"))
+        gzip_file.close()
+        compressed_body = bytesio.getvalue()
+        response = self.fetch(
+            "/",
+            method="POST",
+            body=compressed_body,
+            headers={"Content-Encoding": "GZIP"},
+        )
+        self.assertEqual(json_decode(response.body), {u"foo": [u"bar"]})
+
 
 class GzipUnsupportedTest(GzipBaseTest, AsyncHTTPTestCase):
     def test_gzip_unsupported(self):


### PR DESCRIPTION
…ontent-Encoding values are case-insensitive https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.1

As per https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.1 the content encodings are case insensitive.
Related PR: https://github.com/tornadoweb/tornado/pull/1778

We have an issue of incoming requests not decompressed because they send headers like `Content-Encoding: GZIP`.
I'm not sure if I wrote the test as it should have, let know if it needs some changes.