### PR TITLE
Updated static to static file handler path

### DIFF
--- a/docs/guide/running.rst
+++ b/docs/guide/running.rst
@@ -166,7 +166,7 @@ You can serve static files from Tornado by specifying the
     application = tornado.web.Application([
         (r"/", MainHandler),
         (r"/login", LoginHandler),
-        (r"/(apple-touch-icon\.png)", tornado.web.StaticFileHandler,
+        (r"/static/(apple-touch-icon\.png)", tornado.web.StaticFileHandler,
          dict(path=settings['static_path'])),
     ], **settings)
 


### PR DESCRIPTION
I wasn't able to get anything working without having `static` in the regex expression for the file handler., I found the solution here, https://stackoverflow.com/questions/9531092/how-to-handle-a-http-get-request-to-a-file-in-tornado/9637895#9637895