### PR TITLE
Cast `max_message_size` to `int` to avoid deprecation warning

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -761,7 +761,7 @@ class _PerMessageDeflateDecompressor(object):
         max_message_size: int,
         compression_options: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self._max_message_size = max_message_size
+        self._max_message_size = int(max_message_size)
         if max_wbits is None:
             max_wbits = zlib.MAX_WBITS
         if not (8 <= max_wbits <= zlib.MAX_WBITS):


### PR DESCRIPTION
Using `streamlit` without this change, I get the following deprecation warning:
```
DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```
which in turn causes a timeout:
```
HTTPServerRequest(protocol='http', host='localhost:8501', method='GET', uri='/stream', version='HTTP/1.1', remote_ip='::1')
Traceback (most recent call last):
...
```
Simply casting `max_message_size` (type-hinted as `int`) to an `int` fixes the problem (it was being passed as a `float` somewhere on further inspection).