### PR TITLE
Replace deprecated unittest aliases

### DIFF
--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -122,7 +122,7 @@ class ClientTestMixin(object):
         future = self.client.capitalize("HELLO")
         self.io_loop.add_future(future, self.stop)
         self.wait()
-        self.assertRaisesRegexp(CapError, "already capitalized", future.result)  # type: ignore
+        self.assertRaisesRegex(CapError, "already capitalized", future.result)  # type: ignore
 
     def test_generator(self: typing.Any):
         @gen.coroutine
@@ -135,7 +135,7 @@ class ClientTestMixin(object):
     def test_generator_error(self: typing.Any):
         @gen.coroutine
         def f():
-            with self.assertRaisesRegexp(CapError, "already capitalized"):
+            with self.assertRaisesRegex(CapError, "already capitalized"):
                 yield self.client.capitalize("HELLO")
 
         self.io_loop.run_sync(f)

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -474,7 +474,7 @@ Transfer-Encoding: chunked
             streaming_callback=streaming_callback,
         )
         self.assertEqual(len(first_line), 1, first_line)
-        self.assertRegexpMatches(first_line[0], "HTTP/[0-9]\\.[0-9] 200.*\r\n")
+        self.assertRegex(first_line[0], "HTTP/[0-9]\\.[0-9] 200.*\r\n")
         self.assertEqual(chunks, [b"asdf", b"qwer"])
 
     @gen_test

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -784,7 +784,7 @@ class TestIOStreamMixin(TestReadWriteMixin):
                 "tornado.iostream.BaseIOStream._try_inline_read",
                 side_effect=IOError("boom"),
             ):
-                with self.assertRaisesRegexp(IOError, "boom"):
+                with self.assertRaisesRegex(IOError, "boom"):
                     client.read_until_close()
         finally:
             server.close()

--- a/tornado/test/log_test.py
+++ b/tornado/test/log_test.py
@@ -112,7 +112,7 @@ class LogFormatterTest(unittest.TestCase):
         # This will be "Exception: \xe9" on python 2 or
         # "Exception: b'\xe9'" on python 3.
         output = self.get_output()
-        self.assertRegexpMatches(output, br"Exception.*\\xe9")
+        self.assertRegex(output, br"Exception.*\\xe9")
         # The traceback contains newlines, which should not have been escaped.
         self.assertNotIn(br"\n", output)
 
@@ -148,7 +148,7 @@ class EnablePrettyLoggingTest(unittest.TestCase):
             filenames = glob.glob(tmpdir + "/test_log*")
             self.assertEqual(1, len(filenames))
             with open(filenames[0]) as f:
-                self.assertRegexpMatches(f.read(), r"^\[E [^]]*\] hello$")
+                self.assertRegex(f.read(), r"^\[E [^]]*\] hello$")
         finally:
             for handler in self.logger.handlers:
                 handler.flush()
@@ -168,7 +168,7 @@ class EnablePrettyLoggingTest(unittest.TestCase):
             filenames = glob.glob(tmpdir + "/test_log*")
             self.assertEqual(1, len(filenames))
             with open(filenames[0]) as f:
-                self.assertRegexpMatches(f.read(), r"^\[E [^]]*\] hello$")
+                self.assertRegex(f.read(), r"^\[E [^]]*\] hello$")
         finally:
             for handler in self.logger.handlers:
                 handler.flush()

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -262,7 +262,7 @@ class OptionsTest(unittest.TestCase):
         options.define("foo")
         with self.assertRaises(Error) as cm:
             options.define("foo")
-        self.assertRegexpMatches(str(cm.exception), "Option.*foo.*already defined")
+        self.assertRegex(str(cm.exception), "Option.*foo.*already defined")
 
     def test_error_redefine_underscore(self):
         # Ensure that the dash/underscore normalization doesn't
@@ -279,7 +279,7 @@ class OptionsTest(unittest.TestCase):
                 options.define(a)
                 with self.assertRaises(Error) as cm:
                     options.define(b)
-                self.assertRegexpMatches(
+                self.assertRegex(
                     str(cm.exception), "Option.*foo.bar.*already defined"
                 )
 


### PR DESCRIPTION
https://docs.python.org/3/library/unittest.html#deprecated-aliases