### PR TITLE
Avoid 2GB write limitation on SSLIOStream

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1566,6 +1566,11 @@ class SSLIOStream(IOStream):
         return future
 
     def write_to_fd(self, data: memoryview) -> int:
+        # clip buffer size at 1GB since SSL sockets only support upto 2GB
+        # this change in behaviour is transparent, since the function is
+        # already expected to (possibly) read less than the provided buffer
+        if len(data) >> 30:
+            data = memoryview(data)[: 1 << 30]
         try:
             return self.socket.send(data)  # type: ignore
         except ssl.SSLError as e:


### PR DESCRIPTION
This PR is practically the same as #2970, but for write. The same argument and caveats apply:

This PR avoids an 2GB write (at once) limitation for `iostream.SSLIOStream`, by silently capping write attempts to 1GB.
Normal operation (using the internal buffers) or `write` attempts with `len` < 1GB will not be affected by this change at all.

This issue can be encountered when using `write` e.g. during [`dask`'s data transfers](https://github.com/dask/distributed/blob/master/distributed/comm/tcp.py#L238) (with enabled TLS).

The underlying cause lies in Python's [`ssl.SSLSocket.write`](https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.write), which has a 2GB limitation.
The limitation is caused by an [`int`-type `len`gth  argument](https://github.com/python/cpython/blob/8f42106b5c362495f72c6ca2fa3884538e4023db/Modules/_ssl.c#L2349).
It has been [fixed](https://bugs.python.org/issue42854) by now, and is set to be included in CPython 3.10.

