### PR TITLE
Fix websocket client already closed raise error does not match

### DIFF
--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -340,6 +340,13 @@ class WebSocketTest(WebSocketBaseTestCase):
         self.assertEqual(response, u"hello \u00e9")
 
     @gen_test
+    def test_error_in_closed_client_write_message(self):
+        ws = yield self.ws_connect("/echo")
+        ws.close()
+        with self.assertRaises(WebSocketClosedError):
+            ws.write_message(u"hello \u00e9")
+
+    @gen_test
     def test_render_message(self):
         ws = yield self.ws_connect("/render")
         ws.write_message("hello")

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1501,6 +1501,8 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
            Exception raised on a closed stream changed from `.StreamClosedError`
            to `WebSocketClosedError`.
         """
+        if self.protocol is None:
+            raise WebSocketClosedError("Client connection has been closed")
         return self.protocol.write_message(message, binary=binary)
 
     def read_message(


### PR DESCRIPTION
As doc says "If the stream is closed, raises WebSocketClosedError"

Fix #3002 