### PR TITLE
Add __wrapped__ attribute to _TestMethodWrapper

### DIFF
--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -5,6 +5,7 @@ from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, 
 from tornado.web import Application
 import asyncio
 import contextlib
+import inspect
 import gc
 import os
 import platform
@@ -170,6 +171,14 @@ class AsyncTestCaseWrapperTest(unittest.TestCase):
         test.run(result)
         self.assertEqual(len(result.errors), 1)
         self.assertIn("Return value from test method ignored", result.errors[0][1])
+
+    def test_unwrap(self):
+        class Test(AsyncTestCase):
+            def test_foo(self):
+                pass
+
+        test = Test("test_foo")
+        self.assertIs(inspect.unwrap(test.test_foo), test.test_foo.orig_method)
 
 
 class SetUpTearDownTest(unittest.TestCase):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -95,6 +95,7 @@ class _TestMethodWrapper(object):
 
     def __init__(self, orig_method: Callable) -> None:
         self.orig_method = orig_method
+        self.__wrapped__ = orig_method
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         result = self.orig_method(*args, **kwargs)


### PR DESCRIPTION
Since Python 3.2 the functools.wraps decorator adds a __wrapped__ attribute
pointing to the original callable, this allows wrapped functions to be introspected.