### PR TITLE
Fix tornado.web.RequestHandler.get_browser_locale()

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1293,7 +1293,8 @@ class RequestHandler(object):
                         score = 0.0
                 else:
                     score = 1.0
-                locales.append((parts[0], score))
+                if score > 0:
+                    locales.append((parts[0], score))
             if locales:
                 locales.sort(key=lambda pair: pair[1], reverse=True)
                 codes = [loc[0] for loc in locales]

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1286,9 +1286,9 @@ class RequestHandler(object):
             locales = []
             for language in languages:
                 parts = language.strip().split(";")
-                if len(parts) > 1 and parts[1].startswith("q="):
+                if len(parts) > 1 and parts[1].strip().startswith("q="):
                     try:
-                        score = float(parts[1][2:])
+                        score = float(parts[1].strip()[2:])
                     except (ValueError, TypeError):
                         score = 0.0
                 else:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1289,6 +1289,8 @@ class RequestHandler(object):
                 if len(parts) > 1 and parts[1].strip().startswith("q="):
                     try:
                         score = float(parts[1].strip()[2:])
+                        if score < 0:
+                            raise ValueError()
                     except (ValueError, TypeError):
                         score = 0.0
                 else:


### PR DESCRIPTION
* fix optional whitespace parsing of Accept-Language header
* fix ignoring quality=0 values in Accept-Language
* disallow negative quality values in Accept-Language 