### PR TITLE
fix[curl_httpclient]: allow HTTP header to include non-ASCII ISO8859-1 values

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -350,7 +350,8 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         curl.setopt(
             pycurl.HTTPHEADER,
             [
-                "%s: %s" % (native_str(k), native_str(v))
+                b"%s: %s"
+                % (native_str(k).encode("ASCII"), native_str(v).encode("ISO8859-1"))
                 for k, v in request.headers.get_all()
             ],
         )

--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -61,6 +61,7 @@ class ImportTest(unittest.TestCase):
         import tornado.ioloop
         import tornado.gen
         import tornado.util
+        import asyncio
 
         self.assertIs(tornado.ioloop.TimeoutError, tornado.util.TimeoutError)
         self.assertIs(tornado.gen.TimeoutError, tornado.util.TimeoutError)


### PR DESCRIPTION
It's not possible to contain non-ASCII values in HTTP headers using the async `pycurl` HTTP client

- OK: `tornado.httputil.HTTPHeaders()` only allows to contain unicode strings.
- OK: `tornado.escape.native_string()` would always produce a `UTF-8` decoded string - used here makes only sense for py2 compatibility
- FAIL: unicode strings are given to pycurl instead of bytes, pycurl only accepts ASCII unicode strings

Example failure:
```
from io import BytesIO

import tornado.curl_httpclient

c = tornado.curl_httpclient.CurlAsyncHTTPClient()
curl = c._curls[0]
headers = tornado.httputil.HTTPHeaders({
    # b"Foo": b"b\xe4r",
    "Foo": "b\xe4r",
})
request = tornado.httpclient.HTTPRequest(
    'http://www.example.com', follow_redirects=True, max_redirects=3,
    connect_timeout=1, request_timeout=1, headers=headers
)
c._curl_setup_request(curl, request, BytesIO(), tornado.httputil.HTTPHeaders())
```

raises
```
Traceback (most recent call last):
  File "reproduce.py", line 15, in <module>
    c._curl_setup_request(curl, request, BytesIO(), tornado.httputil.HTTPHeaders())
  File "tornado/curl_httpclient.py", line 354, in _curl_setup_request
    for k, v in request.headers.get_all()
UnicodeEncodeError: 'ascii' codec can't encode character '\xe4' in position 6: ordinal not in range(128)
```

