### PR TITLE
make gen.TimeoutError asyncio.TimeoutError

### DIFF
--- a/docs/util.rst
+++ b/docs/util.rst
@@ -7,3 +7,15 @@
 
 .. automodule:: tornado.util
     :members:
+
+    .. class:: TimeoutError
+
+        Exception raised by `.gen.with_timeout` and `.IOLoop.run_sync`.
+
+        .. versionchanged:: 5.0
+           Unified ``tornado.gen.TimeoutError`` and
+           ``tornado.ioloop.TimeoutError`` as ``tornado.util.TimeoutError``.
+           Both former names remain as aliases.
+
+        .. versionchanged:: 6.2
+           ``tornado.util.TimeoutError`` is an alias to :py:class:`asyncio.TimeoutError`

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -606,6 +606,9 @@ def with_timeout(
     .. versionchanged:: 6.0.3
        ``asyncio.CancelledError`` is now always considered "quiet".
 
+    .. versionchanged:: 6.2
+       ``tornado.util.TimeoutError`` is now an alias to ``asyncio.TimeoutError``.
+
     """
     # It's tempting to optimize this by cancelling the input future on timeout
     # instead of creating a new one, but A) we can't know if we are the only

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -468,7 +468,7 @@ class IOLoop(Configurable):
 
         The keyword-only argument ``timeout`` may be used to set
         a maximum duration for the function.  If the timeout expires,
-        a `tornado.util.TimeoutError` is raised.
+        a `asyncio.TimeoutError` is raised.
 
         This method is useful to allow asynchronous calls in a
         ``main()`` function::
@@ -485,6 +485,8 @@ class IOLoop(Configurable):
         .. versionchanged:: 5.0
            If a timeout occurs, the ``func`` coroutine will be cancelled.
 
+        .. versionchanged:: 6.2
+           ``tornado.util.TimeoutError`` is now an alias to ``asyncio.TimeoutError``.
         """
         future_cell = [None]  # type: List[Optional[Future]]
 

--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -64,3 +64,4 @@ class ImportTest(unittest.TestCase):
 
         self.assertIs(tornado.ioloop.TimeoutError, tornado.util.TimeoutError)
         self.assertIs(tornado.gen.TimeoutError, tornado.util.TimeoutError)
+        self.assertIs(tornado.util.TimeoutError, asyncio.TimeoutError)

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -11,6 +11,7 @@ and `.Resolver`.
 """
 
 import array
+import asyncio
 import atexit
 from inspect import getfullargspec
 import os
@@ -63,14 +64,9 @@ except ImportError:
     is_finalizing = _get_emulated_is_finalizing()
 
 
-class TimeoutError(Exception):
-    """Exception raised by `.with_timeout` and `.IOLoop.run_sync`.
-
-    .. versionchanged:: 5.0:
-       Unified ``tornado.gen.TimeoutError`` and
-       ``tornado.ioloop.TimeoutError`` as ``tornado.util.TimeoutError``.
-       Both former names remain as aliases.
-    """
+# versionchanged:: 6.2
+# no longer our own TimeoutError, use standard asyncio class
+TimeoutError = asyncio.TimeoutError
 
 
 class ObjectDict(Dict[str, Any]):


### PR DESCRIPTION
for more consistent catching of timeouts with other asyncio code.

should be fully backward-compatible. Docs updated as well.

closes #2800