### PR TITLE
support query strings in oauth2_request

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -653,7 +653,10 @@ class OAuth2Mixin(object):
             all_args.update(args)
 
         if all_args:
-            url += "?" + urllib.parse.urlencode(all_args)
+            if "?" in url:
+                url += "&" + urllib.parse.urlencode(all_args)
+            else:
+                url += "?" + urllib.parse.urlencode(all_args)
         http = self.get_auth_http_client()
         if post_args is not None:
             response = await http.fetch(


### PR DESCRIPTION
This pull request is used to pass query parameters in url for get requests.
example:

```
new_entry = await self.oauth2_request(
    "https://example.com/api/stuff?param=value",
     access_token=<access_token>)
```

Regards