### PR TITLE
Handle deprecations in python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
             tox_env: py38-full
           - python: '3.9'
             tox_env: py39-full
+          - python: '3.10'
+            tox_env: py310-full
           - python: 'pypy-3.8'
             # Pypy is a lot slower due to jit warmup costs, so don't run the
             # "full" test config there.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             tox_env: py38-full
           - python: '3.9'
             tox_env: py39-full
-          - python: 'pypy3'
+          - python: 'pypy-3.8'
             # Pypy is a lot slower due to jit warmup costs, so don't run the
             # "full" test config there.
             tox_env: pypy3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,7 +96,7 @@ installed in this way, so you may wish to download a copy of the
 source tarball or clone the `git repository
 <https://github.com/tornadoweb/tornado>`_ as well.
 
-**Prerequisites**: Tornado 6.0 requires Python 3.6 or newer (See
+**Prerequisites**: Tornado 6.0 requires Python 3.7 or newer (See
 `Tornado 5.1 <https://www.tornadoweb.org/en/branch5.1/>`_ if
 compatibility with Python 2.7 is required). The following optional
 packages may be useful:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.cibuildwheel]
-build = "cp3[789]*"
+build = "cp3[789]* cp310*"
 test-command = "python -m tornado.test"
 
 [tool.cibuildwheel.macos]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = LICENSE
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 no_implicit_optional = True
 
 [mypy-tornado.*,tornado.platform.*]

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ if (
 
 
 if setuptools is not None:
-    python_requires = ">= 3.6"
+    python_requires = ">= 3.7"
     kwargs["python_requires"] = python_requires
 
 setup(
@@ -180,10 +180,10 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1530,6 +1530,7 @@ class SSLIOStream(IOStream):
             self._ssl_options,
             server_hostname=self._server_hostname,
             do_handshake_on_connect=False,
+            server_side=False,
         )
         self._add_io_state(old_state)
 

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -32,6 +32,7 @@ import socket
 import sys
 import threading
 import typing
+import warnings
 from tornado.gen import convert_yielded
 from tornado.ioloop import IOLoop, _Selectable
 
@@ -391,7 +392,24 @@ class AnyThreadEventLoopPolicy(_BasePolicy):  # type: ignore
 
     .. versionadded:: 5.0
 
+    .. deprecated:: 6.2
+
+        ``AnyThreadEventLoopPolicy`` affects the implicit creation
+        of an event loop, which is deprecated in Python 3.10 and
+        will be removed in a future version of Python. At that time
+        ``AnyThreadEventLoopPolicy`` will no longer be useful.
+        If you are relying on it, use `asyncio.new_event_loop`
+        or `asyncio.run` explicitly in any non-main threads that
+        need event loops.
     """
+
+    def __init__(self) -> None:
+        super().__init__()
+        warnings.warn(
+            "AnyThreadEventLoopPolicy is deprecated, use asyncio.run "
+            "or asyncio.new_event_loop instead",
+            DeprecationWarning,
+        )
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:
         try:

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -191,7 +191,9 @@ class BaseAsyncIOLoop(IOLoop):
 
     def start(self) -> None:
         try:
-            old_loop = asyncio.get_event_loop()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                old_loop = asyncio.get_event_loop()
         except (RuntimeError, AssertionError):
             old_loop = None  # type: ignore
         try:

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -322,10 +322,18 @@ class AsyncIOLoop(BaseAsyncIOLoop):
 
     def close(self, all_fds: bool = False) -> None:
         if self.is_current:
-            self.clear_current()
+            with warnings.catch_warnings():
+                # We can't get here unless the warning in make_current
+                # was swallowed, so swallow the one from clear_current too.
+                warnings.simplefilter("ignore", DeprecationWarning)
+                self.clear_current()
         super().close(all_fds=all_fds)
 
     def make_current(self) -> None:
+        warnings.warn(
+            "make_current is deprecated; start the event loop first",
+            DeprecationWarning,
+        )
         if not self.is_current:
             try:
                 self.old_asyncio = asyncio.get_event_loop()

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -32,7 +32,10 @@ class AsyncIOLoopTest(AsyncTestCase):
 
     def test_asyncio_callback(self):
         # Basic test that the asyncio loop is set up correctly.
-        asyncio.get_event_loop().call_soon(self.stop)
+        async def add_callback():
+            asyncio.get_event_loop().call_soon(self.stop)
+
+        self.asyncio_loop.run_until_complete(add_callback())
         self.wait()
 
     @gen_test
@@ -90,21 +93,15 @@ class AsyncIOLoopTest(AsyncTestCase):
         # Asyncio only supports coroutines that yield asyncio-compatible
         # Futures (which our Future is since 5.0).
         self.assertEqual(
-            asyncio.get_event_loop().run_until_complete(
-                native_coroutine_without_adapter()
-            ),
+            self.asyncio_loop.run_until_complete(native_coroutine_without_adapter()),
             42,
         )
         self.assertEqual(
-            asyncio.get_event_loop().run_until_complete(
-                native_coroutine_with_adapter()
-            ),
+            self.asyncio_loop.run_until_complete(native_coroutine_with_adapter()),
             42,
         )
         self.assertEqual(
-            asyncio.get_event_loop().run_until_complete(
-                native_coroutine_with_adapter2()
-            ),
+            self.asyncio_loop.run_until_complete(native_coroutine_with_adapter2()),
             42,
         )
 
@@ -119,7 +116,7 @@ class LeakTest(unittest.TestCase):
         asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
 
     def tearDown(self):
-        asyncio.get_event_loop().close()
+        asyncio.get_event_loop_policy().get_event_loop().close()
         asyncio.set_event_loop_policy(self.orig_policy)
 
     def test_ioloop_close_leak(self):

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -104,6 +104,9 @@ class AsyncIOLoopTest(AsyncTestCase):
             self.asyncio_loop.run_until_complete(native_coroutine_with_adapter2()),
             42,
         )
+        # I'm not entirely sure why this manual cleanup is necessary but without
+        # it we have at-a-distance failures in ioloop_test.TestIOLoopCurrent.
+        asyncio.set_event_loop(None)
 
 
 class LeakTest(unittest.TestCase):

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -754,7 +754,7 @@ class HTTPResponseTestCase(unittest.TestCase):
 
 class SyncHTTPClientTest(unittest.TestCase):
     def setUp(self):
-        self.server_ioloop = IOLoop()
+        self.server_ioloop = IOLoop(make_current=False)
         event = threading.Event()
 
         @gen.coroutine

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -181,7 +181,9 @@ class TLSv1Test(BaseSSLTest, SSLTestMixin):
 
 class SSLContextTest(BaseSSLTest, SSLTestMixin):
     def get_ssl_options(self):
-        context = ssl_options_to_context(AsyncHTTPSTestCase.get_ssl_options(self))
+        context = ssl_options_to_context(
+            AsyncHTTPSTestCase.get_ssl_options(self), server_side=True
+        )
         assert isinstance(context, ssl.SSLContext)
         return context
 

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -420,7 +420,7 @@ class TestIOLoop(AsyncTestCase):
         # threads.
         def f():
             for i in range(10):
-                loop = IOLoop()
+                loop = IOLoop(make_current=False)
                 loop.close()
 
         yield gen.multi([self.io_loop.run_in_executor(None, f) for i in range(2)])

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -16,10 +16,15 @@ from tornado.escape import native_str
 from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError, PeriodicCallback
 from tornado.log import app_log
-from tornado.testing import AsyncTestCase, bind_unused_port, ExpectLog, gen_test
+from tornado.testing import (
+    AsyncTestCase,
+    bind_unused_port,
+    ExpectLog,
+    gen_test,
+    setup_with_context_manager,
+)
 from tornado.test.util import (
     ignore_deprecation,
-    setup_with_context_manager,
     skipIfNonUnix,
     skipOnTravis,
 )

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -17,7 +17,12 @@ from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError, PeriodicCallback
 from tornado.log import app_log
 from tornado.testing import AsyncTestCase, bind_unused_port, ExpectLog, gen_test
-from tornado.test.util import skipIfNonUnix, skipOnTravis
+from tornado.test.util import (
+    ignore_deprecation,
+    setup_with_context_manager,
+    skipIfNonUnix,
+    skipOnTravis,
+)
 
 import typing
 
@@ -420,6 +425,7 @@ class TestIOLoop(AsyncTestCase):
 # automatically set as current.
 class TestIOLoopCurrent(unittest.TestCase):
     def setUp(self):
+        setup_with_context_manager(self, ignore_deprecation())
         self.io_loop = None  # type: typing.Optional[IOLoop]
         IOLoop.clear_current()
 
@@ -466,6 +472,10 @@ class TestIOLoopCurrent(unittest.TestCase):
 
 
 class TestIOLoopCurrentAsync(AsyncTestCase):
+    def setUp(self):
+        super().setUp()
+        setup_with_context_manager(self, ignore_deprecation())
+
     @gen_test
     def test_clear_without_current(self):
         # If there is no current IOLoop, clear_current is a no-op (but
@@ -557,7 +567,7 @@ class TestIOLoopFutures(AsyncTestCase):
 
 class TestIOLoopRunSync(unittest.TestCase):
     def setUp(self):
-        self.io_loop = IOLoop()
+        self.io_loop = IOLoop(make_current=False)
 
     def tearDown(self):
         self.io_loop.close()

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -12,7 +12,7 @@ from tornado.iostream import (
 from tornado.httputil import HTTPHeaders
 from tornado.locks import Condition, Event
 from tornado.log import gen_log
-from tornado.netutil import ssl_wrap_socket
+from tornado.netutil import ssl_options_to_context, ssl_wrap_socket
 from tornado.platform.asyncio import AddThreadSelectorEventLoop
 from tornado.tcpserver import TCPServer
 from tornado.testing import (
@@ -23,7 +23,12 @@ from tornado.testing import (
     ExpectLog,
     gen_test,
 )
-from tornado.test.util import skipIfNonUnix, refusing_port, skipPypy3V58
+from tornado.test.util import (
+    skipIfNonUnix,
+    refusing_port,
+    skipPypy3V58,
+    ignore_deprecation,
+)
 from tornado.web import RequestHandler, Application
 import asyncio
 import errno
@@ -900,11 +905,11 @@ class TestIOStream(TestIOStreamMixin, AsyncTestCase):
 
 class TestIOStreamSSL(TestIOStreamMixin, AsyncTestCase):
     def _make_server_iostream(self, connection, **kwargs):
-        connection = ssl.wrap_socket(
+        ssl_ctx = ssl_options_to_context(_server_ssl_options(), server_side=True)
+        connection = ssl_ctx.wrap_socket(
             connection,
             server_side=True,
             do_handshake_on_connect=False,
-            **_server_ssl_options()
         )
         return SSLIOStream(connection, **kwargs)
 
@@ -919,7 +924,7 @@ class TestIOStreamSSL(TestIOStreamMixin, AsyncTestCase):
 # instead of an ssl_options dict to the SSLIOStream constructor.
 class TestIOStreamSSLContext(TestIOStreamMixin, AsyncTestCase):
     def _make_server_iostream(self, connection, **kwargs):
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         context.load_cert_chain(
             os.path.join(os.path.dirname(__file__), "test.crt"),
             os.path.join(os.path.dirname(__file__), "test.key"),
@@ -930,7 +935,9 @@ class TestIOStreamSSLContext(TestIOStreamMixin, AsyncTestCase):
         return SSLIOStream(connection, **kwargs)
 
     def _make_client_iostream(self, connection, **kwargs):
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
         return SSLIOStream(connection, ssl_options=context, **kwargs)
 
 
@@ -1076,8 +1083,11 @@ class WaitForHandshakeTest(AsyncTestCase):
             # to openssl 1.1.c. Other platforms might be affected with
             # newer openssl too). Disable it until we figure out
             # what's up.
-            ssl_ctx.options |= getattr(ssl, "OP_NO_TLSv1_3", 0)
-            client = SSLIOStream(socket.socket(), ssl_options=ssl_ctx)
+            # Update 2021-12-28: Still happening with Python 3.10 on
+            # Windows. OP_NO_TLSv1_3 now raises a DeprecationWarning.
+            with ignore_deprecation():
+                ssl_ctx.options |= getattr(ssl, "OP_NO_TLSv1_3", 0)
+                client = SSLIOStream(socket.socket(), ssl_options=ssl_ctx)
             yield client.connect(("127.0.0.1", port))
             self.assertIsNotNone(client.socket.cipher())
         finally:

--- a/tornado/test/process_test.py
+++ b/tornado/test/process_test.py
@@ -76,15 +76,15 @@ class ProcessTest(unittest.TestCase):
                 sock.close()
                 return
             try:
-                if asyncio is not None:
-                    # Reset the global asyncio event loop, which was put into
-                    # a broken state by the fork.
-                    asyncio.set_event_loop(asyncio.new_event_loop())
                 if id in (0, 1):
                     self.assertEqual(id, task_id())
-                    server = HTTPServer(self.get_app())
-                    server.add_sockets([sock])
-                    IOLoop.current().start()
+
+                    async def f():
+                        server = HTTPServer(self.get_app())
+                        server.add_sockets([sock])
+                        await asyncio.Event().wait()
+
+                    asyncio.run(f())
                 elif id == 2:
                     self.assertEqual(id, task_id())
                     sock.close()

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -1,6 +1,7 @@
 from tornado import gen, ioloop
 from tornado.httpserver import HTTPServer
 from tornado.locks import Event
+from tornado.test.util import ignore_deprecation
 from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, gen_test
 from tornado.web import Application
 import asyncio
@@ -333,7 +334,11 @@ class GetNewIOLoopTest(AsyncTestCase):
     def setUp(self):
         # This simulates the effect of an asyncio test harness like
         # pytest-asyncio.
-        self.orig_loop = asyncio.get_event_loop()
+        with ignore_deprecation():
+            try:
+                self.orig_loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self.orig_loop = None
         self.new_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.new_loop)
         super().setUp()

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -13,31 +13,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import asyncio
-import logging
-import signal
 import unittest
-import warnings
 
-from tornado.escape import utf8
-from tornado import gen
-from tornado.httpclient import AsyncHTTPClient
-from tornado.httpserver import HTTPServer
-from tornado.ioloop import IOLoop
-from tornado.testing import bind_unused_port, AsyncTestCase, gen_test
-from tornado.web import RequestHandler, Application
+from tornado.testing import AsyncTestCase, gen_test
 
 try:
     from twisted.internet.defer import (  # type: ignore
-        Deferred,
         inlineCallbacks,
         returnValue,
     )
-    from twisted.internet.protocol import Protocol  # type: ignore
-    from twisted.internet.asyncioreactor import AsyncioSelectorReactor  # type: ignore
-    from twisted.web.client import Agent, readBody  # type: ignore
-    from twisted.web.resource import Resource  # type: ignore
-    from twisted.web.server import Site  # type: ignore
 
     have_twisted = True
 except ImportError:
@@ -47,173 +31,6 @@ else:
     import tornado.platform.twisted  # noqa: F401
 
 skipIfNoTwisted = unittest.skipUnless(have_twisted, "twisted module not present")
-
-
-def save_signal_handlers():
-    saved = {}
-    signals = [signal.SIGINT, signal.SIGTERM]
-    if hasattr(signal, "SIGCHLD"):
-        signals.append(signal.SIGCHLD)
-    for sig in signals:
-        saved[sig] = signal.getsignal(sig)
-    if "twisted" in repr(saved):
-        # This indicates we're not cleaning up after ourselves properly.
-        raise Exception("twisted signal handlers already installed")
-    return saved
-
-
-def restore_signal_handlers(saved):
-    for sig, handler in saved.items():
-        signal.signal(sig, handler)
-
-
-# Test various combinations of twisted and tornado http servers,
-# http clients, and event loop interfaces.
-
-
-@skipIfNoTwisted
-class CompatibilityTests(unittest.TestCase):
-    def setUp(self):
-        self.saved_signals = save_signal_handlers()
-        self.saved_policy = asyncio.get_event_loop_policy()
-        if hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
-            # Twisted requires a selector event loop, even if Tornado is
-            # doing its own tricks in AsyncIOLoop to support proactors.
-            # Setting an AddThreadSelectorEventLoop exposes various edge
-            # cases so just use a regular selector.
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore
-        self.io_loop = IOLoop()
-        self.io_loop.make_current()
-        self.reactor = AsyncioSelectorReactor()
-
-    def tearDown(self):
-        self.reactor.disconnectAll()
-        self.io_loop.clear_current()
-        self.io_loop.close(all_fds=True)
-        asyncio.set_event_loop_policy(self.saved_policy)
-        restore_signal_handlers(self.saved_signals)
-
-    def start_twisted_server(self):
-        class HelloResource(Resource):
-            isLeaf = True
-
-            def render_GET(self, request):
-                return b"Hello from twisted!"
-
-        site = Site(HelloResource())
-        port = self.reactor.listenTCP(0, site, interface="127.0.0.1")
-        self.twisted_port = port.getHost().port
-
-    def start_tornado_server(self):
-        class HelloHandler(RequestHandler):
-            def get(self):
-                self.write("Hello from tornado!")
-
-        app = Application([("/", HelloHandler)], log_function=lambda x: None)
-        server = HTTPServer(app)
-        sock, self.tornado_port = bind_unused_port()
-        server.add_sockets([sock])
-
-    def run_reactor(self):
-        # In theory, we can run the event loop through Tornado,
-        # Twisted, or asyncio interfaces. However, since we're trying
-        # to avoid installing anything as the global event loop, only
-        # the twisted interface gets everything wired up correectly
-        # without extra hacks. This method is a part of a
-        # no-longer-used generalization that allowed us to test
-        # different combinations.
-        self.stop_loop = self.reactor.stop
-        self.stop = self.reactor.stop
-        self.reactor.run()
-
-    def tornado_fetch(self, url, runner):
-        client = AsyncHTTPClient()
-        fut = asyncio.ensure_future(client.fetch(url))
-        fut.add_done_callback(lambda f: self.stop_loop())
-        runner()
-        return fut.result()
-
-    def twisted_fetch(self, url, runner):
-        # http://twistedmatrix.com/documents/current/web/howto/client.html
-        chunks = []
-        client = Agent(self.reactor)
-        d = client.request(b"GET", utf8(url))
-
-        class Accumulator(Protocol):
-            def __init__(self, finished):
-                self.finished = finished
-
-            def dataReceived(self, data):
-                chunks.append(data)
-
-            def connectionLost(self, reason):
-                self.finished.callback(None)
-
-        def callback(response):
-            finished = Deferred()
-            response.deliverBody(Accumulator(finished))
-            return finished
-
-        d.addCallback(callback)
-
-        def shutdown(failure):
-            if hasattr(self, "stop_loop"):
-                self.stop_loop()
-            elif failure is not None:
-                # loop hasn't been initialized yet; try our best to
-                # get an error message out. (the runner() interaction
-                # should probably be refactored).
-                try:
-                    failure.raiseException()
-                except:
-                    logging.error("exception before starting loop", exc_info=True)
-
-        d.addBoth(shutdown)
-        runner()
-        self.assertTrue(chunks)
-        return b"".join(chunks)
-
-    def twisted_coroutine_fetch(self, url, runner):
-        body = [None]
-
-        @gen.coroutine
-        def f():
-            # This is simpler than the non-coroutine version, but it cheats
-            # by reading the body in one blob instead of streaming it with
-            # a Protocol.
-            client = Agent(self.reactor)
-            response = yield client.request(b"GET", utf8(url))
-            with warnings.catch_warnings():
-                # readBody has a buggy DeprecationWarning in Twisted 15.0:
-                # https://twistedmatrix.com/trac/changeset/43379
-                warnings.simplefilter("ignore", category=DeprecationWarning)
-                body[0] = yield readBody(response)
-            self.stop_loop()
-
-        self.io_loop.add_callback(f)
-        runner()
-        return body[0]
-
-    def testTwistedServerTornadoClientReactor(self):
-        self.start_twisted_server()
-        response = self.tornado_fetch(
-            "http://127.0.0.1:%d" % self.twisted_port, self.run_reactor
-        )
-        self.assertEqual(response.body, b"Hello from twisted!")
-
-    def testTornadoServerTwistedClientReactor(self):
-        self.start_tornado_server()
-        response = self.twisted_fetch(
-            "http://127.0.0.1:%d" % self.tornado_port, self.run_reactor
-        )
-        self.assertEqual(response, b"Hello from tornado!")
-
-    def testTornadoServerTwistedCoroutineClientReactor(self):
-        self.start_tornado_server()
-        response = self.twisted_coroutine_fetch(
-            "http://127.0.0.1:%d" % self.tornado_port, self.run_reactor
-        )
-        self.assertEqual(response, b"Hello from tornado!")
 
 
 @skipIfNoTwisted

--- a/tornado/test/util.py
+++ b/tornado/test/util.py
@@ -112,3 +112,11 @@ def ignore_deprecation():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         yield
+
+
+# From https://nedbatchelder.com/blog/201508/using_context_managers_in_test_setup.html
+def setup_with_context_manager(testcase, cm):
+    """Use a contextmanager to setUp a test case."""
+    val = cm.__enter__()
+    testcase.addCleanup(cm.__exit__, None, None, None)
+    return val

--- a/tornado/test/util.py
+++ b/tornado/test/util.py
@@ -112,11 +112,3 @@ def ignore_deprecation():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         yield
-
-
-# From https://nedbatchelder.com/blog/201508/using_context_managers_in_test_setup.html
-def setup_with_context_manager(testcase, cm):
-    """Use a contextmanager to setUp a test case."""
-    val = cm.__enter__()
-    testcase.addCleanup(cm.__exit__, None, None, None)
-    return val

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -762,6 +762,14 @@ class ExpectLog(logging.Filter):
             raise Exception("did not get expected log message")
 
 
+# From https://nedbatchelder.com/blog/201508/using_context_managers_in_test_setup.html
+def setup_with_context_manager(testcase: unittest.TestCase, cm: Any) -> Any:
+    """Use a contextmanager to setUp a test case."""
+    val = cm.__enter__()
+    testcase.addCleanup(cm.__exit__, None, None, None)
+    return val
+
+
 def main(**kwargs: Any) -> None:
     """A simple test runner.
 

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -248,7 +248,7 @@ class AsyncTestCase(unittest.TestCase):
             tasks = asyncio.Task.all_tasks(asyncio_loop)
         # Tasks that are done may still appear here and may contain
         # non-cancellation exceptions, so filter them out.
-        tasks = [t for t in tasks if not t.done()]
+        tasks = [t for t in tasks if not t.done()]  # type: ignore
         for t in tasks:
             t.cancel()
         # Allow the tasks to run and finalize themselves (which means

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -20,6 +20,7 @@ import signal
 import socket
 import sys
 import unittest
+import warnings
 
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPResponse
@@ -181,8 +182,41 @@ class AsyncTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.io_loop = self.get_new_ioloop()
-        self.io_loop.make_current()
+        # NOTE: this code attempts to navigate deprecation warnings introduced
+        # in Python 3.10. The idea of an implicit current event loop is
+        # deprecated in that version, with the intention that tests like this
+        # explicitly create a new event loop and run on it. However, other
+        # packages such as pytest-asyncio (as of version 0.16.0) still rely on
+        # the implicit current event loop and we want to be compatible with them
+        # (even when run on 3.10, but not, of course, on the future version of
+        # python that removes the get/set_event_loop methods completely).
+        #
+        # Deprecation warnings were introduced inconsistently:
+        # asyncio.get_event_loop warns, but
+        # asyncio.get_event_loop_policy().get_event_loop does not. Similarly,
+        # none of the set_event_loop methods warn, although comments on
+        # https://bugs.python.org/issue39529 indicate that they are also
+        # intended for future removal.
+        #
+        # Therefore, we first attempt to access the event loop with the
+        # (non-warning) policy method, and if it fails, fall back to creating a
+        # new event loop. We do not have effective test coverage of the
+        # new event loop case; this will have to be watched when/if
+        # get_event_loop is actually removed.
+        self.should_close_asyncio_loop = False
+        try:
+            self.asyncio_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except Exception:
+            self.asyncio_loop = asyncio.new_event_loop()
+            self.should_close_asyncio_loop = True
+
+        async def get_loop() -> IOLoop:
+            return self.get_new_ioloop()
+
+        self.io_loop = self.asyncio_loop.run_until_complete(get_loop())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self.io_loop.make_current()
 
     def tearDown(self) -> None:
         # Native coroutines tend to produce warnings if they're not
@@ -217,13 +251,17 @@ class AsyncTestCase(unittest.TestCase):
 
         # Clean up Subprocess, so it can be used again with a new ioloop.
         Subprocess.uninitialize()
-        self.io_loop.clear_current()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self.io_loop.clear_current()
         if not isinstance(self.io_loop, _NON_OWNED_IOLOOPS):
             # Try to clean up any file descriptors left open in the ioloop.
             # This avoids leaks, especially when tests are run repeatedly
             # in the same process with autoreload (because curl does not
             # set FD_CLOEXEC on its file descriptors)
             self.io_loop.close(all_fds=True)
+        if self.should_close_asyncio_loop:
+            self.asyncio_loop.close()
         super().tearDown()
         # In case an exception escaped or the StackContext caught an exception
         # when there wasn't a wait() to re-raise it, do so here.
@@ -242,7 +280,7 @@ class AsyncTestCase(unittest.TestCase):
         loop is being provided by another system (such as
         ``pytest-asyncio``).
         """
-        return IOLoop()
+        return IOLoop(make_current=False)
 
     def _handle_exception(
         self, typ: Type[Exception], value: Exception, tb: TracebackType

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -161,6 +161,17 @@ class AsyncTestCase(unittest.TestCase):
                 response = self.wait()
                 # Test contents of response
                 self.assertIn("FriendFeed", response.body)
+
+    .. deprecated:: 6.2
+
+       AsyncTestCase and AsyncHTTPTestCase are deprecated due to changes
+       in future versions of Python (after 3.10). The interfaces used
+       in this class are incompatible with the deprecation and intended
+       removal of certain methods related to the idea of a "current"
+       event loop while no event loop is actually running. Use
+       `unittest.IsolatedAsyncioTestCase` instead. Note that this class
+       does not emit DeprecationWarnings until better migration guidance
+       can be provided.
     """
 
     def __init__(self, methodName: str = "runTest") -> None:
@@ -181,6 +192,13 @@ class AsyncTestCase(unittest.TestCase):
         self._test_generator = None  # type: Optional[Union[Generator, Coroutine]]
 
     def setUp(self) -> None:
+        setup_with_context_manager(self, warnings.catch_warnings())
+        warnings.filterwarnings(
+            "ignore",
+            message="There is no current event loop",
+            category=DeprecationWarning,
+            module=r"tornado\..*",
+        )
         super().setUp()
         # NOTE: this code attempts to navigate deprecation warnings introduced
         # in Python 3.10. The idea of an implicit current event loop is

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 [tox]
 envlist =
         # Basic configurations: Run the tests for each python version.
-        py36-full,py37-full,py38-full,py39-full,pypy3-full
+        py37-full,py38-full,py39-full,py310-full,pypy3-full
 
         # Build and test the docs with sphinx.
         docs
@@ -27,10 +27,10 @@ whitelist_externals = /bin/sh
 [testenv]
 basepython =
            py3: python3
-           py36: python3.6
            py37: python3.7
            py38: python3.8
            py39: python3.9
+           py310: python3.10
            pypy3: pypy3
            # In theory, it doesn't matter which python version is used here.
            # In practice, things like changes to the ast module can alter
@@ -49,7 +49,7 @@ deps =
 
 setenv =
        # Treat the extension as mandatory in testing (but not on pypy)
-       {py3,py36,py37,py38,py39}: TORNADO_EXTENSION=1
+       {py3,py37,py38,py39,py310}: TORNADO_EXTENSION=1
        # CI workers are often overloaded and can cause our tests to exceed
        # the default timeout of 5s.
        ASYNC_TEST_TIMEOUT=25
@@ -61,7 +61,7 @@ setenv =
        # during sdist installation (and it doesn't seem to be
        # possible to set environment variables during that phase of
        # tox).
-       {py3,py36,py37,py38,py39,pypy3}: PYTHONWARNINGS=error:::tornado
+       {py3,py37,py38,py39,py310,pypy3}: PYTHONWARNINGS=error:::tornado
 
 
 # All non-comment lines but the last must end in a backslash.


### PR DESCRIPTION
Python 3.10 deprecated a number of things we rely on.

In the future, `asyncio.get_event_loop` will become an alias for `get_running_loop`, and anything related to supporting an event loop that is "current" but not running has been deprecated. This is very disruptive for us because that has been the normal mode of operation for tornado during application setup and many testing idioms. For now we need to get the test suite passing, so we catch deprecation warnings in various places and introduce new deprecation warnings to give users better message for things that we'll have to remove. 

There are no intended changes in behavior except as it relates to deprecation warnings; applications that disable these warnings should be unaffected. In some future version of python, most tornado applications will need to be updated to use newer testing idioms; exactly what that means has not yet been determined. 

The `ssl` module has also deprecated some modes of operation with insecure defaults. This PR updates tornado to use the newer modes, which results in a behavior change in some cases. Specifically, client-side usage of SSL will validate server certificates including hostname verification by default in all cases. Previously this was done by higher-level interfaces (like AsyncHTTPClient) but not by the lower-level IOStream or netutil interfaces. Applications that are affected by this should construct a `ssl.SSLContext` object with the appropriate configuration. 

Fixes #3033