### PR TITLE
avoid acquiring IOLoop in ExecutorResolver

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -430,7 +430,6 @@ class ExecutorResolver(Resolver):
         executor: Optional[concurrent.futures.Executor] = None,
         close_executor: bool = True,
     ) -> None:
-        self.io_loop = IOLoop.current()
         if executor is not None:
             self.executor = executor
             self.close_executor = close_executor


### PR DESCRIPTION
`ExecutorResolver` doesn't use the `io_loop` and so just raises a deprecation warning if constructed without a running event loop