### PR TITLE
 provide Resolver implementation that uses the asyncio eventloop

### DIFF
--- a/maint/scripts/test_resolvers.py
+++ b/maint/scripts/test_resolvers.py
@@ -4,7 +4,7 @@ import socket
 
 from tornado import gen
 from tornado.ioloop import IOLoop
-from tornado.netutil import Resolver, ThreadedResolver, DefaultLoopResolver
+from tornado.netutil import Resolver, ThreadedResolver, DefaultExecutorResolver
 from tornado.options import parse_command_line, define, options
 
 try:
@@ -29,7 +29,7 @@ def main():
         args = ['localhost', 'www.google.com',
                 'www.facebook.com', 'www.dropbox.com']
 
-    resolvers = [Resolver(), ThreadedResolver(), DefaultLoopResolver()]
+    resolvers = [Resolver(), ThreadedResolver(), DefaultExecutorResolver()]
 
     if twisted is not None:
         from tornado.platform.twisted import TwistedResolver

--- a/maint/scripts/test_resolvers.py
+++ b/maint/scripts/test_resolvers.py
@@ -4,7 +4,7 @@ import socket
 
 from tornado import gen
 from tornado.ioloop import IOLoop
-from tornado.netutil import Resolver, ThreadedResolver
+from tornado.netutil import Resolver, ThreadedResolver, DefaultLoopResolver
 from tornado.options import parse_command_line, define, options
 
 try:
@@ -29,7 +29,7 @@ def main():
         args = ['localhost', 'www.google.com',
                 'www.facebook.com', 'www.dropbox.com']
 
-    resolvers = [Resolver(), ThreadedResolver()]
+    resolvers = [Resolver(), ThreadedResolver(), DefaultLoopResolver()]
 
     if twisted is not None:
         from tornado.platform.twisted import TwistedResolver

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -323,8 +323,8 @@ class Resolver(Configurable):
 
     The implementations of this interface included with Tornado are
 
-    * `tornado.netutil.DefaultExecutorResolver`
     * `tornado.netutil.DefaultLoopResolver`
+    * `tornado.netutil.DefaultExecutorResolver`
     * `tornado.netutil.BlockingResolver` (deprecated)
     * `tornado.netutil.ThreadedResolver` (deprecated)
     * `tornado.netutil.OverrideResolver`
@@ -334,6 +334,10 @@ class Resolver(Configurable):
     .. versionchanged:: 5.0
        The default implementation has changed from `BlockingResolver` to
        `DefaultExecutorResolver`.
+
+    .. versionchanged:: 6.2
+       The default implementation has changed from `DefaultExecutorResolver` to
+       `DefaultLoopResolver`.
     """
 
     @classmethod

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -346,7 +346,7 @@ class Resolver(Configurable):
 
     @classmethod
     def configurable_default(cls) -> Type["Resolver"]:
-        return DefaultExecutorResolver
+        return DefaultLoopResolver
 
     def resolve(
         self, host: str, port: int, family: socket.AddressFamily = socket.AF_UNSPEC

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -414,7 +414,7 @@ class DefaultExecutorResolver(Resolver):
 
 
 class DefaultLoopResolver(Resolver):
-    """Resolver implementation using `asyncio.get_running_loop().getaddrinfo`."""
+    """Resolver implementation using `asyncio.loop.getaddrinfo`."""
 
     async def resolve(
         self, host: str, port: int, family: socket.AddressFamily = socket.AF_UNSPEC
@@ -446,7 +446,7 @@ class ExecutorResolver(Resolver):
        The ``io_loop`` argument (deprecated since version 4.1) has been removed.
 
     .. deprecated:: 5.0
-       The default `Resolver` now uses `asyncio.get_running_loop().getaddrinfo`;
+       The default `Resolver` now uses `asyncio.loop.getaddrinfo`;
        use that instead of this class.
     """
 

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -446,8 +446,8 @@ class ExecutorResolver(Resolver):
        The ``io_loop`` argument (deprecated since version 4.1) has been removed.
 
     .. deprecated:: 5.0
-       The default `Resolver` now uses `.IOLoop.run_in_executor`; use that instead
-       of this class.
+       The default `Resolver` now uses `asyncio.get_running_loop().getaddrinfo`;
+       use that instead of this class.
     """
 
     def initialize(


### PR DESCRIPTION
usually this is pretty much the same as DefaultExecutorResolver, (the stdlib event loop just uses the default executor) however some loops eg `uvloop.Loop` do implement `getaddrinfo`