### PR TITLE
web: Fix type annotation for docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,7 @@ missing_references = {
     "tornado.options._Mockable",
     "tornado.web._ArgDefaultMarker",
     "tornado.web._HandlerDelegate",
+    "_RequestHandlerType",
     "traceback",
     "WSGIAppType",
     "Yieldable",

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1822,10 +1822,10 @@ class RequestHandler(object):
             self.clear_header(h)
 
 
-RequestHandlerType = TypeVar("RequestHandlerType", bound=RequestHandler)
+_RequestHandlerType = TypeVar("_RequestHandlerType", bound=RequestHandler)
 
 
-def stream_request_body(cls: Type[RequestHandlerType]) -> Type[RequestHandlerType]:
+def stream_request_body(cls: Type[_RequestHandlerType]) -> Type[_RequestHandlerType]:
     """Apply to `RequestHandler` subclasses to enable streaming body support.
 
     This decorator implies the following changes:


### PR DESCRIPTION
Our version of sphinx isn't resolving this annotation correctly.

Introduced in #3014 because CI was broken when it was submitted.