### PR TITLE
Use sequence instead of list

### DIFF
--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -184,7 +184,7 @@ from tornado.escape import url_escape, url_unescape, utf8
 from tornado.log import app_log
 from tornado.util import basestring_type, import_object, re_unescape, unicode_type
 
-from typing import Any, Union, Optional, Awaitable, List, Dict, Pattern, Tuple, overload
+from typing import Any, Sequence, Union, Optional, Awaitable, List, Dict, Pattern, Tuple, overload
 
 
 class Router(httputil.HTTPServerConnectionDelegate):
@@ -286,10 +286,10 @@ class _DefaultMessageDelegate(httputil.HTTPMessageDelegate):
 
 # _RuleList can either contain pre-constructed Rules or a sequence of
 # arguments to be passed to the Rule constructor.
-_RuleList = List[
+_RuleList = Sequence[
     Union[
         "Rule",
-        List[Any],  # Can't do detailed typechecking of lists.
+        Sequence[Any],  # Can't do detailed typechecking of lists.
         Tuple[Union[str, "Matcher"], Any],
         Tuple[Union[str, "Matcher"], Any, Dict[str, Any]],
         Tuple[Union[str, "Matcher"], Any, Dict[str, Any], str],


### PR DESCRIPTION
This patch uses immutable sequence to ensure that List[Rules] is a valid type for _RuleList

With the current typing it is not possible to correctly type code that uses List[Rule]. This is caused by the type annotation using `List[Union[Rule]]` which is not a superclass of `List[Rule]`. This is solved by using Sequence.

This is also illustrated by:

```python
from typing import List, Sequence, Union, Any

class Rule: pass

RuleList = List[
    Union[
        "Rule",
        List[Any],  # Can't do detailed typechecking of lists.
    ]
]

RuleSequence = Sequence[
    Union[
        "Rule",
        Sequence[Any],  # Can't do detailed typechecking of lists.
    ]
]


my_rules = [Rule(), Rule()]

var1: RuleList = my_rules
var2: RuleSequence = my_rules
```

When you run mypy on it, it will produce the following output:
```
❯ mypy demo.py
demo.py:22: error: Incompatible types in assignment (expression has type "List[Rule]", variable has type "List[Union[Rule, List[Any]]]")
demo.py:22: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
demo.py:22: note: Consider using "Sequence" instead, which is covariant
Found 1 error in 1 file (checked 1 source file)
```