### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,9 @@ setup(
     author="Facebook",
     author_email="python-tornado@googlegroups.com",
     url="http://www.tornadoweb.org/",
+    project_urls={
+        "Source": "https://github.com/tornadoweb/tornado",
+    },
     license="http://www.apache.org/licenses/LICENSE-2.0",
     description=(
         "Tornado is a Python web framework and asynchronous networking library,"


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.