### PR TITLE
avoid thread unsafe catch_warnings

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -317,11 +317,6 @@ class IOLoop(Configurable):
 
     @staticmethod
     def clear_current() -> None:
-        warnings.warn("clear_current is deprecated", DeprecationWarning)
-        IOLoop._clear_current()
-
-    @staticmethod
-    def _clear_current() -> None:
         """Clears the `IOLoop` for the current thread.
 
         Intended primarily for use by test frameworks in between tests.
@@ -330,6 +325,11 @@ class IOLoop(Configurable):
            This method also clears the current `asyncio` event loop.
         .. deprecated:: 6.2
         """
+        warnings.warn("clear_current is deprecated", DeprecationWarning)
+        IOLoop._clear_current()
+
+    @staticmethod
+    def _clear_current() -> None:
         old = IOLoop.current(instance=False)
         if old is not None:
             old._clear_current_hook()

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -315,8 +315,14 @@ class IOLoop(Configurable):
         # The asyncio event loops override this method.
         raise NotImplementedError()
 
+
     @staticmethod
     def clear_current() -> None:
+        warnings.warn("clear_current is deprecated", DeprecationWarning)
+        IOLoop._clear_current()
+
+    @staticmethod
+    def _clear_current() -> None:
         """Clears the `IOLoop` for the current thread.
 
         Intended primarily for use by test frameworks in between tests.
@@ -325,7 +331,6 @@ class IOLoop(Configurable):
            This method also clears the current `asyncio` event loop.
         .. deprecated:: 6.2
         """
-        warnings.warn("clear_current is deprecated", DeprecationWarning)
         old = IOLoop.current(instance=False)
         if old is not None:
             old._clear_current_hook()

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -315,7 +315,6 @@ class IOLoop(Configurable):
         # The asyncio event loops override this method.
         raise NotImplementedError()
 
-
     @staticmethod
     def clear_current() -> None:
         warnings.warn("clear_current is deprecated", DeprecationWarning)

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -81,7 +81,7 @@ if sys.version_info >= (3, 10):
         except RuntimeError:
             pass
 
-        asyncio.get_event_loop_policy().get_event_loop()
+        return asyncio.get_event_loop_policy().get_event_loop()
 else:
     from asyncio import get_event_loop as _get_event_loop
 

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -74,6 +74,17 @@ def _atexit_callback() -> None:
 
 atexit.register(_atexit_callback)
 
+if sys.version_info >= (3, 10):
+    def _get_event_loop() -> asyncio.AbstractEventLoop:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+
+        asyncio.get_event_loop_policy().get_event_loop()
+else:
+    from asyncio import get_event_loop as _get_event_loop
+
 
 class BaseAsyncIOLoop(IOLoop):
     def initialize(  # type: ignore
@@ -191,9 +202,7 @@ class BaseAsyncIOLoop(IOLoop):
 
     def start(self) -> None:
         try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                old_loop = asyncio.get_event_loop()
+            old_loop = _get_event_loop()
         except (RuntimeError, AssertionError):
             old_loop = None  # type: ignore
         try:
@@ -320,11 +329,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
 
     def close(self, all_fds: bool = False) -> None:
         if self.is_current:
-            with warnings.catch_warnings():
-                # We can't get here unless the warning in make_current
-                # was swallowed, so swallow the one from clear_current too.
-                warnings.simplefilter("ignore", DeprecationWarning)
-                self.clear_current()
+            self._clear_current()
         super().close(all_fds=all_fds)
 
     def make_current(self) -> None:

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -75,6 +75,7 @@ def _atexit_callback() -> None:
 atexit.register(_atexit_callback)
 
 if sys.version_info >= (3, 10):
+
     def _get_event_loop() -> asyncio.AbstractEventLoop:
         try:
             return asyncio.get_running_loop()
@@ -82,6 +83,8 @@ if sys.version_info >= (3, 10):
             pass
 
         return asyncio.get_event_loop_policy().get_event_loop()
+
+
 else:
     from asyncio import get_event_loop as _get_event_loop
 

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -129,7 +129,7 @@ class LeakTest(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
                 loop = AsyncIOLoop()
-            loop.close()
+                loop.close()
         new_count = len(IOLoop._ioloop_for_asyncio) - orig_count
         self.assertEqual(new_count, 0)
 


### PR DESCRIPTION
`with warnings.catch_warnings():` mutates the warnings filters for the
whole process and so is unsafe to call from multiple threads