### PR TITLE
Add web.RequestHandler.get_reason()

### DIFF
--- a/docs/web.rst
+++ b/docs/web.rst
@@ -142,6 +142,7 @@
    .. automethod:: RequestHandler.get_browser_locale
    .. automethod:: RequestHandler.get_current_user
    .. automethod:: RequestHandler.get_login_url
+   .. automethod:: RequestHandler.get_reason
    .. automethod:: RequestHandler.get_status
    .. automethod:: RequestHandler.get_template_path
    .. automethod:: RequestHandler.get_user_locale

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -572,6 +572,7 @@ class TypeCheckHandler(RequestHandler):
         self.errors = {}  # type: typing.Dict[str, str]
 
         self.check_type("status", self.get_status(), int)
+        self.check_type("reason", self.get_reason(), str)
 
         # get_argument is an exception from the general rule of using
         # type str for non-body data mainly for historical reasons.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -364,6 +364,10 @@ class RequestHandler(object):
         """Returns the status code for our response."""
         return self._status_code
 
+    def get_reason(self) -> str:
+        """Returns the reason phrase for our response."""
+        return self._reason
+
     def set_header(self, name: str, value: _HeaderTypes) -> None:
         """Sets the given response header name and value.
 


### PR DESCRIPTION
This mirrors `get_status()` and prevents applications from relying on the internal `self._reason` variable.

Fixes #3126 