### PR TITLE
bump urllib3 to security issue patched version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,4 +23,4 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-urllib3==1.25.11
+urllib3==1.26.5


### PR DESCRIPTION
the infor was Provided By The Dependabot About
Catastrophic backtracking in URL authority parser when passed URL containing many @ characters

for that urllib3 version

so i updated the urllib3 version in docs/requirements.txt

Issue Details at [Catastrophic backtracking in URL authority parser when passed URL containing many @ characters](https://github.com/advisories/GHSA-q2q7-5pp4-w6pg)