### PR TITLE
remove _setup_logging

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -34,7 +34,6 @@ import asyncio
 import concurrent.futures
 import datetime
 import functools
-import logging
 import numbers
 import os
 import sys
@@ -447,26 +446,6 @@ class IOLoop(Configurable):
         will make the loop stop after the current event iteration completes.
         """
         raise NotImplementedError()
-
-    def _setup_logging(self) -> None:
-        """The IOLoop catches and logs exceptions, so it's
-        important that log output be visible.  However, python's
-        default behavior for non-root loggers (prior to python
-        3.2) is to print an unhelpful "no handlers could be
-        found" message rather than the actual log entry, so we
-        must explicitly configure logging if we've made it this
-        far without anything.
-
-        This method should be called from start() in subclasses.
-        """
-        if not any(
-            [
-                logging.getLogger().handlers,
-                logging.getLogger("tornado").handlers,
-                logging.getLogger("tornado.application").handlers,
-            ]
-        ):
-            logging.basicConfig()
 
     def stop(self) -> None:
         """Stop the I/O loop.

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -212,7 +212,6 @@ class BaseAsyncIOLoop(IOLoop):
         except (RuntimeError, AssertionError):
             old_loop = None  # type: ignore
         try:
-            self._setup_logging()
             asyncio.set_event_loop(self.asyncio_loop)
             self.asyncio_loop.run_forever()
         finally:


### PR DESCRIPTION
Python 3.2+ now features a logger of lastResort https://docs.python.org/3/library/logging.html#logging.lastResort and so I think _setup_logging is redundant