### PR TITLE
Import WSGI types from _typeshed.wsgi

### DIFF
--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -41,7 +41,7 @@ import typing
 
 if typing.TYPE_CHECKING:
     from typing import Type  # noqa: F401
-    from wsgiref.types import WSGIApplication as WSGIAppType  # noqa: F401
+    from _typeshed.wsgi import WSGIApplication as WSGIAppType  # noqa: F401
 
 
 # PEP 3333 specifies that WSGI on python 3 generally deals with byte strings


### PR DESCRIPTION
wsgiref.types is a new module in Python 3.11. Accordingly, typeshed's stubs were updated so that this module is only available from Python 3.11 onwards. But the typeshed-specific module _typeshed.wsgi (which is considered stable by typeshed) contains all the necessary definitions for all supported Python versions.