### PR TITLE
autoreload: Remove calls to logging.basicConfig

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -76,7 +76,6 @@ if __name__ == "__main__":
         del sys.path[0]
 
 import functools
-import logging
 import os
 import pkgutil  # type: ignore
 import sys
@@ -325,10 +324,8 @@ def main() -> None:
                 del __package__
                 exec_in(f.read(), globals(), globals())
     except SystemExit as e:
-        logging.basicConfig()
         gen_log.info("Script exited with status %s", e.code)
     except Exception as e:
-        logging.basicConfig()
         gen_log.warning("Script exited with uncaught exception", exc_info=True)
         # If an exception occurred at import time, the file with the error
         # never made it into sys.modules and so we won't know to watch it.
@@ -343,7 +340,6 @@ def main() -> None:
             if e.filename is not None:
                 watch(e.filename)
     else:
-        logging.basicConfig()
         gen_log.info("Script exited normally")
     # restore sys.argv so subsequent executions will include autoreload
     sys.argv = original_argv


### PR DESCRIPTION
This is unnecessary since python 3.2 added a default logger of
last resort (and the two calls that precede "info" log messages
didn't do anything in the first place since basicConfig only logs
warnings and higher).

Fixes the second part of #2961