### PR TITLE
Google OAuth2: change oauth config provision from hardcoded to develo…

### DIFF
--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -853,12 +853,20 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = "https://www.googleapis.com/oauth2/v4/token"
     _OAUTH_USERINFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo"
     _OAUTH_NO_CALLBACKS = False
+    _OAUTH_SETTINGS_KEY = "google_oauth"
 
-    @property
-    def google_oauth_config(self) -> Dict:
-        """If your config is stored at a different location, override this method for custom provision."""
+    def get_google_oauth_settings(self) -> Dict[str, str]:
+        """Return the Google OAuth 2.0 credentials that you created with
+        [Google Cloud Platform](https://console.cloud.google.com/apis/credentials). The dict format is:
+        {
+            "key": "your_client_id",
+            "secret": "your_client_secret"
+        }
+
+        If your credentials are stored differently (e.g. in a db) you can override this method for custom provision.
+        """
         handler = cast(RequestHandler, self)
-        return handler.settings['google_oauth']
+        return handler.settings[self._OAUTH_SETTINGS_KEY]
 
     async def get_authenticated_user(
         self,
@@ -896,7 +904,7 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
                     else:
                         self.authorize_redirect(
                             redirect_uri='http://your.site.com/auth/google',
-                            client_id=self.google_oauth_config['key'],
+                            client_id=self.get_google_oauth_settings()['key'],
                             scope=['profile', 'email'],
                             response_type='code',
                             extra_params={'approval_prompt': 'auto'})
@@ -908,10 +916,11 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
 
            The ``callback`` argument was removed. Use the returned awaitable object instead.
         """  # noqa: E501
+
         if not client_id:
-            client_id = self.google_oauth_config["key"]
+            client_id = self.get_google_oauth_settings()['key'],
         if not client_secret:
-            client_secret = self.google_oauth_config["secret"]
+            client_secret = self.get_google_oauth_settings()['secret'],
         http = self.get_auth_http_client()
         body = urllib.parse.urlencode(
             {


### PR DESCRIPTION
There is a use case to use 2 different set of google oauth credentials, due to different app branding. I ran into the "HTTP 401: Unauthorized" error, and it was too vague to tell the root causing. After tracing into the tornado.auth code, it turns out that GoogleOAuth2Mixin has hardcoded assumption that the oauth credentials is read from handler.settings['google_oauth']. Two possible solutions:

1. Override GoogleOAuth2Mixin._OAUTH_SETTINGS_KEY. Pros: a simple fix on developers side, and no code change to tornado framework. Cons: the error message is too vague and it can waste another developers hours to realize it.

2. Apply this patch. Pros:  fail loud and easier to notice missing puzzle, and it's backwards compatible. Cons: More code changes to tornado framework.

I'd recommend to the #2 and it's preferred. 

Below is a copy of the error message:
----------------------------------------------
[E 220504 14:49:11 web:1789] Uncaught exception GET /app/login/google?state=nonce%3D15560EC1F92442C3A1281CA66FD7278F&code=4%2F0AX4XfSidsdiDkFcscmedNEk_gudM9iXsqW14PPfNs4Fyogc-xX2a8YAbluVWq3ATA&scope=email+profile+openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&authuser=0&prompt=none (127.0.0.1)
    HTTPServerRequest(protocol='https', host='frankdu.com', method='GET', uri='/app/login/google?state=nonce%3D15560EC1F92442C3A1281CA66FD7278F&code=4%2F0AX4XfSidsdiDkFcscmedNEk_gudM9iXsqW14PPfNs4Fyogc-xX2a8YAbluVWq3ATA&scope=email+profile+openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&authuser=0&prompt=none', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/Users/frankdu/.virtualenvs/ab3/lib/python3.9/site-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/Users/frankdu/Documents/work/ABRepo/Web/tornado/spark/auth/login_app_handlers.py", line 36, in get
        await self.process_google_auth(
      File "/Users/frankdu/Documents/work/ABRepo/Web/tornado/spark/auth/login_handlers.py", line 157, in process_google_auth
        user_auth_data = await self.get_authenticated_user(
      File "/Users/frankdu/.virtualenvs/ab3/lib/python3.9/site-packages/tornado/auth.py", line 915, in get_authenticated_user
        response = await http.fetch(
    tornado.httpclient.HTTPClientError: HTTP 401: Unauthorized
[E 220504 14:49:11 web:2239] 500 GET /app/login/google?state=nonce%3D15560EC1F92442C3A1281CA66FD7278F&code=4%2F0AX4XfSidsdiDkFcscmedNEk_gudM9iXsqW14PPfNs4Fyogc-xX2a8YAbluVWq3ATA&scope=email+profile+openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&authuser=0&prompt=none (127.0.0.1) 115.61ms




