### PR TITLE
Add stacklevel to deprecation warnings

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -312,7 +312,11 @@ class IOLoop(Configurable):
            This method also clears the current `asyncio` event loop.
         .. deprecated:: 6.2
         """
-        warnings.warn("clear_current is deprecated", DeprecationWarning)
+        warnings.warn(
+            "clear_current is deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         IOLoop._clear_current()
 
     @staticmethod

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -341,6 +341,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
         warnings.warn(
             "make_current is deprecated; start the event loop first",
             DeprecationWarning,
+            stacklevel=2,
         )
         if not self.is_current:
             try:
@@ -425,6 +426,7 @@ class AnyThreadEventLoopPolicy(_BasePolicy):  # type: ignore
             "AnyThreadEventLoopPolicy is deprecated, use asyncio.run "
             "or asyncio.new_event_loop instead",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:


### PR DESCRIPTION
so warnings are associated with the line where the deprecated methods are called rather than the line where the warning itself is

In:

```python
# run with PYTHONWARNINGS=d python test.py
from tornado.ioloop import IOLoop

loop = IOLoop(make_current=False)
loop.make_current()
```

before:

```
tornado/platform/asyncio.py:341: DeprecationWarning: make_current is deprecated; start the event loop first
  warnings.warn(
```

after:

```
test.py:4: DeprecationWarning: make_current is deprecated; start the event loop first
  loop.make_current()
```