### PR TITLE
add type-var ignore for the recently introduced mypy error

### DIFF
--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -381,7 +381,7 @@ class PriorityQueue(Queue):
     def _put(self, item: _T) -> None:
         heapq.heappush(self._queue, item)
 
-    def _get(self) -> _T:
+    def _get(self) -> _T:  # type: ignore[type-var]
         return heapq.heappop(self._queue)
 
 
@@ -418,5 +418,5 @@ class LifoQueue(Queue):
     def _put(self, item: _T) -> None:
         self._queue.append(item)
 
-    def _get(self) -> _T:
+    def _get(self) -> _T:  # type: ignore[type-var]
         return self._queue.pop()


### PR DESCRIPTION
A new error introduced to mypy is detected in tornado's repository. 

tornado (https://github.com/tornadoweb/tornado)
+ tornado/queues.py:384: error: A function returning TypeVar should receive at least one argument containing the same Typevar
+ tornado/queues.py:421: error: A function returning TypeVar should receive at least one argument containing the same Typevar

This PR adds ignore to that error.

Reference: https://github.com/python/mypy/pull/13166
