### PR TITLE
Block path traversal characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ MANIFEST
 # Used in demo apps
 secrets.cfg
 .mypy_cache/
-/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ MANIFEST
 # Used in demo apps
 secrets.cfg
 .mypy_cache/
+/.idea

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1404,6 +1404,30 @@ class StaticFileTest(WebTestCase):
         response = self.get_and_head("/root_static" + urllib.parse.quote(path))
         self.assertEqual(response.code, 200)
 
+    def test_same_directory_traversal(self):
+        response = self.fetch("/static/./password.txt", follow_redirects=False)
+        self.assertEqual(response.code, 301)
+        self.assertTrue(response.headers["Location"].endswith("/static/password.txt"))
+
+    def test_inside_directory_traversal(self):
+        response = self.fetch("/static/../static/password.txt", follow_redirects=False)
+        self.assertEqual(response.code, 301)
+        self.assertTrue(response.headers["Location"].endswith("/static/password.txt"))
+
+    def test_uri_encoding(self):
+        response = self.fetch("/static/password.tx%74", follow_redirects=False)
+        self.assertEqual(response.code, 301)
+        self.assertTrue(response.headers["Location"].endswith("/static/password.txt"))
+
+    def test_double_uri_encoding(self):
+        response = self.fetch("/static/password.tx%2574", follow_redirects=False)
+        self.assertEqual(response.code, 301)
+        self.assertTrue(response.headers["Location"].endswith("/static/password.tx%74"))
+
+    def test_slash_uri_encoding(self):
+        response = self.fetch("/static%2Fpassword.txt", follow_redirects=False)
+        self.assertEqual(response.code, 404)
+
 
 class StaticDefaultFilenameTest(WebTestCase):
     def get_app_kwargs(self):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2801,8 +2801,6 @@ class StaticFileHandler(RequestHandler):
         # the requested path so a request to root/ will match.
         if not (absolute_path + os.path.sep).startswith(root):
             raise HTTPError(403, "%s is not in root static directory", self.path)
-        if os.path.join(self.root, self.path) != absolute_path:
-            raise HTTPError(403, "%s was blocked", self.path)
         if os.path.isdir(absolute_path) and self.default_filename is not None:
             # need to look at the request.path here for when path is empty
             # but there is some prefix to the path that was already
@@ -2811,6 +2809,10 @@ class StaticFileHandler(RequestHandler):
                 self.redirect(self.request.path + "/", permanent=True)
                 return None
             absolute_path = os.path.join(absolute_path, self.default_filename)
+            if os.path.join(self.root, self.path, self.default_filename) != absolute_path:
+                raise HTTPError(403, "%s was blocked", self.path)
+        elif os.path.join(self.root, self.path) != absolute_path:
+            raise HTTPError(403, "%s was blocked", self.path)
         if not os.path.exists(absolute_path):
             raise HTTPError(404)
         if not os.path.isfile(absolute_path):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2809,10 +2809,23 @@ class StaticFileHandler(RequestHandler):
                 self.redirect(self.request.path + "/", permanent=True)
                 return None
             absolute_path = os.path.join(absolute_path, self.default_filename)
-            if os.path.join(self.root, self.path, self.default_filename) != absolute_path:
-                raise HTTPError(403, "%s was blocked", self.path)
-        elif os.path.join(self.root, self.path) != absolute_path:
-            raise HTTPError(403, "%s was blocked", self.path)
+            canonical_path = os.path.normcase(os.path.normpath(absolute_path))
+            if os.path.join(self.root, self.path, self.default_filename).replace('/', os.path.sep) != canonical_path:
+                # raise HTTPError(403, "%s is not the normalized path", self.path)
+                new_url = os.path.relpath(canonical_path, self.root).replace(os.path.sep, '/')
+                if not new_url.startswith('/'):
+                    new_url = '/' + new_url
+                self.redirect(new_url, permanent=True)
+                return None
+        else:
+            canonical_path = os.path.normcase(os.path.normpath(absolute_path))
+            if os.path.join(self.root, self.path).replace('/', os.path.sep) != canonical_path:
+                # raise HTTPError(403, "%s is not the normalized path", self.path)
+                new_url = os.path.relpath(canonical_path, self.root).replace(os.path.sep, '/')
+                if not new_url.startswith('/'):
+                    new_url = '/' + new_url
+                self.redirect(new_url, permanent=True)
+                return None
         if not os.path.exists(absolute_path):
             raise HTTPError(404)
         if not os.path.isfile(absolute_path):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2812,7 +2812,8 @@ class StaticFileHandler(RequestHandler):
         else:
             canonical_path = os.path.normcase(os.path.normpath(absolute_path))
             new_url = os.path.relpath(canonical_path, self.root).replace(os.path.sep, '/')
-            if os.path.join(self.root, self.path).replace('/', os.path.sep) != canonical_path or not self.request.path.endswith(new_url):
+            if os.path.join(self.root, self.path).replace('/', os.path.sep)\
+                    != canonical_path or not self.request.path.endswith(new_url):
                 if not new_url.startswith('/'):
                     new_url = '/' + new_url
                 if self.request.path.endswith(new_url):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2809,24 +2809,6 @@ class StaticFileHandler(RequestHandler):
                 self.redirect(self.request.path + "/", permanent=True)
                 return None
             absolute_path = os.path.join(absolute_path, self.default_filename)
-            canonical_path = os.path.normcase(os.path.normpath(absolute_path))
-            new_url = os.path.relpath(canonical_path, self.root).replace(os.path.sep, '/')
-            effective_request_path = os.path.join(self.request.path, self.default_filename).replace(os.path.sep, '/')
-            if os.path.join(self.root, self.path).replace('/',
-                                                          os.path.sep) != canonical_path or not effective_request_path.endswith(
-                    new_url):
-                if not new_url.startswith('/'):
-                    new_url = '/' + new_url
-                if effective_request_path.endswith(new_url):
-                    path_prefix = self.request.path[:-len(new_url)]
-                elif urllib.parse.unquote(effective_request_path).endswith(new_url):
-                    path_prefix = urllib.parse.unquote(effective_request_path)[:-len(new_url)]
-                else:
-                    raise HTTPError(403, "could not replicate URL parsing for %s", self.path)
-                path_prefix = os.path.normpath(path_prefix).replace(os.path.sep, '/')
-                full_new_url = (path_prefix + new_url).replace(os.path.sep, '/')
-                self.redirect(full_new_url, permanent=True)
-                return None
         else:
             canonical_path = os.path.normcase(os.path.normpath(absolute_path))
             new_url = os.path.relpath(canonical_path, self.root).replace(os.path.sep, '/')

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2801,6 +2801,8 @@ class StaticFileHandler(RequestHandler):
         # the requested path so a request to root/ will match.
         if not (absolute_path + os.path.sep).startswith(root):
             raise HTTPError(403, "%s is not in root static directory", self.path)
+        if os.path.join(self.root, self.path) != absolute_path:
+            raise HTTPError(403, "%s was blocked", self.path)
         if os.path.isdir(absolute_path) and self.default_filename is not None:
             # need to look at the request.path here for when path is empty
             # but there is some prefix to the path that was already


### PR DESCRIPTION
Only allows files to be fetched when referenced by their real path (no `../` or `./` magic).