### PR TITLE
Allow custom resolver in WebSocketClientConnection

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -34,6 +34,7 @@ from tornado import gen, httpclient, httputil
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.iostream import StreamClosedError, IOStream
 from tornado.log import gen_log, app_log
+from tornado.netutil import Resolver
 from tornado import simple_httpclient
 from tornado.queues import Queue
 from tornado.tcpclient import TCPClient
@@ -1362,6 +1363,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         ping_timeout: Optional[float] = None,
         max_message_size: int = _default_max_message_size,
         subprotocols: Optional[List[str]] = [],
+        resolver: Optional[Resolver] = None,
     ) -> None:
         self.connect_future = Future()  # type: Future[WebSocketClientConnection]
         self.read_queue = Queue(1)  # type: Queue[Union[None, str, bytes]]
@@ -1402,7 +1404,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         # Websocket connection is currently unable to follow redirects
         request.follow_redirects = False
 
-        self.tcp_client = TCPClient()
+        self.tcp_client = TCPClient(resolver=resolver)
         super().__init__(
             None,
             request,


### PR DESCRIPTION
`SimpleAsyncHTTPClient` accepts a custom `resolver` instance, and this can be used to make an HTTP connection to Unix sockets (see also #2671). I would like to do the same with WebSocketClientConnection. It's possible by globally configuring the resolver class, but I'd prefer to do it without global side-effects.

For more context, this is part of an effort for jupyter-server-proxy to support proxying services listening securely on Unix sockets, as well as TCP sockets (https://github.com/jupyterhub/jupyter-server-proxy/pull/337 ). This is currently working apart from Websocket support, which this PR would make possible.