### PR TITLE
Fix contextvars.Context propagation to first yield with native coroutines

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -743,7 +743,7 @@ class Runner(object):
         self.running = False
         self.finished = False
         self.io_loop = IOLoop.current()
-        if self.handle_yield(first_yielded):
+        if self.ctx_run(self.handle_yield, first_yielded):
             gen = result_future = first_yielded = None  # type: ignore
             self.ctx_run(self.run)
 

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1114,6 +1114,16 @@ class ContextVarsTest(AsyncTestCase):
         # so we must make sure that we maintain that property across yield.
         ctx_var.reset(token)
 
+    @gen_test
+    def test_propagate_to_first_yield_with_native_async_function(self):
+        x = 10
+                
+        async def native_async_function():
+            self.assertEquals(ctx_var.get(), x)
+        
+        ctx_var.set(x)
+        yield native_async_function()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1117,10 +1117,10 @@ class ContextVarsTest(AsyncTestCase):
     @gen_test
     def test_propagate_to_first_yield_with_native_async_function(self):
         x = 10
-                
+
         async def native_async_function():
             self.assertEquals(ctx_var.get(), x)
-        
+
         ctx_var.set(x)
         yield native_async_function()
 


### PR DESCRIPTION
`Runner.handle_yield` uses `convert_yielded`, which uses `asyncio.ensure_future` for native coroutines. `asyncio.ensure_future` should be called with passed context.