### PR TITLE
Fix typo in release notes

### DIFF
--- a/docs/releases/v6.2.0.rst
+++ b/docs/releases/v6.2.0.rst
@@ -49,7 +49,7 @@ General changes
 ~~~~~~~~~~~~~
 
 - Fixed a bug in which ``WaitIterator.current_index`` could be incorrect.
-- ``tornado.gen.TimeoutError``` is now an alias for `asyncio.TimeoutError`.
+- ``tornado.gen.TimeoutError`` is now an alias for `asyncio.TimeoutError`.
 
 `tornado.http1connection`
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The change at the end is put in since I edited the doc in GitHub's browser. Feel free to remove if you don't want this. 