### PR TITLE
added add_background_task to web.RequestHandler

### DIFF
--- a/demos/background_task/background_task.py
+++ b/demos/background_task/background_task.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import asyncio
+import tornado.httpserver
+import tornado.options
+import tornado.web
+
+from tornado.options import define, options
+
+define("port", default=8888, help="run on the given port", type=int)
+
+
+async def do_slow_task(task, param1, param2):
+    await asyncio.sleep(3)
+    print('Task is Done: ', task)
+    print('Param1: ', param1)
+    print('Param2: ', param2)
+
+class MainHandler(tornado.web.RequestHandler):
+    def get(self):
+        task = self.get_query_argument('task')
+        self.add_background_task(do_slow_task, task, 'param1', 'param2')
+        self.write(f"Hello {task}")
+
+
+async def main():
+    tornado.options.parse_command_line()
+    application = tornado.web.Application([(r"/", MainHandler)])
+    http_server = tornado.httpserver.HTTPServer(application)
+    http_server.listen(options.port)
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -91,6 +91,7 @@ from tornado import gen
 from tornado.httpserver import HTTPServer
 from tornado import httputil
 from tornado import iostream
+from tornado.ioloop import IOLoop
 import tornado.locale
 from tornado import locale
 from tornado.log import access_log, app_log, gen_log
@@ -276,6 +277,17 @@ class RequestHandler(object):
     patch = _unimplemented_method  # type: Callable[..., Optional[Awaitable[None]]]
     put = _unimplemented_method  # type: Callable[..., Optional[Awaitable[None]]]
     options = _unimplemented_method  # type: Callable[..., Optional[Awaitable[None]]]
+
+    def add_background_task(self, background_task: Callable, *args) -> None:
+        """Adds a callback to be run in the background after the current request.
+
+        This method can be called from any thread.  The callback will be
+        run in the main thread after the current request has been
+        completed.  If the request has already completed, the callback
+        will be run immediately.
+        """
+        IOLoop.current().spawn_callback(background_task, *args)
+
 
     def prepare(self) -> Optional[Awaitable[None]]:
         """Called at the beginning of a request before  `get`/`post`/etc.


### PR DESCRIPTION
Added _add_background_task_ method to _web.RequestHandler_ which provides simpler **non-blocking** background task management. There is an example usage in _demos/background_task/background_task.py_

**demos/background_task/background_task.py**
```python
async def do_slow_task(task, param1, param2):
    await asyncio.sleep(3)
    print('Task is Done: ', task)
    print('Param1: ', param1)
    print('Param2: ', param2)

class MainHandler(tornado.web.RequestHandler):
    def get(self):
        task = self.get_query_argument('task')
        self.add_background_task(do_slow_task, task, 'param1', 'param2')
        self.write(f"Hello {task}")
```