### PR TITLE
Make 5.1 branch compatible with Python 3.10

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -104,7 +104,7 @@ class _NormalizedHeaderCache(dict):
 _normalized_headers = _NormalizedHeaderCache(1000)
 
 
-class HTTPHeaders(collections.MutableMapping):
+class HTTPHeaders(collections.abc.MutableMapping):
     """A dictionary that maintains ``Http-Header-Case`` for all keys.
 
     Supports multiple values per key via a pair of new methods,


### PR DESCRIPTION
The Python 3.10 version finally removed the deprecated aliases for ABC collections classes, see https://docs.python.org/3/whatsnew/3.10.html#removed.

Migration to collections.abc.MutableMapping happened at https://github.com/tornadoweb/tornado/commit/6dceb64ed27c1d48af22142f2ebae946f0e85e95 but never made it to the 5.1 branch.

This makes possible to run Tornado 5.1.x in Python 3.10.