### PR TITLE
setup: Drop support for python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: '3.7'
-            tox_env: py37-full
           - python: '3.8'
             tox_env: py38-full
           - python: '3.9'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ installed in this way, so you may wish to download a copy of the
 source tarball or clone the `git repository
 <https://github.com/tornadoweb/tornado>`_ as well.
 
-**Prerequisites**: Tornado 6.2 requires Python 3.7 or newer. The following
+**Prerequisites**: Tornado 6.3 requires Python 3.8 or newer. The following
 optional packages may be useful:
 
 * `pycurl <http://pycurl.io/>`_ is used by the optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp3[789]* cp310* cp311*"
+build = "cp3[89]* cp310* cp311*"
 test-command = "python -m tornado.test"
 
 [tool.cibuildwheel.macos]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = LICENSE
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 no_implicit_optional = True
 
 [mypy-tornado.*,tornado.platform.*]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if (
             # Use the stable ABI so our wheels are compatible across python
             # versions.
             py_limited_api=True,
-            define_macros=[("Py_LIMITED_API", "0x03070000")],
+            define_macros=[("Py_LIMITED_API", "0x03080000")],
         )
     ]
 
@@ -63,7 +63,7 @@ if wheel is not None:
             python, abi, plat = super().get_tag()
 
             if python.startswith("cp"):
-                return "cp37", "abi3", plat
+                return "cp38", "abi3", plat
             return python, abi, plat
 
     kwargs["cmdclass"] = {"bdist_wheel": bdist_wheel_abi3}
@@ -72,7 +72,7 @@ if wheel is not None:
 setuptools.setup(
     name="tornado",
     version=version,
-    python_requires=">= 3.7",
+    python_requires=">= 3.8",
     packages=["tornado", "tornado.test", "tornado.platform"],
     package_data={
         # data files need to be listed both here (which determines what gets
@@ -112,7 +112,6 @@ setuptools.setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 [tox]
 envlist =
         # Basic configurations: Run the tests for each python version.
-        py37-full,py38-full,py39-full,py310-full,py311-full,pypy3-full
+        py38-full,py39-full,py310-full,py311-full,pypy3-full
 
         # Build and test the docs with sphinx.
         docs
@@ -27,7 +27,6 @@ whitelist_externals = /bin/sh
 [testenv]
 basepython =
            py3: python3
-           py37: python3.7
            py38: python3.8
            py39: python3.9
            py310: python3.10
@@ -51,7 +50,7 @@ deps =
 
 setenv =
        # Treat the extension as mandatory in testing (but not on pypy)
-       {py3,py37,py38,py39,py310,py311}: TORNADO_EXTENSION=1
+       {py3,py38,py39,py310,py311}: TORNADO_EXTENSION=1
        # CI workers are often overloaded and can cause our tests to exceed
        # the default timeout of 5s.
        ASYNC_TEST_TIMEOUT=25
@@ -63,7 +62,7 @@ setenv =
        # during sdist installation (and it doesn't seem to be
        # possible to set environment variables during that phase of
        # tox).
-       {py3,py37,py38,py39,py310,py311,pypy3}: PYTHONWARNINGS=error:::tornado
+       {py3,py38,py39,py310,py311,pypy3}: PYTHONWARNINGS=error:::tornado
 
 
 # All non-comment lines but the last must end in a backslash.


### PR DESCRIPTION
The main reason to drop this version before it reaches its EOL is so that we can begin to use unittest.IsolatedAsyncioTestCase to replace deprecated portions of the tornado.testing module.

A secondary reason is that Python 3.8 introduced support for the samesite cookie attribute, which allows us to deprecate the xsrf_token mechanism.