### PR TITLE
testing: Deprecate environment-dependent behavior in ExpectLog

### DIFF
--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -754,7 +754,7 @@ class UnixSocketTest(AsyncTestCase):
     def test_unix_socket_bad_request(self):
         # Unix sockets don't have remote addresses so they just return an
         # empty string.
-        with ExpectLog(gen_log, "Malformed HTTP message from"):
+        with ExpectLog(gen_log, "Malformed HTTP message from", level=logging.INFO):
             self.stream.write(b"garbage\r\n\r\n")
             response = yield self.stream.read_until_close()
         self.assertEqual(response, b"HTTP/1.1 400 Bad Request\r\n\r\n")

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -10,6 +10,7 @@ import inspect
 import gc
 import os
 import platform
+import sys
 import traceback
 import unittest
 import warnings
@@ -133,6 +134,9 @@ class AsyncTestCaseWrapperTest(unittest.TestCase):
     @unittest.skipIf(
         platform.python_implementation() == "PyPy",
         "pypy destructor warnings cannot be silenced",
+    )
+    @unittest.skipIf(
+        sys.version_info >= (3, 12), "py312 has its own check for test case returns"
     )
     def test_undecorated_coroutine(self):
         class Test(AsyncTestCase):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -388,7 +388,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         sock, port = bind_unused_port()
         sock.close()
         with self.assertRaises(IOError):
-            with ExpectLog(gen_log, ".*"):
+            with ExpectLog(gen_log, ".*", required=False):
                 yield websocket_connect(
                     "ws://127.0.0.1:%d/" % port, connect_timeout=3600
                 )


### PR DESCRIPTION
ExpectLog is sensitive to the difference between tornado.testing.main (which sets the logging level to info) and most other test runners, which do not. In the future ExpectLog will match WARNING and above by default; matching lower levels without using the ``level`` argument is deprecated.

Fix one test in httpserver_test.py that is affected by this.