### PR TITLE
Add executor support to WSGIContainer

### DIFF
--- a/tornado/test/wsgi_test.py
+++ b/tornado/test/wsgi_test.py
@@ -1,19 +1,33 @@
+import concurrent.futures
+
 from wsgiref.validate import validator
 
 from tornado.testing import AsyncHTTPTestCase
 from tornado.wsgi import WSGIContainer
 
 
-class WSGIContainerTest(AsyncHTTPTestCase):
-    # TODO: Now that WSGIAdapter is gone, this is a pretty weak test.
+class WSGIAppMixin:
     def wsgi_app(self, environ, start_response):
         status = "200 OK"
         response_headers = [("Content-Type", "text/plain")]
         start_response(status, response_headers)
         return [b"Hello world!"]
 
+
+class WSGIContainerTest(WSGIAppMixin, AsyncHTTPTestCase):
+    # TODO: Now that WSGIAdapter is gone, this is a pretty weak test.
     def get_app(self):
         return WSGIContainer(validator(self.wsgi_app))
+
+    def test_simple(self):
+        response = self.fetch("/")
+        self.assertEqual(response.body, b"Hello world!")
+
+
+class WSGIContainerThreadPoolTest(WSGIAppMixin, AsyncHTTPTestCase):
+    def get_app(self):
+        executor = concurrent.futures.ThreadPoolExecutor()
+        return WSGIContainer(validator(self.wsgi_app), executor)
 
     def test_simple(self):
         response = self.fetch("/")

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -28,11 +28,14 @@ container.
 """
 
 import sys
+from concurrent import futures
 from io import BytesIO
 import tornado
 
+from tornado import concurrent
 from tornado import escape
 from tornado import httputil
+from tornado import ioloop
 from tornado.log import access_log
 
 from typing import List, Tuple, Optional, Callable, Any, Dict, Text
@@ -91,9 +94,11 @@ class WSGIContainer(object):
     https://github.com/bdarnell/django-tornado-demo for a complete example.
     """
 
-    def __init__(self, wsgi_application: "WSGIAppType") -> None:
+    def __init__(self, wsgi_application: "WSGIAppType", executor: futures.Executor = None) -> None:
         self.wsgi_application = wsgi_application
+        self.executor = concurrent.dummy_executor if executor is None else executor
 
+    @gen.coroutine
     def __call__(self, request: httputil.HTTPServerRequest) -> None:
         data = {}  # type: Dict[str, Any]
         response = []  # type: List[bytes]
@@ -113,8 +118,12 @@ class WSGIContainer(object):
             data["headers"] = headers
             return response.append
 
-        app_response = self.wsgi_application(
-            WSGIContainer.environ(request), start_response
+        loop = ioloop.IOLoop.current()
+        app_response = yield loop.run_in_executor(
+            self.executor,
+            self.wsgi_application,
+            self.environ(request),
+            start_response,
         )
         try:
             response.extend(app_response)

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -34,6 +34,7 @@ import tornado
 
 from tornado import concurrent
 from tornado import escape
+from tornado import gen
 from tornado import httputil
 from tornado import ioloop
 from tornado.log import access_log

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -93,6 +93,26 @@ class WSGIContainer(object):
     The `tornado.web.FallbackHandler` class is often useful for mixing
     Tornado and WSGI apps in the same server.  See
     https://github.com/bdarnell/django-tornado-demo for a complete example.
+
+    `WSGIContainer` supports executing the WSGI application in custom executors
+    using `IOLoop.run_in_executor`. The default executor uses
+    `tornado.concurrent.dummy_executor` which works synchronously, but other
+    executors subclassing `concurrent.futures.Executor` may be used. To execute
+    WSGI application code in separate threads in an event-loop compatible way
+    use::
+
+        async def main():
+            executor = concurrent.futures.ThreadPoolExecutor()
+            # ^-- Execute requests in separate threads.
+            container = tornado.wsgi.WSGIContainer(simple_app, executor)
+            # Initialize the WSGI container with custom executor --^
+            http_server = tornado.httpserver.HTTPServer(container)
+            http_server.listen(8888)
+            await asyncio.Event().wait()
+
+    Running the WSGI app with a `ThreadPoolExecutor` remains *less scalable*
+    than running the same app in a multi-threaded WSGI server like ``gunicorn``
+    or ``uwsgi``.
     """
 
     def __init__(self, wsgi_application: "WSGIAppType", executor: futures.Executor = None) -> None:


### PR DESCRIPTION
WSGIContainer executes wsgi application code synchronously. If this code blocks (as in the case of database queries), the event loop is frozen. Fortunately, `IOLoop.run_in_executor` provides a solution. These changes modify WSGIContainer to support a new executor parameter (defaults to the synchronous dummy executor) and executes the wsgi application in the executor using the coroutine pattern.

All credit for the design goes to the discussion in https://stackoverflow.com/questions/26015116/making-tornado-to-serve-a-request-on-a-separate-thread

I think this also fixes a couple of related issues:

1. https://github.com/tornadoweb/tornado/pull/1098/ -- calling `WSGIContainer.environ` should use the standard Python object model via `self.environ` to support overriding via inheritance.
2. https://github.com/tornadoweb/tornado/pull/1075 -- previous ask for executor support. These changes seem more complex based on an older version of the code.

I wrote a test and verified that it worked and added notes to the docstring. I'm not sure if there's a changelog somewhere that I should edit too? I looked under docs/releases but there's no template for version 6.3 yet.

Also, I'm not sure if I just missed them but I couldn't find a development guide. I executed the tests using `tox -e py311` which I think is good enough for these changes. I'll leave further testing to CI.