### PR TITLE
Revert some deprecations, following asyncio changes

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -33,6 +33,7 @@ import sys
 import time
 import math
 import random
+import warnings
 from inspect import isawaitable
 
 from tornado.concurrent import (
@@ -287,6 +288,10 @@ class IOLoop(Configurable):
 
         .. versionchanged:: 5.0
            This method also sets the current `asyncio` event loop.
+
+        .. deprecated:: 6.2
+           Setting and clearing the current event loop through Tornado is
+           deprecated. Use ``asyncio.set_event_loop`` instead if you need this.
         """
         # The asyncio event loops override this method.
         raise NotImplementedError()
@@ -299,7 +304,13 @@ class IOLoop(Configurable):
 
         .. versionchanged:: 5.0
            This method also clears the current `asyncio` event loop.
+        .. deprecated:: 6.2
         """
+        warnings.warn(
+            "clear_current is deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         IOLoop._clear_current()
 
     @staticmethod

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -305,7 +305,7 @@ class IOLoop(Configurable):
         )
         self._make_current()
 
-    def _make_current(self):
+    def _make_current(self) -> None:
         # The asyncio event loops override this method.
         raise NotImplementedError()
 

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -143,6 +143,11 @@ class IOLoop(Configurable):
        Uses the `asyncio` event loop by default. The ``IOLoop.configure`` method
        cannot be used on Python 3 except to redundantly specify the `asyncio`
        event loop.
+
+    .. versionchanged:: 6.3
+       ``make_current=False`` is now the default when creating an IOLoop -
+       previously the default was to make the event loop current if there wasn't
+       already a current one. Passing ``make_current=True`` is deprecated.
     """
 
     # These constants were originally based on constants from the epoll module.
@@ -268,7 +273,7 @@ class IOLoop(Configurable):
             if instance:
                 from tornado.platform.asyncio import AsyncIOMainLoop
 
-                current = AsyncIOMainLoop(make_current=True)  # type: Optional[IOLoop]
+                current = AsyncIOMainLoop()  # type: Optional[IOLoop]
             else:
                 current = None
         return current
@@ -336,11 +341,13 @@ class IOLoop(Configurable):
 
         return AsyncIOLoop
 
-    def initialize(self, make_current: Optional[bool] = None) -> None:
-        if make_current is None:
-            if IOLoop.current(instance=False) is None:
-                self.make_current()
-        elif make_current:
+    def initialize(self, make_current: bool = False) -> None:
+        if make_current:
+            warnings.warn(
+                "IOLoop(make_current=True) is deprecated",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             current = IOLoop.current(instance=False)
             # AsyncIO loops can already be current by this point.
             if current is not None and current is not self:

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -254,10 +254,13 @@ class IOLoop(Configurable):
         """
         try:
             loop = asyncio.get_event_loop()
-        except (RuntimeError, AssertionError):
+        except RuntimeError:
             if not instance:
                 return None
-            raise
+            # Create a new asyncio event loop for this thread.
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
         try:
             return IOLoop._ioloop_for_asyncio[loop]
         except KeyError:

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -33,7 +33,6 @@ import sys
 import time
 import math
 import random
-import warnings
 from inspect import isawaitable
 
 from tornado.concurrent import (
@@ -123,8 +122,7 @@ class IOLoop(Configurable):
     and instead initialize the `asyncio` event loop and use `IOLoop.current()`.
     In some cases, such as in test frameworks when initializing an `IOLoop`
     to be run in a secondary thread, it may be appropriate to construct
-    an `IOLoop` with ``IOLoop(make_current=False)``. Constructing an `IOLoop`
-    without the ``make_current=False`` argument is deprecated since Tornado 6.2.
+    an `IOLoop` with ``IOLoop(make_current=False)``.
 
     In general, an `IOLoop` cannot survive a fork or be shared across processes
     in any way. When multiple processes are being used, each process should
@@ -144,13 +142,6 @@ class IOLoop(Configurable):
        Uses the `asyncio` event loop by default. The ``IOLoop.configure`` method
        cannot be used on Python 3 except to redundantly specify the `asyncio`
        event loop.
-
-    .. deprecated:: 6.2
-       It is deprecated to create an event loop that is "current" but not
-       running. This means it is deprecated to pass
-       ``make_current=True`` to the ``IOLoop`` constructor, or to create
-       an ``IOLoop`` while no asyncio event loop is running unless
-       ``make_current=False`` is used.
     """
 
     # These constants were originally based on constants from the epoll module.
@@ -293,13 +284,6 @@ class IOLoop(Configurable):
 
         .. versionchanged:: 5.0
            This method also sets the current `asyncio` event loop.
-
-        .. deprecated:: 6.2
-           The concept of an event loop that is "current" without
-           currently running is deprecated in asyncio since Python
-           3.10. All related functionality in Tornado is also
-           deprecated. Instead, start the event loop with `asyncio.run`
-           before interacting with it.
         """
         # The asyncio event loops override this method.
         raise NotImplementedError()
@@ -312,13 +296,7 @@ class IOLoop(Configurable):
 
         .. versionchanged:: 5.0
            This method also clears the current `asyncio` event loop.
-        .. deprecated:: 6.2
         """
-        warnings.warn(
-            "clear_current is deprecated",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         IOLoop._clear_current()
 
     @staticmethod

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -327,7 +327,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
             self._clear_current()
         super().close(all_fds=all_fds)
 
-    def _make_current(self):
+    def _make_current(self) -> None:
         if not self.is_current:
             try:
                 self.old_asyncio = asyncio.get_event_loop()

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -276,7 +276,7 @@ class AsyncIOMainLoop(BaseAsyncIOLoop):
     def initialize(self, **kwargs: Any) -> None:  # type: ignore
         super().initialize(asyncio.get_event_loop(), **kwargs)
 
-    def make_current(self) -> None:
+    def _make_current(self) -> None:
         # AsyncIOMainLoop already refers to the current asyncio loop so
         # nothing to do here.
         pass
@@ -327,12 +327,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
             self._clear_current()
         super().close(all_fds=all_fds)
 
-    def make_current(self) -> None:
-        warnings.warn(
-            "make_current is deprecated; start the event loop first",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    def _make_current(self):
         if not self.is_current:
             try:
                 self.old_asyncio = asyncio.get_event_loop()

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -328,11 +328,6 @@ class AsyncIOLoop(BaseAsyncIOLoop):
         super().close(all_fds=all_fds)
 
     def make_current(self) -> None:
-        warnings.warn(
-            "make_current is deprecated; start the event loop first",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if not self.is_current:
             try:
                 self.old_asyncio = asyncio.get_event_loop()

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -328,6 +328,11 @@ class AsyncIOLoop(BaseAsyncIOLoop):
         super().close(all_fds=all_fds)
 
     def make_current(self) -> None:
+        warnings.warn(
+            "make_current is deprecated; start the event loop first",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not self.is_current:
             try:
                 self.old_asyncio = asyncio.get_event_loop()

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -246,9 +246,7 @@ class TCPServer(object):
 
         .. deprecated:: 6.2
            Use either ``listen()`` or ``add_sockets()`` instead of ``bind()``
-           and ``start()``. The ``bind()/start()`` pattern depends on
-           interfaces that have been deprecated in Python 3.10 and will be
-           removed in future versions of Python.
+           and ``start()``.
         """
         sockets = bind_sockets(
             port,
@@ -295,9 +293,7 @@ class TCPServer(object):
 
         .. deprecated:: 6.2
            Use either ``listen()`` or ``add_sockets()`` instead of ``bind()``
-           and ``start()``. The ``bind()/start()`` pattern depends on
-           interfaces that have been deprecated in Python 3.10 and will be
-           removed in future versions of Python.
+           and ``start()``.
         """
         assert not self._started
         self._started = True

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -108,9 +108,6 @@ class AsyncIOLoopTest(AsyncTestCase):
             self.asyncio_loop.run_until_complete(native_coroutine_with_adapter2()),
             42,
         )
-        # I'm not entirely sure why this manual cleanup is necessary but without
-        # it we have at-a-distance failures in ioloop_test.TestIOLoopCurrent.
-        asyncio.set_event_loop(None)
 
 
 class LeakTest(unittest.TestCase):

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -30,6 +30,10 @@ class AsyncIOLoopTest(AsyncTestCase):
         io_loop = AsyncIOLoop(make_current=False)
         return io_loop
 
+    @property
+    def asyncio_loop(self):
+        return self.io_loop.asyncio_loop
+
     def test_asyncio_callback(self):
         # Basic test that the asyncio loop is set up correctly.
         async def add_callback():

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -32,7 +32,7 @@ class AsyncIOLoopTest(AsyncTestCase):
 
     @property
     def asyncio_loop(self):
-        return self.io_loop.asyncio_loop
+        return self.io_loop.asyncio_loop  # type: ignore
 
     def test_asyncio_callback(self):
         # Basic test that the asyncio loop is set up correctly.
@@ -191,7 +191,8 @@ class AnyThreadEventLoopPolicyTest(unittest.TestCase):
             # Set the policy and we can get a loop.
             asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
             self.assertIsInstance(
-                self.executor.submit(asyncio.get_event_loop).result(), asyncio.AbstractEventLoop
+                self.executor.submit(asyncio.get_event_loop).result(),
+                asyncio.AbstractEventLoop,
             )
             # Clean up to silence leak warnings. Always use asyncio since
             # IOLoop doesn't (currently) close the underlying loop.
@@ -202,15 +203,11 @@ class AnyThreadEventLoopPolicyTest(unittest.TestCase):
         # regardless of this event loop policy.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            self.assertIsInstance(
-                self.executor.submit(IOLoop.current).result(), IOLoop
-            )
+            self.assertIsInstance(self.executor.submit(IOLoop.current).result(), IOLoop)
             # Clean up to silence leak warnings. Always use asyncio since
             # IOLoop doesn't (currently) close the underlying loop.
             self.executor.submit(lambda: asyncio.get_event_loop().close()).result()  # type: ignore
 
             asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
-            self.assertIsInstance(
-                self.executor.submit(IOLoop.current).result(), IOLoop
-            )
+            self.assertIsInstance(self.executor.submit(IOLoop.current).result(), IOLoop)
             self.executor.submit(lambda: asyncio.get_event_loop().close()).result()  # type: ignore

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -450,15 +450,6 @@ class TestIOLoopCurrent(unittest.TestCase):
         if self.io_loop is not None:
             self.io_loop.close()
 
-    def test_default_current(self):
-        self.io_loop = IOLoop()
-        # The first IOLoop with default arguments is made current.
-        self.assertIs(self.io_loop, IOLoop.current())
-        # A second IOLoop can be created but is not made current.
-        io_loop2 = IOLoop()
-        self.assertIs(self.io_loop, IOLoop.current())
-        io_loop2.close()
-
     def test_non_current(self):
         self.io_loop = IOLoop(make_current=False)
         # The new IOLoop is not initially made current.

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -472,11 +472,6 @@ class TestIOLoopCurrent(unittest.TestCase):
     def test_force_current(self):
         self.io_loop = IOLoop(make_current=True)
         self.assertIs(self.io_loop, IOLoop.current())
-        with self.assertRaises(RuntimeError):
-            # A second make_current=True construction cannot succeed.
-            IOLoop(make_current=True)
-        # current() was not affected by the failed construction.
-        self.assertIs(self.io_loop, IOLoop.current())
 
 
 class TestIOLoopCurrentAsync(AsyncTestCase):

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -1,7 +1,6 @@
 from tornado import gen, ioloop
 from tornado.httpserver import HTTPServer
 from tornado.locks import Event
-from tornado.test.util import ignore_deprecation
 from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, gen_test
 from tornado.web import Application
 import asyncio

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -342,33 +342,5 @@ class GenTest(AsyncTestCase):
             self.finished = True
 
 
-class GetNewIOLoopTest(AsyncTestCase):
-    def get_new_ioloop(self):
-        # Use the current loop instead of creating a new one here.
-        return ioloop.IOLoop.current()
-
-    def setUp(self):
-        # This simulates the effect of an asyncio test harness like
-        # pytest-asyncio.
-        with ignore_deprecation():
-            try:
-                self.orig_loop = asyncio.get_event_loop()
-            except RuntimeError:
-                self.orig_loop = None  # type: ignore[assignment]
-        self.new_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.new_loop)
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-        # AsyncTestCase must not affect the existing asyncio loop.
-        self.assertFalse(asyncio.get_event_loop().is_closed())
-        asyncio.set_event_loop(self.orig_loop)
-        self.new_loop.close()
-
-    def test_loop(self):
-        self.assertIs(self.io_loop.asyncio_loop, self.new_loop)  # type: ignore
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -190,8 +190,12 @@ class AsyncTestCase(unittest.TestCase):
             module=r"tornado\..*",
         )
         super().setUp()
+        try:
+            self._prev_aio_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self._prev_aio_loop = None  # type: ignore[assignment]
         self.io_loop = self.get_new_ioloop()
-        self.io_loop.make_current()
+        asyncio.set_event_loop(self.io_loop.asyncio_loop)  # type: ignore[attr-defined]
 
     def tearDown(self) -> None:
         # Native coroutines tend to produce warnings if they're not
@@ -226,7 +230,7 @@ class AsyncTestCase(unittest.TestCase):
 
         # Clean up Subprocess, so it can be used again with a new ioloop.
         Subprocess.uninitialize()
-        self.io_loop.clear_current()
+        asyncio.set_event_loop(self._prev_aio_loop)
         if not isinstance(self.io_loop, _NON_OWNED_IOLOOPS):
             # Try to clean up any file descriptors left open in the ioloop.
             # This avoids leaks, especially when tests are run repeatedly

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -162,17 +162,6 @@ class AsyncTestCase(unittest.TestCase):
                 response = self.wait()
                 # Test contents of response
                 self.assertIn("FriendFeed", response.body)
-
-    .. deprecated:: 6.2
-
-       AsyncTestCase and AsyncHTTPTestCase are deprecated due to changes
-       in future versions of Python (after 3.10). The interfaces used
-       in this class are incompatible with the deprecation and intended
-       removal of certain methods related to the idea of a "current"
-       event loop while no event loop is actually running. Use
-       `unittest.IsolatedAsyncioTestCase` instead. Note that this class
-       does not emit DeprecationWarnings until better migration guidance
-       can be provided.
     """
 
     def __init__(self, methodName: str = "runTest") -> None:
@@ -435,10 +424,6 @@ class AsyncHTTPTestCase(AsyncTestCase):
     like ``http_client.fetch()``, into a synchronous operation. If you need
     to do other asynchronous operations in tests, you'll probably need to use
     ``stop()`` and ``wait()`` yourself.
-
-    .. deprecated:: 6.2
-       `AsyncTestCase` and `AsyncHTTPTestCase` are deprecated due to changes
-       in Python 3.10; see comments on `AsyncTestCase` for more details.
     """
 
     def setUp(self) -> None:

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -182,6 +182,13 @@ class AsyncTestCase(unittest.TestCase):
         self._test_generator = None  # type: Optional[Union[Generator, Coroutine]]
 
     def setUp(self) -> None:
+        setup_with_context_manager(self, warnings.catch_warnings())
+        warnings.filterwarnings(
+            "ignore",
+            message="There is no current event loop",
+            category=DeprecationWarning,
+            module=r"tornado\..*",
+        )
         super().setUp()
         self.io_loop = self.get_new_ioloop()
         self.io_loop.make_current()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -190,10 +190,6 @@ class AsyncTestCase(unittest.TestCase):
             module=r"tornado\..*",
         )
         super().setUp()
-        try:
-            self._prev_aio_loop = asyncio.get_event_loop()
-        except RuntimeError:
-            self._prev_aio_loop = None  # type: ignore[assignment]
         self.io_loop = self.get_new_ioloop()
         asyncio.set_event_loop(self.io_loop.asyncio_loop)  # type: ignore[attr-defined]
 
@@ -230,7 +226,7 @@ class AsyncTestCase(unittest.TestCase):
 
         # Clean up Subprocess, so it can be used again with a new ioloop.
         Subprocess.uninitialize()
-        asyncio.set_event_loop(self._prev_aio_loop)
+        asyncio.set_event_loop(None)
         if not isinstance(self.io_loop, _NON_OWNED_IOLOOPS):
             # Try to clean up any file descriptors left open in the ioloop.
             # This avoids leaks, especially when tests are run repeatedly


### PR DESCRIPTION
This is an attempt to tackle #3216 - at least the straightforward parts of it.

- Remove deprecation warnings and notices for ioloop `make_current` and `clear_current` methods, and the `make_current` constructor parameter.
- Remove deprecation notices on `AsyncTestCase` and `AsyncHTTPTestCase`
- Remove the mention of Python changes from the TCPServer `bind` & `start` deprecation notices (but they're still deprecated)

I've assumed that removing the deprecation notices is sufficient documentation - we could add notes saying that they were deprecated and then undeprecated again, but that feels like unnecessary clutter.

Still to figure out:

- [ ] `IOLoop.current()` has a deprecation notice for using it without a running asyncio loop. Is this also un-deprecated? Does it need some code change to handle when there's no running loop nor a default loop specifically set in asyncio?
- [ ] Are some changes needed to this code in AsyncTestCase? https://github.com/tornadoweb/tornado/blob/59536016e37704a1c47a3a0d262f46ceb6132c06/tornado/testing.py#L204-L238
- [x] `AnyThreadEventLoopPolicy` remains deprecated (as mentioned in #3216), but is any change needed to its deprecation notice? https://github.com/tornadoweb/tornado/blob/59536016e37704a1c47a3a0d262f46ceb6132c06/tornado/platform/asyncio.py#L423-L431