### PR TITLE
web: Deprecate xsrf_cookies

### DIFF
--- a/demos/blog/blog.py
+++ b/demos/blog/blog.py
@@ -68,7 +68,6 @@ class Application(tornado.web.Application):
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=os.path.join(os.path.dirname(__file__), "static"),
             ui_modules={"Entry": EntryModule},
-            xsrf_cookies=True,
             cookie_secret="__TODO:_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__",
             login_url="/auth/login",
             debug=True,
@@ -242,7 +241,7 @@ class AuthCreateHandler(BaseHandler):
             self.get_argument("name"),
             tornado.escape.to_unicode(hashed_password),
         )
-        self.set_signed_cookie("blogdemo_user", str(author.id))
+        self.set_signed_cookie("blogdemo_user", str(author.id), samesite="lax")
         self.redirect(self.get_argument("next", "/"))
 
 
@@ -269,7 +268,7 @@ class AuthLoginHandler(BaseHandler):
             tornado.escape.utf8(author.hashed_password),
         )
         if password_equal:
-            self.set_signed_cookie("blogdemo_user", str(author.id))
+            self.set_signed_cookie("blogdemo_user", str(author.id), samesite="lax")
             self.redirect(self.get_argument("next", "/"))
         else:
             self.render("login.html", error="incorrect password")

--- a/demos/blog/templates/compose.html
+++ b/demos/blog/templates/compose.html
@@ -12,7 +12,6 @@
     {% if entry %}
       <input type="hidden" name="id" value="{{ entry.id }}"/>
     {% end %}
-    {% module xsrf_form_html() %}
   </form>
 {% end %}
 

--- a/demos/blog/templates/create_author.html
+++ b/demos/blog/templates/create_author.html
@@ -5,7 +5,6 @@
   Email: <input name="email" type="text"><br>
   Name: <input name="name" type="text"><br>
   Password: <input name="password" type="password"><br>
-  {% module xsrf_form_html() %}
   <input type="submit">
 </form>
 {% end %}

--- a/demos/blog/templates/login.html
+++ b/demos/blog/templates/login.html
@@ -8,7 +8,6 @@
 <form action="/auth/login" method="POST">
   Email: <input name="email" type="text"><br>
   Password: <input name="password" type="password"><br>
-  {% module xsrf_form_html() %}
   <input type="submit">
 </form>
 {% end %}

--- a/demos/chat/chatdemo.py
+++ b/demos/chat/chatdemo.py
@@ -115,7 +115,6 @@ async def main():
         cookie_secret="__TODO:_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__",
         template_path=os.path.join(os.path.dirname(__file__), "templates"),
         static_path=os.path.join(os.path.dirname(__file__), "static"),
-        xsrf_cookies=True,
         debug=options.debug,
     )
     app.listen(options.port)

--- a/demos/chat/static/chat.js
+++ b/demos/chat/static/chat.js
@@ -52,7 +52,6 @@ function getCookie(name) {
 }
 
 jQuery.postJSON = function(url, args, callback) {
-    args._xsrf = getCookie("_xsrf");
     $.ajax({url: url, data: $.param(args), dataType: "text", type: "POST",
             success: function(response) {
         if (callback) callback(eval("(" + response + ")"));
@@ -90,7 +89,6 @@ var updater = {
     cursor: null,
 
     poll: function() {
-        var args = {"_xsrf": getCookie("_xsrf")};
         if (updater.cursor) args.cursor = updater.cursor;
         $.ajax({url: "/a/message/updates", type: "POST", dataType: "text",
                 data: $.param(args), success: updater.onSuccess,

--- a/demos/chat/templates/index.html
+++ b/demos/chat/templates/index.html
@@ -20,7 +20,6 @@
               <td style="padding-left:5px">
                 <input type="submit" value="{{ _("Post") }}">
                 <input type="hidden" name="next" value="{{ request.path }}">
-                {% module xsrf_form_html() %}
               </td>
             </tr>
           </table>

--- a/demos/facebook/facebook.py
+++ b/demos/facebook/facebook.py
@@ -83,7 +83,9 @@ class AuthLoginHandler(BaseHandler, tornado.auth.FacebookGraphMixin):
                 client_secret=self.settings["facebook_secret"],
                 code=self.get_argument("code"),
             )
-            self.set_signed_cookie("fbdemo_user", tornado.escape.json_encode(user), samesite="lax")
+            self.set_signed_cookie(
+                "fbdemo_user", tornado.escape.json_encode(user), samesite="lax"
+            )
             self.redirect(self.get_argument("next", "/"))
             return
         self.authorize_redirect(

--- a/demos/facebook/facebook.py
+++ b/demos/facebook/facebook.py
@@ -37,7 +37,6 @@ class Application(tornado.web.Application):
             login_url="/auth/login",
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=os.path.join(os.path.dirname(__file__), "static"),
-            xsrf_cookies=True,
             facebook_api_key=options.facebook_api_key,
             facebook_secret=options.facebook_secret,
             ui_modules={"Post": PostModule},
@@ -84,7 +83,7 @@ class AuthLoginHandler(BaseHandler, tornado.auth.FacebookGraphMixin):
                 client_secret=self.settings["facebook_secret"],
                 code=self.get_argument("code"),
             )
-            self.set_signed_cookie("fbdemo_user", tornado.escape.json_encode(user))
+            self.set_signed_cookie("fbdemo_user", tornado.escape.json_encode(user), samesite="lax")
             self.redirect(self.get_argument("next", "/"))
             return
         self.authorize_redirect(

--- a/demos/websocket/chatdemo.py
+++ b/demos/websocket/chatdemo.py
@@ -36,7 +36,6 @@ class Application(tornado.web.Application):
             cookie_secret="__TODO:_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__",
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=os.path.join(os.path.dirname(__file__), "static"),
-            xsrf_cookies=True,
         )
         super().__init__(handlers, **settings)
 

--- a/demos/websocket/templates/index.html
+++ b/demos/websocket/templates/index.html
@@ -20,7 +20,6 @@
               <td style="padding-left:5px">
                 <input type="submit" value="{{ _("Post") }}">
                 <input type="hidden" name="next" value="{{ request.path }}">
-                {% module xsrf_form_html() %}
               </td>
             </tr>
           </table>

--- a/docs/guide/running.rst
+++ b/docs/guide/running.rst
@@ -167,7 +167,6 @@ You can serve static files from Tornado by specifying the
         "static_path": os.path.join(os.path.dirname(__file__), "static"),
         "cookie_secret": "__TODO:_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__",
         "login_url": "/login",
-        "xsrf_cookies": True,
     }
     application = tornado.web.Application([
         (r"/", MainHandler),

--- a/docs/guide/security.rst
+++ b/docs/guide/security.rst
@@ -338,6 +338,13 @@ for authentication, provides protection against XSRF attacks that is
 equivalent to Tornado's ``xsrf_cookies`` feature, so that feature is now
 deprecated.
 
+You may wish to continue using ``xsrf_cookies`` in some situations:
+
+* If your application may perform side effects in response to HTTP GET
+  requests, but cannot use ``samesite="strict"``.
+* If your authentication is based on something other than cookies, such
+  as TLS certificates or network addresses.
+
 If you have an application that uses Tornado's ``xsrf_cookies`` feature
 and you want to migrate to the ``samesite`` cookie attribute, follow these
 steps:

--- a/docs/guide/security.rst
+++ b/docs/guide/security.rst
@@ -251,6 +251,17 @@ XSRF token was passed whenever it was needed. Since the ``samesite`` cookie
 attribute provides equivalent protection with less work, the ``xsrf_cookies``
 feature is deprecated. 
 
+.. note::
+
+   By default, the ``xsrf_cookies`` feature does not protect against
+   same-site attacks. However, when combined with the use of the
+   `host-only cookie prefix <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Cookie_prefixes>`_
+   it becomes stronger and may be better than relying on ``samesite="lax"``.
+   To try this, use the application setting 
+   ``xsrf_cookie_kwargs={"name": "__Host-xsrf"}``. This usage should be
+   considered experimental, but if it works the ``xsrf_cookies`` feature may
+   become un-deprecated.
+
 To enable the ``xsrf_cookies`` feature, use the application setting
 ``xsrf_cookies=True``:
 

--- a/docs/guide/templates.rst
+++ b/docs/guide/templates.rst
@@ -177,7 +177,6 @@ Here is a properly internationalized template::
            <div>{{ _("Username") }} <input type="text" name="username"/></div>
            <div>{{ _("Password") }} <input type="password" name="password"/></div>
            <div><input type="submit" value="{{ _("Sign in") }}"/></div>
-           {% module xsrf_form_html() %}
          </form>
        </body>
      </html>

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -243,16 +243,18 @@
          * ``login_url``: The `authenticated` decorator will redirect
            to this url if the user is not logged in.  Can be further
            customized by overriding `RequestHandler.get_login_url`
-         * ``xsrf_cookies``: If ``True``, :ref:`xsrf` will be enabled.
+         * ``xsrf_cookies``: If ``True``, :ref:`legacy-xsrf` will be enabled.
+           This functionality is deprecated as of Tornado 6.3; see
+           :ref:`xsrf-deprecation` for more.
          * ``xsrf_cookie_version``: Controls the version of new XSRF
            cookies produced by this server.  Should generally be left
            at the default (which will always be the highest supported
            version), but may be set to a lower value temporarily
            during version transitions.  New in Tornado 3.2.2, which
-           introduced XSRF cookie version 2.
+           introduced XSRF cookie version 2. Deprecated since Tornado 6.3.
          * ``xsrf_cookie_kwargs``: May be set to a dictionary of
            additional arguments to be passed to `.RequestHandler.set_cookie`
-           for the XSRF cookie.
+           for the XSRF cookie. Deprecated since Tornado 6.3.
          * ``twitter_consumer_key``, ``twitter_consumer_secret``,
            ``friendfeed_consumer_key``, ``friendfeed_consumer_secret``,
            ``google_consumer_key``, ``google_consumer_secret``,

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -17,6 +17,7 @@ from tornado.log import app_log, gen_log
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from tornado.template import DictLoader
 from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
+from tornado.test.util import ignore_deprecation
 from tornado.util import ObjectDict, unicode_type
 from tornado.web import (
     Application,
@@ -1721,6 +1722,11 @@ class ErrorHandlerXSRFTest(WebTestCase):
         # explicitly defined error handler and an implicit 404.
         return [("/error", ErrorHandler, dict(status_code=417))]
 
+    def get_app(self):
+        # xsrf_cookies is deprecated
+        with ignore_deprecation():
+            return super().get_app()
+
     def get_app_kwargs(self):
         return dict(xsrf_cookies=True)
 
@@ -2728,6 +2734,11 @@ class XSRFTest(SimpleHandlerTestCase):
         def post(self):
             self.write("ok")
 
+    def get_app(self):
+        # xsrf_cookies is deprecated
+        with ignore_deprecation():
+            return super().get_app()
+
     def get_app_kwargs(self):
         return dict(xsrf_cookies=True)
 
@@ -2923,6 +2934,11 @@ class XSRFCookieKwargsTest(SimpleHandlerTestCase):
     class Handler(RequestHandler):
         def get(self):
             self.write(self.xsrf_token)
+
+    def get_app(self):
+        # xsrf_cookies is deprecated
+        with ignore_deprecation():
+            return super().get_app()
 
     def get_app_kwargs(self):
         return dict(

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -84,6 +84,7 @@ import traceback
 import types
 import urllib.parse
 from urllib.parse import urlencode
+import warnings
 
 from tornado.concurrent import Future, future_set_result_unless_cancelled
 from tornado import escape
@@ -1434,7 +1435,7 @@ class RequestHandler(object):
 
     @property
     def xsrf_token(self) -> bytes:
-        """The XSRF-prevention token for the current user/session.
+        """The deprecated XSRF-prevention token for the current user/session.
 
         To prevent cross-site request forgery, we set an '_xsrf' cookie
         and include the same '_xsrf' value as an argument with all POST
@@ -1464,6 +1465,10 @@ class RequestHandler(object):
            ``xsrf_cookie_kwargs=dict(httponly=True, secure=True)``
            will set the ``secure`` and ``httponly`` flags on the
            ``_xsrf`` cookie.
+
+        .. deprecated:: 6.3
+
+           See :ref:`xsrf-deprecation`.
         """
         if not hasattr(self, "_xsrf_token"):
             version, token, timestamp = self._get_raw_xsrf_token()
@@ -1568,6 +1573,10 @@ class RequestHandler(object):
         .. versionchanged:: 3.2.2
            Added support for cookie version 2.  Both versions 1 and 2 are
            supported.
+
+        .. deprecated:: 6.3
+
+           See :ref:`xsrf-deprecation`.
         """
         # Prior to release 1.1.1, this check was ignored if the HTTP header
         # ``X-Requested-With: XMLHTTPRequest`` was present.  This exception
@@ -1601,6 +1610,10 @@ class RequestHandler(object):
         xsrf_form_html() %}``
 
         See `check_xsrf_cookie()` above for more information.
+
+        .. deprecated:: 6.3
+
+           See :ref:`xsrf-deprecation`
         """
         return (
             '<input type="hidden" name="_xsrf" value="'
@@ -2104,6 +2117,8 @@ class Application(ReversibleRouter):
         transforms: Optional[List[Type["OutputTransform"]]] = None,
         **settings: Any,
     ) -> None:
+        if settings.get("xsrf_cookies"):
+            warnings.warn("xsrf_cookies setting is deprecated", DeprecationWarning)
         if transforms is None:
             self.transforms = []  # type: List[Type[OutputTransform]]
             if settings.get("compress_response") or settings.get("gzip"):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1474,6 +1474,7 @@ class RequestHandler(object):
             version, token, timestamp = self._get_raw_xsrf_token()
             output_version = self.settings.get("xsrf_cookie_version", 2)
             cookie_kwargs = self.settings.get("xsrf_cookie_kwargs", {})
+            cookie_name = cookie_kwargs.get("name", "_xsrf")
             if output_version == 1:
                 self._xsrf_token = binascii.b2a_hex(token)
             elif output_version == 2:
@@ -1491,7 +1492,7 @@ class RequestHandler(object):
             if version is None:
                 if self.current_user and "expires_days" not in cookie_kwargs:
                     cookie_kwargs["expires_days"] = 30
-                self.set_cookie("_xsrf", self._xsrf_token, **cookie_kwargs)
+                self.set_cookie(cookie_name, self._xsrf_token, **cookie_kwargs)
         return self._xsrf_token
 
     def _get_raw_xsrf_token(self) -> Tuple[Optional[int], bytes, float]:
@@ -1506,7 +1507,9 @@ class RequestHandler(object):
           for version 1 cookies)
         """
         if not hasattr(self, "_raw_xsrf_token"):
-            cookie = self.get_cookie("_xsrf")
+            cookie_kwargs = self.settings.get("xsrf_cookie_kwargs", {})
+            cookie_name = cookie_kwargs.get("name", "_xsrf")
+            cookie = self.get_cookie(cookie_name)
             if cookie:
                 version, token, timestamp = self._decode_xsrf_token(cookie)
             else:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -745,6 +745,16 @@ class RequestHandler(object):
         Similar to `set_cookie`, the effect of this method will not be
         seen until the following request.
 
+        Consider setting additional attributes whenever you set a signed
+        cookie:
+
+        * Use the ``samesite="lax"`` (or ``"strict"``) attribute on any
+          cookie used for authentication to protect against XSRF attacks.
+        * Use the ``secure=True`` attribute if your application is
+          only available over HTTPS.
+        * Use the ``httponly=True`` attribute unless you need this cookie
+          to be readable from javascript.
+
         .. versionchanged:: 3.2.1
 
            Added the ``version`` argument.  Introduced cookie version 2


### PR DESCRIPTION
This feature is more invasive than using the samesite cookie attribute
but does not provide additional protection, so it is no longer
something that we should recommend.
