### PR TITLE
Add import lines for tornado.{locks and web} on chatdemo demo.

### DIFF
--- a/demos/chat/chatdemo.py
+++ b/demos/chat/chatdemo.py
@@ -16,6 +16,8 @@
 
 import asyncio
 import tornado
+import tornado.locks
+import tornado.web
 import os.path
 import uuid
 


### PR DESCRIPTION
avoid tornado.locks attribute not found.
avoid tornado.web attribute not found.
By:
importing tornado.web and tornado.locks on chatdemo example.