### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setuptools.setup(
     project_urls={
         "Source": "https://github.com/tornadoweb/tornado",
     },
-    license="http://www.apache.org/licenses/LICENSE-2.0",
+    license="Apache-2.0",
     description=(
         "Tornado is a Python web framework and asynchronous networking library,"
         " originally developed at FriendFeed."


### PR DESCRIPTION
Use SPDX license identifier: Apache-2.0
This will help tools to produce valid SPDX.