### PR TITLE
typing: Eagerly import all submodules in __init__.pyi

### DIFF
--- a/docs/releases/v6.3.0.rst
+++ b/docs/releases/v6.3.0.rst
@@ -29,9 +29,7 @@ General changes
   version 3.11.1. 
 - Tornado submodules are now imported automatically on demand. This means it is
   now possible to use a single ``import tornado`` statement and refer to objects
-  in submodules such as `tornado.web.RequestHandler`. Note that this automatic
-  import is not currently compatible with type checkers such as mypy, so users
-  of these tools may still wish to import the submodules explicitly.
+  in submodules such as `tornado.web.RequestHandler`.
 
 Deprecation notices
 ~~~~~~~~~~~~~~~~~~~

--- a/tornado/__init__.pyi
+++ b/tornado/__init__.pyi
@@ -1,0 +1,33 @@
+import typing
+
+version: str
+version_info: typing.Tuple[int, int, int, int]
+
+from . import auth
+from . import autoreload
+from . import concurrent
+from . import curl_httpclient
+from . import escape
+from . import gen
+from . import http1connection
+from . import httpclient
+from . import httpserver
+from . import httputil
+from . import ioloop
+from . import iostream
+from . import locale
+from . import locks
+from . import log
+from . import netutil
+from . import options
+from . import platform
+from . import process
+from . import queues
+from . import routing
+from . import simple_httpclient
+from . import tcpclient
+from . import tcpserver
+from . import template
+from . import testing
+from . import util
+from . import web

--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -57,9 +57,7 @@ class ImportTest(unittest.TestCase):
 
     def test_import_aliases(self):
         # Ensure we don't delete formerly-documented aliases accidentally.
-        import tornado.ioloop
-        import tornado.gen
-        import tornado.util
+        import tornado
         import asyncio
 
         self.assertIs(tornado.ioloop.TimeoutError, tornado.util.TimeoutError)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -91,10 +91,8 @@ from tornado import gen
 from tornado.httpserver import HTTPServer
 from tornado import httputil
 from tornado import iostream
-import tornado.locale
 from tornado import locale
 from tornado.log import access_log, app_log, gen_log
-import tornado.netutil
 from tornado import template
 from tornado.escape import utf8, _unicode
 from tornado.routing import (

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -18,7 +18,7 @@ import hashlib
 import os
 import sys
 import struct
-import tornado.web
+import tornado
 from urllib.parse import urlparse
 import zlib
 


### PR DESCRIPTION
This makes the auto-import functionality compatible with mypy
and other typing-based tools such as autocomplete functionality.
Excluding these imports from static typing feels like a premature
optimization and made it much less appealing to make use of the
auto-imports.

This may slow down type checking of applications that use Tornado by
a little, since the type checker must now process all of Tornado and
not only the subset that was imported. However, the increasing use
of long-lived daemons for type checkers should mitigate this cost.