### PR TITLE
web: Restore case-insensitivity of set_cookie args

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   releases/v6.3.1
    releases/v6.3.0
    releases/v6.2.0
    releases/v6.1.0

--- a/docs/releases/v6.3.1.rst
+++ b/docs/releases/v6.3.1.rst
@@ -1,0 +1,12 @@
+What's new in Tornado 6.3.1
+===========================
+
+Apr 21, 2023
+------------
+
+``tornado.web``
+~~~~~~~~~~~~~~~
+
+- `.RequestHandler.set_cookie` once again accepts capitalized keyword arguments
+  for backwards compatibility. This is deprecated and in Tornado 7.0 only lowercase
+  arguments will be accepted. 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -79,6 +79,7 @@ import socket
 import sys
 import threading
 import time
+import warnings
 import tornado
 import traceback
 import types
@@ -607,6 +608,7 @@ class RequestHandler(object):
         httponly: bool = False,
         secure: bool = False,
         samesite: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         """Sets an outgoing cookie name/value with the given options.
 
@@ -623,6 +625,10 @@ class RequestHandler(object):
         to set an expiration time in days from today (if both are set, ``expires``
         is used).
 
+        .. deprecated:: 6.3
+           Keyword arguments are currently accepted case-insensitively.
+           In Tornado 7.0 this will be changed to only accept lowercase
+           arguments.
         """
         # The cookie library only accepts type str, in both python 2 and 3
         name = escape.native_str(name)
@@ -657,6 +663,17 @@ class RequestHandler(object):
             morsel["secure"] = True
         if samesite:
             morsel["samesite"] = samesite
+        if kwargs:
+            # The setitem interface is case-insensitive, so continue to support
+            # kwargs for backwards compatibility until we can remove deprecated
+            # features.
+            for k, v in kwargs.items():
+                morsel[k] = v
+            warnings.warn(
+                f"Deprecated arguments to set_cookie: {set(kwargs.keys())} "
+                "(should be lowercase)",
+                DeprecationWarning,
+            )
 
     def clear_cookie(self, name: str, **kwargs: Any) -> None:
         """Deletes the cookie with the given name.


### PR DESCRIPTION
This was an unintended feature that got broken in #3224. Bring it back for now but deprecate it for future cleanup.

Fixes #3252