### PR TITLE
test: Close a websocket client that causes occasional test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     name: Upload to PyPI (test)
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-22.04
-    if: github.event_name == 'push' && startsWith(github.ref_name, 'build-workflow')
+    if: github.repository == 'tornadoweb/tornado' && github.event_name == 'push' && startsWith(github.ref_name, 'build-workflow')
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -86,7 +86,7 @@ jobs:
     name: Upload to PyPI (prod)
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-22.04
-    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    if: github.repository == 'tornadoweb/tornado' && github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -807,6 +807,7 @@ class ClientPeriodicPingTest(WebSocketBaseTestCase):
             response = yield ws.read_message()
             self.assertEqual(response, "got ping")
         # TODO: test that the connection gets closed if ping responses stop.
+        ws.close()
 
 
 class ManualPingTest(WebSocketBaseTestCase):


### PR DESCRIPTION
These failures occur on the build.yml workflow on the emulated arm64
platform: an ill-timed timer firing during test shutdown can result
in a message being logged and the test failing for dirty logs.