### PR TITLE
web: Fix an open redirect in StaticFileHandler

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2879,6 +2879,15 @@ class StaticFileHandler(RequestHandler):
             # but there is some prefix to the path that was already
             # trimmed by the routing
             if not self.request.path.endswith("/"):
+                if self.request.path.startswith("//"):
+                    # A redirect with two initial slashes is a "protocol-relative" URL.
+                    # This means the next path segment is treated as a hostname instead
+                    # of a part of the path, making this effectively an open redirect.
+                    # Reject paths starting with two slashes to prevent this.
+                    # This is only reachable under certain configurations.
+                    raise HTTPError(
+                        403, "cannot redirect path with two initial slashes"
+                    )
                 self.redirect(self.request.path + "/", permanent=True)
                 return None
             absolute_path = os.path.join(absolute_path, self.default_filename)


### PR DESCRIPTION
Under some configurations the default_filename redirect could be exploited to redirect to an attacker-controlled site. This change refuses to redirect to URLs that could be misinterpreted.

A test case for the specific vulnerable configuration will follow after the patch has been available.