### PR TITLE
ci: Disable Python 3.12 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,9 @@ jobs:
             tox_env: py311-full
           - python: '3.11.0'
             tox_env: py311-full
-          - python: '3.12.0-alpha - 3.12'
-            tox_env: py312-full
+          # 3.12 is disabled until https://github.com/python/cpython/issues/105808 is fixed
+          #- python: '3.12.0-alpha - 3.12'
+          #  tox_env: py312-full
           - python: 'pypy-3.8'
             # Pypy is a lot slower due to jit warmup costs, so don't run the
             # "full" test config there.


### PR DESCRIPTION
Current betas have a bug in GzipFile we can't easily work around. https://github.com/python/cpython/issues/105808