### PR TITLE
Python >= 3.10 MutableMapping import for Tornado 5.x

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -28,6 +28,7 @@ import datetime
 import email.utils
 import numbers
 import re
+import sys
 import time
 import unicodedata
 import warnings
@@ -40,11 +41,14 @@ if PY3:
     import http.cookies as Cookie
     from http.client import responses
     from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
+    if sys.version_info.minor >= 10:
+        from collections.abc import MutableMapping
 else:
     import Cookie
     from httplib import responses
     from urllib import urlencode
     from urlparse import urlparse, urlunparse, parse_qsl
+    from collections import MutableMapping
 
 
 # responses is unused in this file, but we re-export it to other files.
@@ -104,7 +108,7 @@ class _NormalizedHeaderCache(dict):
 _normalized_headers = _NormalizedHeaderCache(1000)
 
 
-class HTTPHeaders(collections.MutableMapping):
+class HTTPHeaders(MutableMapping):
     """A dictionary that maintains ``Http-Header-Case`` for all keys.
 
     Supports multiple values per key via a pair of new methods,

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -41,13 +41,16 @@ if PY3:
     import http.cookies as Cookie
     from http.client import responses
     from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
-    if sys.version_info.minor >= 10:
-        from collections.abc import MutableMapping
 else:
     import Cookie
     from httplib import responses
     from urllib import urlencode
     from urlparse import urlparse, urlunparse, parse_qsl
+
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    from collections.abc import MutableMapping
+else:
     from collections import MutableMapping
 
 


### PR DESCRIPTION
Are you still accepting PRs for the Tornado 5.x branch? I'm in the process of upgrading an application using Tornado 5.x to newer versions of Python 3. The only blocker seems to be the import of `MutableMapping` which has moved from `collections` to `collections.abc`.

Feel free to close if there is no interest in merging. I had some difficulty running the old tests, even in old versions of Python 3.