### PR TITLE
[docs] Explicit tornado.web import

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Hello, world
 Here is a simple "Hello, world" example web app for Tornado::
 
     import asyncio
-    import tornado
+    import tornado.web
 
     class MainHandler(tornado.web.RequestHandler):
         def get(self):


### PR DESCRIPTION
The landing page of the docs currently features an hello world that does not actually run in most cases, because `import tornado` does not expose `tornado.web.*`.