### PR TITLE
autoreload: Various updates

### DIFF
--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -236,27 +236,7 @@ def _reload() -> None:
         subprocess.Popen([sys.executable] + argv)
         os._exit(0)
     else:
-        try:
-            os.execv(sys.executable, [sys.executable] + argv)
-        except OSError:
-            # Mac OS X versions prior to 10.6 do not support execv in
-            # a process that contains multiple threads.  Instead of
-            # re-executing in the current process, start a new one
-            # and cause the current process to exit.  This isn't
-            # ideal since the new process is detached from the parent
-            # terminal and thus cannot easily be killed with ctrl-C,
-            # but it's better than not being able to autoreload at
-            # all.
-            # Unfortunately the errno returned in this case does not
-            # appear to be consistent, so we can't easily check for
-            # this error specifically.
-            os.spawnv(
-                os.P_NOWAIT, sys.executable, [sys.executable] + argv  # type: ignore
-            )
-            # At this point the IOLoop has been closed and finally
-            # blocks will experience errors if we allow the stack to
-            # unwind, so just exit uncleanly.
-            os._exit(0)
+        os.execv(sys.executable, [sys.executable] + argv)
 
 
 _USAGE = """

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -60,8 +60,7 @@ import sys
 # may become relative in spite of the future import.
 #
 # We address the former problem by reconstructing the original command
-# line (Python >= 3.4) or by setting the $PYTHONPATH environment
-# variable (Python < 3.4) before re-execution so the new process will
+# line before re-execution so the new process will
 # see the correct path.  We attempt to address the latter problem when
 # tornado.autoreload is run as __main__.
 
@@ -214,10 +213,7 @@ def _reload() -> None:
     # sys.path fixes: see comments at top of file.  If __main__.__spec__
     # exists, we were invoked with -m and the effective path is about to
     # change on re-exec.  Reconstruct the original command line to
-    # ensure that the new process sees the same path we did.  If
-    # __spec__ is not available (Python < 3.4), check instead if
-    # sys.path[0] is an empty string and add the current directory to
-    # $PYTHONPATH.
+    # ensure that the new process sees the same path we did.
     if _autoreload_is_main:
         assert _original_argv is not None
         spec = _original_spec
@@ -235,12 +231,7 @@ def _reload() -> None:
         # Some of this, including the use of exactly __main__ as a spec for directory mode,
         # is documented at https://docs.python.org/3/library/runpy.html#runpy.run_path
         argv = ["-m", spec.name] + argv[1:]
-    else:
-        path_prefix = "." + os.pathsep
-        if sys.path[0] == "" and not os.environ.get("PYTHONPATH", "").startswith(
-            path_prefix
-        ):
-            os.environ["PYTHONPATH"] = path_prefix + os.environ.get("PYTHONPATH", "")
+
     if not _has_execv:
         subprocess.Popen([sys.executable] + argv)
         os._exit(0)

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -325,24 +325,13 @@ def main() -> None:
         sys.argv = [sys.argv[0]] + rest
 
     try:
-        if opts.module is not None:
-            import runpy
+        import runpy
 
+        if opts.module is not None:
             runpy.run_module(opts.module, run_name="__main__", alter_sys=True)
         else:
             assert path is not None
-            with open(path) as f:
-                # Execute the script in our namespace instead of creating
-                # a new one so that something that tries to import __main__
-                # (e.g. the unittest module) will see names defined in the
-                # script instead of just those defined in this module.
-                global __file__
-                __file__ = path
-                # If __package__ is defined, imports may be incorrectly
-                # interpreted as relative to this module.
-                global __package__
-                del __package__
-                exec_in(f.read(), globals(), globals())
+            runpy.run_path(path, run_name="__main__")
     except SystemExit as e:
         gen_log.info("Script exited with status %s", e.code)
     except Exception as e:

--- a/tornado/test/autoreload_test.py
+++ b/tornado/test/autoreload_test.py
@@ -4,6 +4,7 @@ import subprocess
 from subprocess import Popen
 import sys
 from tempfile import mkdtemp
+import textwrap
 import time
 import unittest
 
@@ -11,6 +12,32 @@ import unittest
 class AutoreloadTest(unittest.TestCase):
     def setUp(self):
         self.path = mkdtemp()
+
+        # Each test app runs itself twice via autoreload. The first time it manually triggers
+        # a reload (could also do this by touching a file but this is faster since filesystem
+        # timestamps are not necessarily high resolution). The second time it exits directly
+        # so that the autoreload wrapper (if it is used) doesn't catch it.
+        #
+        # The last line of each test's "main" program should be
+        #     exec(open("run_twice_magic.py").read())
+        self.write_files(
+            {
+                "run_twice_magic.py": """
+                    import os
+                    import sys
+
+                    import tornado.autoreload
+
+                    sys.stdout.flush()
+
+                    if "TESTAPP_STARTED" not in os.environ:
+                        os.environ["TESTAPP_STARTED"] = "1"
+                        tornado.autoreload._reload()
+                    else:
+                        os._exit(0)
+                """
+            }
+        )
 
     def tearDown(self):
         try:
@@ -24,12 +51,55 @@ class AutoreloadTest(unittest.TestCase):
             time.sleep(1)
             shutil.rmtree(self.path)
 
+    def write_files(self, tree, base_path=None):
+        """Write a directory tree to self.path.
+
+        tree is a dictionary mapping file names to contents, or
+        sub-dictionaries representing subdirectories.
+        """
+        if base_path is None:
+            base_path = self.path
+        for name, contents in tree.items():
+            if isinstance(contents, dict):
+                os.mkdir(os.path.join(base_path, name))
+                self.write_files(contents, os.path.join(base_path, name))
+            else:
+                with open(os.path.join(base_path, name), "w", encoding="utf-8") as f:
+                    f.write(textwrap.dedent(contents))
+
+    def run_subprocess(self, args):
+        # Make sure the tornado module under test is available to the test
+        # application
+        pythonpath = os.getcwd()
+        if "PYTHONPATH" in os.environ:
+            pythonpath += os.pathsep + os.environ["PYTHONPATH"]
+
+        p = Popen(
+            args,
+            stdout=subprocess.PIPE,
+            env=dict(os.environ, PYTHONPATH=pythonpath),
+            cwd=self.path,
+            universal_newlines=True,
+            encoding="utf-8",
+        )
+
+        # This timeout needs to be fairly generous for pypy due to jit
+        # warmup costs.
+        for i in range(40):
+            if p.poll() is not None:
+                break
+            time.sleep(0.1)
+        else:
+            p.kill()
+            raise Exception("subprocess failed to terminate")
+
+        out = p.communicate()[0]
+        self.assertEqual(p.returncode, 0)
+        return out
+
     def test_reload(self):
         main = """\
-import os
 import sys
-
-from tornado import autoreload
 
 # In module mode, the path is set to the parent directory and we can import testapp.
 try:
@@ -41,40 +111,23 @@ else:
 
 spec = getattr(sys.modules[__name__], '__spec__', None)
 print(f"Starting {__name__=}, __spec__.name={getattr(spec, 'name', None)}")
-if 'TESTAPP_STARTED' not in os.environ:
-    os.environ['TESTAPP_STARTED'] = '1'
-    sys.stdout.flush()
-    autoreload._reload()
+exec(open("run_twice_magic.py").read())
 """
 
         # Create temporary test application
-        os.mkdir(os.path.join(self.path, "testapp"))
-        open(
-            os.path.join(self.path, "testapp/__init__.py"), "w", encoding="utf-8"
-        ).close()
-        with open(
-            os.path.join(self.path, "testapp/__main__.py"), "w", encoding="utf-8"
-        ) as f:
-            f.write(main)
-
-        # Make sure the tornado module under test is available to the test
-        # application
-        pythonpath = os.getcwd()
-        if "PYTHONPATH" in os.environ:
-            pythonpath += os.pathsep + os.environ["PYTHONPATH"]
+        self.write_files(
+            {
+                "testapp": {
+                    "__init__.py": "",
+                    "__main__.py": main,
+                },
+            }
+        )
 
         with self.subTest(mode="module"):
             # In module mode, the path is set to the parent directory and we can import testapp.
             # Also, the __spec__.name is set to the fully qualified module name.
-            p = Popen(
-                [sys.executable, "-m", "testapp"],
-                stdout=subprocess.PIPE,
-                cwd=self.path,
-                env=dict(os.environ, PYTHONPATH=pythonpath),
-                universal_newlines=True,
-                encoding="utf-8",
-            )
-            out = p.communicate()[0]
+            out = self.run_subprocess([sys.executable, "-m", "testapp"])
             self.assertEqual(
                 out,
                 (
@@ -87,15 +140,7 @@ if 'TESTAPP_STARTED' not in os.environ:
         with self.subTest(mode="file"):
             # When the __main__.py file is run directly, there is no qualified module spec and we
             # cannot import testapp.
-            p = Popen(
-                [sys.executable, "testapp/__main__.py"],
-                stdout=subprocess.PIPE,
-                cwd=self.path,
-                env=dict(os.environ, PYTHONPATH=pythonpath),
-                universal_newlines=True,
-                encoding="utf-8",
-            )
-            out = p.communicate()[0]
+            out = self.run_subprocess([sys.executable, "testapp/__main__.py"])
             self.assertEqual(
                 out,
                 "import testapp failed\nStarting __name__='__main__', __spec__.name=None\n"
@@ -105,15 +150,7 @@ if 'TESTAPP_STARTED' not in os.environ:
         with self.subTest(mode="directory"):
             # Running as a directory finds __main__.py like a module. It does not manipulate
             # sys.path but it does set a spec with a name of exactly __main__.
-            p = Popen(
-                [sys.executable, "testapp"],
-                stdout=subprocess.PIPE,
-                cwd=self.path,
-                env=dict(os.environ, PYTHONPATH=pythonpath),
-                universal_newlines=True,
-                encoding="utf-8",
-            )
-            out = p.communicate()[0]
+            out = self.run_subprocess([sys.executable, "testapp"])
             self.assertEqual(
                 out,
                 "import testapp failed\nStarting __name__='__main__', __spec__.name=__main__\n"
@@ -125,7 +162,6 @@ if 'TESTAPP_STARTED' not in os.environ:
         # is used on an application that also has an internal
         # autoreload, the reload wrapper is preserved on restart.
         main = """\
-import os
 import sys
 
 # This import will fail if path is not set up correctly
@@ -134,78 +170,38 @@ import testapp
 if 'tornado.autoreload' not in sys.modules:
     raise Exception('started without autoreload wrapper')
 
-import tornado.autoreload
-
 print('Starting')
-sys.stdout.flush()
-if 'TESTAPP_STARTED' not in os.environ:
-    os.environ['TESTAPP_STARTED'] = '1'
-    # Simulate an internal autoreload (one not caused
-    # by the wrapper).
-    tornado.autoreload._reload()
-else:
-    # Exit directly so autoreload doesn't catch it.
-    os._exit(0)
+exec(open("run_twice_magic.py").read())
 """
 
-        # Create temporary test application
-        os.mkdir(os.path.join(self.path, "testapp"))
-        init_file = os.path.join(self.path, "testapp", "__init__.py")
-        open(init_file, "w", encoding="utf-8").close()
-        main_file = os.path.join(self.path, "testapp", "__main__.py")
-        with open(main_file, "w", encoding="utf-8") as f:
-            f.write(main)
-
-        # Make sure the tornado module under test is available to the test
-        # application
-        pythonpath = os.getcwd()
-        if "PYTHONPATH" in os.environ:
-            pythonpath += os.pathsep + os.environ["PYTHONPATH"]
-
-        autoreload_proc = Popen(
-            [sys.executable, "-m", "tornado.autoreload", "-m", "testapp"],
-            stdout=subprocess.PIPE,
-            cwd=self.path,
-            env=dict(os.environ, PYTHONPATH=pythonpath),
-            universal_newlines=True,
-            encoding="utf-8",
+        self.write_files(
+            {
+                "testapp": {
+                    "__init__.py": "",
+                    "__main__.py": main,
+                },
+            }
         )
 
-        # This timeout needs to be fairly generous for pypy due to jit
-        # warmup costs.
-        for i in range(40):
-            if autoreload_proc.poll() is not None:
-                break
-            time.sleep(0.1)
-        else:
-            autoreload_proc.kill()
-            raise Exception("subprocess failed to terminate")
-
-        out = autoreload_proc.communicate()[0]
+        out = self.run_subprocess(
+            [sys.executable, "-m", "tornado.autoreload", "-m", "testapp"]
+        )
         self.assertEqual(out, "Starting\n" * 2)
 
     def test_reload_wrapper_args(self):
         main = """\
-import os
 import sys
 
 print(os.path.basename(sys.argv[0]))
 print(f'argv={sys.argv[1:]}')
-sys.stdout.flush()
-os._exit(0)
+exec(open("run_twice_magic.py").read())
 """
         # Create temporary test application
-        main_file = os.path.join(self.path, "main.py")
-        with open(main_file, "w", encoding="utf-8") as f:
-            f.write(main)
+        self.write_files({"main.py": main})
 
         # Make sure the tornado module under test is available to the test
         # application
-        pythonpath = os.getcwd()
-        if "PYTHONPATH" in os.environ:
-            pythonpath += os.pathsep + os.environ["PYTHONPATH"]
-
-        autoreload_proc = Popen(
+        out = self.run_subprocess(
             [
                 sys.executable,
                 "-m",
@@ -216,14 +212,6 @@ os._exit(0)
                 "-m",
                 "arg3",
             ],
-            stdout=subprocess.PIPE,
-            cwd=self.path,
-            env=dict(os.environ, PYTHONPATH=pythonpath),
-            universal_newlines=True,
-            encoding="utf-8",
         )
 
-        out, err = autoreload_proc.communicate()
-        if err:
-            print("subprocess stderr:", err)
-        self.assertEqual(out, "main.py\nargv=['arg1', '--arg2', '-m', 'arg3']\n")
+        self.assertEqual(out, "main.py\nargv=['arg1', '--arg2', '-m', 'arg3']\n" * 2)


### PR DESCRIPTION
* Support running a directory instead of a module (#2855). In both the regular debug mode and CLI wrapper
* Use a real option parser for CLI wrapper
* Add `--until-success` flag (#2398)
* More tests!
* Remove some old compatibility code and update type annotations