### PR TITLE
httpserver_test: Add ExpectLog to fix CI

### DIFF
--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -575,9 +575,10 @@ Transfer-Encoding: chunked
                 b"\n", b"\r\n"
             )
         )
-        start_line, headers, response = self.io_loop.run_sync(
-            lambda: read_stream_body(self.stream)
-        )
+        with ExpectLog(gen_log, ".*invalid chunk size", level=logging.INFO):
+            start_line, headers, response = self.io_loop.run_sync(
+                lambda: read_stream_body(self.stream)
+            )
         self.assertEqual(400, start_line.code)
 
     @gen_test


### PR DESCRIPTION
The github security advisory feature lets you make private PRs but it apparently doesn't support CI so this log failure wasn't caught until after the PR was merged.