### PR TITLE
Fix WebSocketClientConnection parameter

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -1357,7 +1357,7 @@ class WebSocketClientConnection(simple_httpclient._HTTPConnection):
         ping_interval: Optional[float] = None,
         ping_timeout: Optional[float] = None,
         max_message_size: int = _default_max_message_size,
-        subprotocols: Optional[List[str]] = [],
+        subprotocols: Optional[List[str]] = None,
         resolver: Optional[Resolver] = None,
     ) -> None:
         self.connect_future = Future()  # type: Future[WebSocketClientConnection]


### PR DESCRIPTION
Hi,

This is my first time making PR to this repo. Wish this will help.

While developing libs based on Tornado, I found a mutable default argument value in `WebSocketClientConnection.__init__`.

```python
subprotocols: Optional[List[str]] = []
```

I think it's better to set the default argument value to `None` to prevent from some unpredictable problems.