### PR TITLE
httpclient_test: Increase test_destructor_log timeout

### DIFF
--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -853,7 +853,7 @@ class SyncHTTPClientSubprocessTest(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,
-            timeout=5,
+            timeout=15,
         )
         if proc.stdout:
             print("STDOUT:")


### PR DESCRIPTION
This test has recently become flaky on windows CI, and before investigating further, see if it's just because the CI machines are overloaded and subprocesses are slower on windows.