### PR TITLE
docs: Fix build after readthedocs/readthedocs.org#10638

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@ import os
 import sphinx.errors
 import sys
 
+import sphinx_rtd_theme
+
 # Ensure we get the local copy of tornado instead of what's on the standard path
 sys.path.insert(0, os.path.abspath(".."))
 import tornado
@@ -84,16 +86,8 @@ latex_documents = [
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-# On RTD we can't import sphinx_rtd_theme, but it will be applied by
-# default anyway.  This block will use the same theme when building locally
-# as on RTD.
-if not on_rtd:
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Suppress warnings about "class reference target not found" for these types.
 # In most cases these types come from type annotations and are for mypy's use.


### PR DESCRIPTION
The old magic for sphinx_rtd_theme has been removed; now we should handle the theme in the same way we do for local builds.