### PR TITLE
use typing.NamedTuple instead of collections.namedtuple

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -552,7 +552,9 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         if header_line.startswith("HTTP/"):
             headers.clear()
             try:
-                (__, __, reason) = httputil.parse_response_start_line(header_line)
+                (_version, _code, reason) = httputil.parse_response_start_line(
+                    header_line
+                )
                 header_line = "X-Http-Reason: %s" % reason
             except httputil.HTTPInputError:
                 return

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -873,9 +873,10 @@ def format_timestamp(
     return email.utils.formatdate(time_num, usegmt=True)
 
 
-RequestStartLine = collections.namedtuple(
-    "RequestStartLine", ["method", "path", "version"]
-)
+class RequestStartLine(typing.NamedTuple):
+    method: str
+    path: str
+    version: str
 
 
 _http_version_re = re.compile(r"^HTTP/1\.[0-9]$")
@@ -884,7 +885,7 @@ _http_version_re = re.compile(r"^HTTP/1\.[0-9]$")
 def parse_request_start_line(line: str) -> RequestStartLine:
     """Returns a (method, path, version) tuple for an HTTP 1.x request line.
 
-    The response is a `collections.namedtuple`.
+    The response is a `typing.NamedTuple`.
 
     >>> parse_request_start_line("GET /foo HTTP/1.1")
     RequestStartLine(method='GET', path='/foo', version='HTTP/1.1')
@@ -902,9 +903,10 @@ def parse_request_start_line(line: str) -> RequestStartLine:
     return RequestStartLine(method, path, version)
 
 
-ResponseStartLine = collections.namedtuple(
-    "ResponseStartLine", ["version", "code", "reason"]
-)
+class ResponseStartLine(typing.NamedTuple):
+    version: str
+    code: int
+    reason: str
 
 
 _http_response_line_re = re.compile(r"(HTTP/1.[0-9]) ([0-9]+) ([^\r]*)")
@@ -913,7 +915,7 @@ _http_response_line_re = re.compile(r"(HTTP/1.[0-9]) ([0-9]+) ([^\r]*)")
 def parse_response_start_line(line: str) -> ResponseStartLine:
     """Returns a (version, code, reason) tuple for an HTTP 1.x response line.
 
-    The response is a `collections.namedtuple`.
+    The response is a `typing.NamedTuple`.
 
     >>> parse_response_start_line("HTTP/1.1 200 OK")
     ResponseStartLine(version='HTTP/1.1', code=200, reason='OK')


### PR DESCRIPTION
Enhances typing for `RequestStartLine` and `ResponseStartLine`.

`HTTPServerRequest` may set its `method`/`uri`/`version` properties from `RequestStartLine`. On Pyright, since these properties' types are unknown, those `HTTPServerRequest` properties may also become unknown.
