### PR TITLE
web,demos: Remove more uses of deprecated datetime utc methods

### DIFF
--- a/demos/blog/templates/feed.xml
+++ b/demos/blog/templates/feed.xml
@@ -5,7 +5,7 @@
   {% if len(entries) > 0 %}
     <updated>{{ max(e.updated for e in entries).strftime(date_format) }}</updated>
   {% else %}
-    <updated>{{ datetime.datetime.utcnow().strftime(date_format) }}</updated>
+    <updated>{{ datetime.datetime.now(datetime.timezone.utc).strftime(date_format) }}</updated>
   {% end %}
   <id>http://{{ request.host }}/</id>
   <link rel="alternate" href="http://{{ request.host }}/" title="{{ handler.settings["blog_title"] }}" type="text/html"/>

--- a/demos/s3server/s3server.py
+++ b/demos/s3server/s3server.py
@@ -138,7 +138,9 @@ class RootHandler(BaseRequestHandler):
             buckets.append(
                 {
                     "Name": name,
-                    "CreationDate": datetime.datetime.utcfromtimestamp(info.st_ctime),
+                    "CreationDate": datetime.datetime.fromtimestamp(
+                        info.st_ctime, datetime.timezone.utc
+                    ),
                 }
             )
         self.render_xml({"ListAllMyBucketsResult": {"Buckets": {"Bucket": buckets}}})

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1128,6 +1128,15 @@ class StaticFileTest(WebTestCase):
         self.assertTrue(b"Disallow: /" in response.body)
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
 
+    def test_static_files_cacheable(self):
+        # Test that the version parameter triggers cache-control headers. This
+        # test is pretty weak but it gives us coverage of the code path which
+        # was important for detecting the deprecation of datetime.utcnow.
+        response = self.fetch("/robots.txt?v=12345")
+        self.assertTrue(b"Disallow: /" in response.body)
+        self.assertIn("Cache-Control", response.headers)
+        self.assertIn("Expires", response.headers)
+
     def test_static_compressed_files(self):
         response = self.fetch("/static/sample.xml.gz")
         self.assertEqual(response.headers.get("Content-Type"), "application/gzip")

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2797,7 +2797,8 @@ class StaticFileHandler(RequestHandler):
         if cache_time > 0:
             self.set_header(
                 "Expires",
-                datetime.datetime.utcnow() + datetime.timedelta(seconds=cache_time),
+                datetime.datetime.now(datetime.timezone.utc)
+                + datetime.timedelta(seconds=cache_time),
             )
             self.set_header("Cache-Control", "max-age=" + str(cache_time))
 


### PR DESCRIPTION
Add a simple test case to give us some basic coverage of this code path.

Closes #3335