### PR TITLE
Automatic usage of threads for synchronous methods.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -93,6 +93,7 @@ from tornado.httpserver import HTTPServer
 from tornado import httputil
 from tornado import iostream
 from tornado import locale
+from tornado.ioloop import IOLoop
 from tornado.log import access_log, app_log, gen_log
 from tornado import template
 from tornado.escape import utf8, _unicode
@@ -1790,7 +1791,7 @@ class RequestHandler(object):
             else:
                 executor = getattr(self, "executor")
                 method = functools.partial(method, **self.path_kwargs)
-                await asyncio.get_running_loop().run_in_executor(executor, method, *self.path_args)
+                await IOLoop.current().run_in_executor(executor, method, *self.path_args)
 
             if self._auto_finish and not self._finished:
                 self.finish()

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -59,7 +59,7 @@ request, or to limit your use of other threads to
 the executor do not refer to Tornado objects.
 
 """
-
+import asyncio
 import base64
 import binascii
 import datetime
@@ -1785,9 +1785,13 @@ class RequestHandler(object):
                     return
 
             method = getattr(self, self.request.method.lower())
-            result = method(*self.path_args, **self.path_kwargs)
-            if result is not None:
-                result = await result
+            if asyncio.iscoroutinefunction(method):
+                await method(*self.path_args, **self.path_kwargs)
+            else:
+                executor = getattr(self, "executor")
+                method = functools.partial(method, **self.path_kwargs)
+                await asyncio.get_running_loop().run_in_executor(executor, method, *self.path_args)
+
             if self._auto_finish and not self._finished:
                 self.finish()
         except Exception as e:


### PR DESCRIPTION
I got inspiration from fastapi

https://github.com/tiangolo/fastapi/blob/master/fastapi/routing.py#L183

<img width="872" alt="image" src="https://github.com/tornadoweb/tornado/assets/52483823/b36dee93-68b2-41ef-baa5-a0262b23bf62">
