### PR TITLE
web: Type SUPPORTED_METHODS so it can be overridden.

### DIFF
--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -121,7 +121,7 @@ class PatchHandler(RequestHandler):
 
 
 class AllMethodsHandler(RequestHandler):
-    SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ("OTHER",)  # type: ignore
+    SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ("OTHER",)
 
     def method(self):
         assert self.request.method is not None

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2187,9 +2187,7 @@ class AllHTTPMethodsTest(SimpleHandlerTestCase):
 
 class PatchMethodTest(SimpleHandlerTestCase):
     class Handler(RequestHandler):
-        SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + (  # type: ignore
-            "OTHER",
-        )
+        SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ("OTHER",)
 
         def patch(self):
             self.write("patch")

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -130,7 +130,7 @@ from types import TracebackType
 import typing
 
 if typing.TYPE_CHECKING:
-    from typing import Set  # noqa: F401
+    from typing import Collection, Set  # noqa: F401
 
 
 # The following types are accepted by RequestHandler.set_header
@@ -192,7 +192,15 @@ class RequestHandler(object):
 
     """
 
-    SUPPORTED_METHODS = ("GET", "HEAD", "POST", "DELETE", "PATCH", "PUT", "OPTIONS")
+    SUPPORTED_METHODS = (
+        "GET",
+        "HEAD",
+        "POST",
+        "DELETE",
+        "PATCH",
+        "PUT",
+        "OPTIONS",
+    )  # type: Collection[str]
 
     _template_loaders = {}  # type: Dict[str, template.BaseLoader]
     _template_loader_lock = threading.Lock()


### PR DESCRIPTION
Its default type is `Tuple[str, str, str, str, str, str, str]`, which can only be overridden by a tuple of the exact same length.  Which is not terribly useful for its stated purpose.

Type it as a `Collection[str]`, which should support folks overriding it as any number of reasonable things, as it is only used by way of `if request.method not in self.SUPPORTED_METHODS`.