### PR TITLE
autoreload_test: Handle a relative PYTHONPATH

### DIFF
--- a/tornado/test/autoreload_test.py
+++ b/tornado/test/autoreload_test.py
@@ -73,9 +73,13 @@ class AutoreloadTest(unittest.TestCase):
     def run_subprocess(self, args):
         # Make sure the tornado module under test is available to the test
         # application
-        pythonpath = os.getcwd()
+        parts = [os.getcwd()]
         if "PYTHONPATH" in os.environ:
-            pythonpath += os.pathsep + os.environ["PYTHONPATH"]
+            parts += [
+                os.path.join(os.getcwd(), part)
+                for part in os.environ["PYTHONPATH"].split(os.pathsep)
+            ]
+        pythonpath = os.pathsep.join(parts)
 
         p = Popen(
             args,


### PR DESCRIPTION
This came up in the Debian package build of tornado, where we run the tests from a staged build of the module.