### PR TITLE
testing: allow to instantiate an empty AsyncTestCase

### DIFF
--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -61,6 +61,15 @@ class AsyncTestCaseTest(AsyncTestCase):
         self.io_loop.add_timeout(self.io_loop.time() + 0.2, self.stop)
         self.wait(timeout=0.4)
 
+    def test_empty_instantation_is_allowed(self):
+        """
+        Test that empty instatiation of an AsyncTestCase is allowed.
+
+        unittest.TestCase docs guarantee this working, and pytest's unittest
+        support relies on it.
+        """
+        AsyncTestCaseTest()
+
 
 class LeakTest(AsyncTestCase):
     def tearDown(self):

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -177,7 +177,17 @@ class AsyncTestCase(unittest.TestCase):
         # the test will silently be ignored because nothing will consume
         # the generator.  Replace the test method with a wrapper that will
         # make sure it's not an undecorated generator.
-        setattr(self, methodName, _TestMethodWrapper(getattr(self, methodName)))
+        try:
+            test_method = getattr(self, methodName)
+        except AttributeError:
+            if methodName != "runTest":
+                # We allow instantiation with no explicit method name
+                # but not an *incorrect* or missing method name.
+                raise ValueError(
+                    "no such test method in %s: %s" % (self.__class__, methodName)
+                )
+        else:
+            setattr(self, methodName, _TestMethodWrapper(test_method))
 
         # Not used in this class itself, but used by @gen_test
         self._test_generator = None  # type: Optional[Union[Generator, Coroutine]]


### PR DESCRIPTION
`unittest.TestCase` has a feature where it allows instantiating `MyTestClass()` with the default method name `runTest` even if a `runTest` method doesn't actually exist. This is documented in `TestCase`'s docs under "Changed in version 3.2" ([link]( https://docs.python.org/3/library/unittest.html#unittest.TestCase)).

Since version 8.2, pytest relies on this, and started breaking on Tornado's `AsyncTestCase`, see https://github.com/pytest-dev/pytest/issues/12263.

Change `AsyncTestCase` to allow empty instatiation, by matching the [upstream code](https://github.com/python/cpython/blob/51aefc5bf907ddffaaf083ded0de773adcdf08c8/Lib/unittest/case.py#L419-L426).