### PR TITLE
websockets: fix ping_timeout

### DIFF
--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -878,7 +878,10 @@ class ServerPingTimeoutTest(WebSocketBaseTestCase):
     @gen_test
     def test_client_ping_timeout(self):
         # websocket client
-        ws = yield self.ws_connect("/", ping_interval=0.2, ping_timeout=0.05)
+        interval = 0.2
+        ws = yield self.ws_connect(
+            "/", ping_interval=interval, ping_timeout=interval / 4
+        )
 
         # websocket handler (server side)
         handler = self.handlers[0]
@@ -894,11 +897,11 @@ class ServerPingTimeoutTest(WebSocketBaseTestCase):
             # connection should still be open from the client end
             assert ws.protocol.close_code is None
 
-        # delay the pong message by 0.10 seconds (timeout=0.05)
+        # suppress the pong response message
         self.suppress_pong(ws)
 
         # give the server time to register this
-        yield gen.sleep(0.2)
+        yield gen.sleep(interval * 1.5)
 
         # connection should be closed from the server side
         self.assertEqual(handler.close_code, 1000)

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -888,8 +888,8 @@ class ServerPingTimeoutTest(WebSocketBaseTestCase):
             yield gen.sleep(0.2)
 
             # connection should still be open from the server end
-            assert handler.close_code is None
-            assert handler.close_reason is None
+            self.assertIsNone(handler.close_code)
+            self.assertIsNone(handler.close_reason)
 
             # connection should still be open from the client end
             assert ws.protocol.close_code is None
@@ -901,11 +901,11 @@ class ServerPingTimeoutTest(WebSocketBaseTestCase):
         yield gen.sleep(0.2)
 
         # connection should be closed from the server side
-        assert handler.close_code == 1000
-        assert handler.close_reason == "ping timed out"
+        self.assertEqual(handler.close_code, 1000)
+        self.assertEqual(handler.close_reason, "ping timed out")
 
         # client should have received a close operation
-        assert ws.protocol.close_code == 1000
+        self.assertEqual(ws.protocol.close_code, 1000)
 
 
 class ManualPingTest(WebSocketBaseTestCase):


### PR DESCRIPTION
Closes #3258
Closes #2905
Closes #2655

Fixes an issue with the calculation of ping timeout interval which caused connections to be erroneously closed from the server end. This could happen shortly after the connection was opened, *before* the ping was even sent (as reported in #3258) as the result of startup logic. It could also happen when pong responses were sent back from the client *within* the configured timeout as the result of a race condition.

To test this fix, try repeating the steps in this example: https://github.com/tornadoweb/tornado/issues/3258#issuecomment-2084940884

~I found a [TODO](https://github.com/tornadoweb/tornado/blob/f399f40fde0ae1b130646db783a6f79cc59231b2/tornado/test/websocket_test.py#L817) to implement testing for ping timeout. I tried to fill this in but couldn't get it to work, any pointers appreciated (note, it has to be tested from the server side).~