### PR TITLE
test: Address warnings about using the default encoding

### DIFF
--- a/tornado/test/autoreload_test.py
+++ b/tornado/test/autoreload_test.py
@@ -114,7 +114,7 @@ else:
 
 spec = getattr(sys.modules[__name__], '__spec__', None)
 print(f"Starting {__name__=}, __spec__.name={getattr(spec, 'name', None)}")
-exec(open("run_twice_magic.py").read())
+exec(open("run_twice_magic.py", encoding="utf-8").read())
 """
 
         # Create temporary test application
@@ -195,7 +195,7 @@ if 'tornado.autoreload' not in sys.modules:
     raise Exception('started without autoreload wrapper')
 
 print('Starting')
-exec(open("run_twice_magic.py").read())
+exec(open("run_twice_magic.py", encoding="utf-8").read())
 """
 
         self.write_files(
@@ -219,7 +219,7 @@ import sys
 
 print(os.path.basename(sys.argv[0]))
 print(f'argv={sys.argv[1:]}')
-exec(open("run_twice_magic.py").read())
+exec(open("run_twice_magic.py", encoding="utf-8").read())
 """
         # Create temporary test application
         self.write_files({"main.py": main})
@@ -251,7 +251,7 @@ if "TESTAPP_STARTED" in os.environ:
     sys.exit(0)
 else:
     print("reloading")
-    exec(open("run_twice_magic.py").read())
+    exec(open("run_twice_magic.py", encoding="utf-8").read())
 """
 
         # Create temporary test application

--- a/tox.ini
+++ b/tox.ini
@@ -68,10 +68,9 @@ setenv =
        PYTHONWARNDEFAULTENCODING=1
 
 # Allow shell commands in tests
-allowlist_externals = sh
+allowlist_externals = sh, env
 
 
-# All non-comment lines but the last must end in a backslash.
 # Tox filters line-by-line based on the environment name.
 commands =
          # py3*: -b turns on an extra warning when calling
@@ -111,12 +110,15 @@ commands =
          black --check --diff {posargs:tornado demos}
          # Many syscalls are defined differently on linux and windows,
          # so we have to typecheck both.
-         mypy --platform linux {posargs:tornado}
-         mypy --platform windows {posargs:tornado}
+         # Mypy currently uses the default encoding so we must unset the warning variable
+         # here (must be completely unset, not just set to zero/empty). Remove this
+         # (and the allowlist_externals for env) when mypy sets the encoding explicitly.
+         env -u PYTHONWARNDEFAULTENCODING mypy --platform linux {posargs:tornado}
+         env -u PYTHONWARNDEFAULTENCODING mypy --platform windows {posargs:tornado}
          # We mainly lint on the oldest version of Python we support, since
          # we're more likely to catch problems of accidentally depending on
          # something new than of depending on something old and deprecated.
          # But sometimes something we depend on gets removed so we should also
          # test the newest version.
-         mypy --platform linux --python-version 3.13 {posargs:tornado}
+         env -u PYTHONWARNDEFAULTENCODING mypy --platform linux --python-version 3.13 {posargs:tornado}
 changedir = {toxinidir}


### PR DESCRIPTION
I'm not sure exactly how these warnings are getting logged without causing the build to fail, but they are.