### PR TITLE
*: Automated changes from pyupgrade

### DIFF
--- a/demos/chat/chatdemo.py
+++ b/demos/chat/chatdemo.py
@@ -25,7 +25,7 @@ define("port", default=8888, help="run on the given port", type=int)
 define("debug", default=True, help="run in debug mode")
 
 
-class MessageBuffer(object):
+class MessageBuffer:
     def __init__(self):
         # cond is notified whenever the message cache is updated
         self.cond = tornado.locks.Condition()

--- a/demos/webspider/webspider.py
+++ b/demos/webspider/webspider.py
@@ -74,7 +74,7 @@ async def main():
             try:
                 await fetch_url(url)
             except Exception as e:
-                print("Exception: %s %s" % (e, url))
+                print(f"Exception: {e} {url}")
                 dead.add(url)
             finally:
                 q.task_done()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+
 [tool.cibuildwheel]
 build = "cp3[89]* cp310* cp311* cp312*"
 test-command = "python -m tornado.test"

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -632,7 +632,7 @@ class OAuth2Mixin:
         url: str,
         access_token: Optional[str] = None,
         post_args: Optional[Dict[str, Any]] = None,
-        **args: Any
+        **args: Any,
     ) -> Any:
         """Fetches the given URL auth an OAuth2 access token.
 
@@ -761,7 +761,7 @@ class TwitterMixin(OAuthMixin):
         path: str,
         access_token: Dict[str, Any],
         post_args: Optional[Dict[str, Any]] = None,
-        **args: Any
+        **args: Any,
     ) -> Any:
         """Fetches the given API path, e.g., ``statuses/user_timeline/btaylor``
 
@@ -1096,7 +1096,7 @@ class FacebookGraphMixin(OAuth2Mixin):
         path: str,
         access_token: Optional[str] = None,
         post_args: Optional[Dict[str, Any]] = None,
-        **args: Any
+        **args: Any,
     ) -> Any:
         """Fetches the given relative API path, e.g., "/btaylor/picture"
 

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -375,9 +375,9 @@ class OAuthMixin:
         if not request_cookie:
             raise AuthError("Missing OAuth request token cookie")
         handler.clear_cookie("_oauth_request_token")
-        cookie_key, cookie_secret = [
+        cookie_key, cookie_secret = (
             base64.b64decode(escape.utf8(i)) for i in request_cookie.split("|")
-        ]
+        )
         if cookie_key != request_key:
             raise AuthError("Request token does not match cookie")
         token = dict(

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -185,7 +185,7 @@ class OpenIdMixin:
             ax_attrs = set(ax_attrs)
             required = []  # type: List[str]
             if "name" in ax_attrs:
-                ax_attrs -= set(["name", "firstname", "fullname", "lastname"])
+                ax_attrs -= {"name", "firstname", "fullname", "lastname"}
                 required += ["firstname", "fullname", "lastname"]
                 args.update(
                     {
@@ -1047,9 +1047,7 @@ class FacebookGraphMixin(OAuth2Mixin):
             "client_secret": client_secret,
         }
 
-        fields = set(
-            ["id", "name", "first_name", "last_name", "locale", "picture", "link"]
-        )
+        fields = {"id", "name", "first_name", "last_name", "locale", "picture", "link"}
         if extra_fields:
             fields.update(extra_fields)
 

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -147,9 +147,9 @@ class OpenIdMixin:
         """
         handler = cast(RequestHandler, self)
         # Verify the OpenID response via direct request to the OP
-        args = dict(
-            (k, v[-1]) for k, v in handler.request.arguments.items()
-        )  # type: Dict[str, Union[str, bytes]]
+        args = {
+            k: v[-1] for k, v in handler.request.arguments.items()
+        }  # type: Dict[str, Union[str, bytes]]
         args["openid.mode"] = "check_authentication"
         url = self._OPENID_ENDPOINT  # type: ignore
         if http_client is None:

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -1170,9 +1170,7 @@ def _oauth_signature(
     base_elems.append(method.upper())
     base_elems.append(normalized_url)
     base_elems.append(
-        "&".join(
-            "%s=%s" % (k, _oauth_escape(str(v))) for k, v in sorted(parameters.items())
-        )
+        "&".join(f"{k}={_oauth_escape(str(v))}" for k, v in sorted(parameters.items()))
     )
     base_string = "&".join(_oauth_escape(e) for e in base_elems)
 
@@ -1203,9 +1201,7 @@ def _oauth10a_signature(
     base_elems.append(method.upper())
     base_elems.append(normalized_url)
     base_elems.append(
-        "&".join(
-            "%s=%s" % (k, _oauth_escape(str(v))) for k, v in sorted(parameters.items())
-        )
+        "&".join(f"{k}={_oauth_escape(str(v))}" for k, v in sorted(parameters.items()))
     )
 
     base_string = "&".join(_oauth_escape(e) for e in base_elems)

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -91,7 +91,7 @@ class AuthError(Exception):
     pass
 
 
-class OpenIdMixin(object):
+class OpenIdMixin:
     """Abstract implementation of OpenID and Attribute Exchange.
 
     Class attributes:
@@ -284,7 +284,7 @@ class OpenIdMixin(object):
         return httpclient.AsyncHTTPClient()
 
 
-class OAuthMixin(object):
+class OAuthMixin:
     """Abstract implementation of OAuth 1.0 and 1.0a.
 
     See `TwitterMixin` below for an example implementation.
@@ -552,7 +552,7 @@ class OAuthMixin(object):
         return httpclient.AsyncHTTPClient()
 
 
-class OAuth2Mixin(object):
+class OAuth2Mixin:
     """Abstract implementation of OAuth 2.0.
 
     See `FacebookGraphMixin` or `GoogleOAuth2Mixin` below for example

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -448,7 +448,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             "PUT": pycurl.UPLOAD,
             "HEAD": pycurl.NOBODY,
         }
-        custom_methods = set(["DELETE", "OPTIONS", "PATCH"])
+        custom_methods = {"DELETE", "OPTIONS", "PATCH"}
         for o in curl_options.values():
             curl.setopt(o, False)
         if request.method in curl_options:

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -271,9 +271,7 @@ def recursive_unicode(obj: Any) -> Any:
     Supports lists, tuples, and dictionaries.
     """
     if isinstance(obj, dict):
-        return dict(
-            (recursive_unicode(k), recursive_unicode(v)) for (k, v) in obj.items()
-        )
+        return {recursive_unicode(k): recursive_unicode(v) for (k, v) in obj.items()}
     elif isinstance(obj, list):
         return list(recursive_unicode(i) for i in obj)
     elif isinstance(obj, tuple):

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -392,7 +392,7 @@ def linkify(
                     # have a status bar, such as Safari by default)
                     params += ' title="%s"' % href
 
-        return '<a href="%s"%s>%s</a>' % (href, params, url)
+        return f'<a href="{href}"{params}>{url}</a>'
 
     # First HTML-escape so that our strings are all safe.
     # The regex is modified to avoid character entites other than &amp; so

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -874,7 +874,7 @@ def convert_yielded(yielded: _Yieldable) -> Future:
     elif isawaitable(yielded):
         return _wrap_awaitable(yielded)  # type: ignore
     else:
-        raise BadYieldError("yielded unknown object %r" % (yielded,))
+        raise BadYieldError(f"yielded unknown object {yielded!r}")
 
 
 convert_yielded = singledispatch(convert_yielded)

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -362,10 +362,10 @@ class WaitIterator:
             raise ValueError("You must provide args or kwargs, not both")
 
         if kwargs:
-            self._unfinished = dict((f, k) for (k, f) in kwargs.items())
+            self._unfinished = {f: k for (k, f) in kwargs.items()}
             futures = list(kwargs.values())  # type: Sequence[Future]
         else:
-            self._unfinished = dict((f, i) for (i, f) in enumerate(args))
+            self._unfinished = {f: i for (i, f) in enumerate(args)}
             futures = args
 
         self._finished = collections.deque()  # type: Deque[Future]

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -300,7 +300,7 @@ class Return(Exception):
         self.args = (value,)
 
 
-class WaitIterator(object):
+class WaitIterator:
     """Provides an iterator to yield the results of awaitables as they finish.
 
     Yielding a set of awaitables like this:
@@ -668,7 +668,7 @@ def sleep(duration: float) -> "Future[None]":
     return f
 
 
-class _NullFuture(object):
+class _NullFuture:
     """_NullFuture resembles a Future that finished with a result of None.
 
     It's not actually a `Future` to avoid depending on a particular event loop.
@@ -713,7 +713,7 @@ In native coroutines, the equivalent of ``yield gen.moment`` is
 """
 
 
-class Runner(object):
+class Runner:
     """Internal implementation of `tornado.gen.coroutine`.
 
     Maintains information about pending callbacks and their results.

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -389,7 +389,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         if self.is_client:
             assert isinstance(start_line, httputil.RequestStartLine)
             self._request_start_line = start_line
-            lines.append(utf8("%s %s HTTP/1.1" % (start_line[0], start_line[1])))
+            lines.append(utf8(f"{start_line[0]} {start_line[1]} HTTP/1.1"))
             # Client requests with a non-empty body must have either a
             # Content-Length or a Transfer-Encoding. If Content-Length is not
             # present we'll add our Transfer-Encoding below.

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -46,7 +46,7 @@ class _QuietException(Exception):
         pass
 
 
-class _ExceptionLoggingContext(object):
+class _ExceptionLoggingContext:
     """Used with the ``with`` statement when calling delegate methods to
     log any exceptions with the given logger.  Any exceptions caught are
     converted to _QuietException
@@ -70,7 +70,7 @@ class _ExceptionLoggingContext(object):
             raise _QuietException
 
 
-class HTTP1ConnectionParameters(object):
+class HTTP1ConnectionParameters:
     """Parameters for `.HTTP1Connection` and `.HTTP1ServerConnection`."""
 
     def __init__(
@@ -761,7 +761,7 @@ class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
         return self._delegate.on_connection_close()
 
 
-class HTTP1ServerConnection(object):
+class HTTP1ServerConnection:
     """An HTTP/1.x server."""
 
     def __init__(

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -684,7 +684,7 @@ class HTTPResponse:
 
     def __repr__(self) -> str:
         args = ",".join("%s=%r" % i for i in sorted(self.__dict__.items()))
-        return "%s(%s)" % (self.__class__.__name__, args)
+        return f"{self.__class__.__name__}({args})"
 
 
 class HTTPClientError(Exception):

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -89,7 +89,7 @@ class HTTPClient:
     def __init__(
         self,
         async_client_class: "Optional[Type[AsyncHTTPClient]]" = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         # Initialize self._closed at the beginning of the constructor
         # so that an exception raised here doesn't lead to confusing
@@ -250,7 +250,7 @@ class AsyncHTTPClient(Configurable):
         self,
         request: Union[str, "HTTPRequest"],
         raise_error: bool = True,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "Future[HTTPResponse]":
         """Executes a request, asynchronously returning an `HTTPResponse`.
 

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -203,7 +203,7 @@ class AsyncHTTPClient(Configurable):
             instance_cache = cls._async_clients()
         if instance_cache is not None and io_loop in instance_cache:
             return instance_cache[io_loop]
-        instance = super(AsyncHTTPClient, cls).__new__(cls, **kwargs)  # type: ignore
+        instance = super().__new__(cls, **kwargs)  # type: ignore
         # Make sure the instance knows which cache to remove itself from.
         # It can't simply call _async_clients() because we may be in
         # __new__(AsyncHTTPClient) but instance.__class__ may be
@@ -333,7 +333,7 @@ class AsyncHTTPClient(Configurable):
 
            AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
         """
-        super(AsyncHTTPClient, cls).configure(impl, **kwargs)
+        super().configure(impl, **kwargs)
 
 
 class HTTPRequest:

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -56,7 +56,7 @@ from tornado.util import Configurable
 from typing import Type, Any, Union, Dict, Callable, Optional, cast
 
 
-class HTTPClient(object):
+class HTTPClient:
     """A blocking HTTP client.
 
     This interface is provided to make it easier to share code between
@@ -336,7 +336,7 @@ class AsyncHTTPClient(Configurable):
         super(AsyncHTTPClient, cls).configure(impl, **kwargs)
 
 
-class HTTPRequest(object):
+class HTTPRequest:
     """HTTP client request object."""
 
     _headers = None  # type: Union[Dict[str, str], httputil.HTTPHeaders]
@@ -571,7 +571,7 @@ class HTTPRequest(object):
         self._body = utf8(value)
 
 
-class HTTPResponse(object):
+class HTTPResponse:
     """HTTP Response object.
 
     Attributes:
@@ -732,7 +732,7 @@ class HTTPClientError(Exception):
 HTTPError = HTTPClientError
 
 
-class _RequestProxy(object):
+class _RequestProxy:
     """Combines an object with a dictionary of defaults.
 
     Used internally by AsyncHTTPClient implementations.

--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -295,7 +295,7 @@ class _CallableAdapter(httputil.HTTPMessageDelegate):
         del self._chunks
 
 
-class _HTTPRequestContext(object):
+class _HTTPRequestContext:
     def __init__(
         self,
         stream: iostream.IOStream,

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -253,7 +253,7 @@ class HTTPHeaders(StrMutableMapping):
     __unicode__ = __str__
 
 
-class HTTPServerRequest(object):
+class HTTPServerRequest:
     """A single HTTP request.
 
     All attributes are type `str` unless otherwise noted.
@@ -494,7 +494,7 @@ class HTTPOutputError(Exception):
     pass
 
 
-class HTTPServerConnectionDelegate(object):
+class HTTPServerConnectionDelegate:
     """Implement this interface to handle requests from `.HTTPServer`.
 
     .. versionadded:: 4.0
@@ -523,7 +523,7 @@ class HTTPServerConnectionDelegate(object):
         pass
 
 
-class HTTPMessageDelegate(object):
+class HTTPMessageDelegate:
     """Implement this interface to handle an HTTP request or response.
 
     .. versionadded:: 4.0
@@ -569,7 +569,7 @@ class HTTPMessageDelegate(object):
         pass
 
 
-class HTTPConnection(object):
+class HTTPConnection:
     """Applications use this interface to write their responses.
 
     .. versionadded:: 4.0

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -247,7 +247,7 @@ class HTTPHeaders(StrMutableMapping):
     def __str__(self) -> str:
         lines = []
         for name, value in self.get_all():
-            lines.append("%s: %s\n" % (name, value))
+            lines.append(f"{name}: {value}\n")
         return "".join(lines)
 
     __unicode__ = __str__
@@ -471,8 +471,8 @@ class HTTPServerRequest:
 
     def __repr__(self) -> str:
         attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
-        args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
-        return "%s(%s)" % (self.__class__.__name__, args)
+        args = ", ".join([f"{n}={getattr(self, n)!r}" for n in attrs])
+        return f"{self.__class__.__name__}({args})"
 
 
 class HTTPInputError(Exception):
@@ -741,7 +741,7 @@ def _get_content_range(start: Optional[int], end: Optional[int], total: int) -> 
     """
     start = start or 0
     end = (end or total) - 1
-    return "bytes %s-%s/%s" % (start, end, total)
+    return f"bytes {start}-{end}/{total}"
 
 
 def _int_or_none(val: str) -> Optional[int]:
@@ -1008,7 +1008,7 @@ def _encode_header(key: str, pdict: Dict[str, str]) -> str:
             out.append(k)
         else:
             # TODO: quote if necessary.
-            out.append("%s=%s" % (k, v))
+            out.append(f"{k}={v}")
     return "; ".join(out)
 
 

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -1132,13 +1132,13 @@ def parse_cookie(cookie: str) -> Dict[str, str]:
     .. versionadded:: 4.4.2
     """
     cookiedict = {}
-    for chunk in cookie.split(str(";")):
-        if str("=") in chunk:
-            key, val = chunk.split(str("="), 1)
+    for chunk in cookie.split(";"):
+        if "=" in chunk:
+            key, val = chunk.split("=", 1)
         else:
             # Assume an empty name per
             # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
-            key, val = str(""), chunk
+            key, val = "", chunk
         key, val = key.strip(), val.strip()
         if key or val:
             # unquote using Python's algorithm.

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -178,7 +178,7 @@ class IOLoop(Configurable):
             impl = import_object(impl)
         if isinstance(impl, type) and not issubclass(impl, BaseAsyncIOLoop):
             raise RuntimeError("only AsyncIOLoop is allowed when asyncio is available")
-        super(IOLoop, cls).configure(impl, **kwargs)
+        super().configure(impl, **kwargs)
 
     @staticmethod
     def instance() -> "IOLoop":

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -554,7 +554,7 @@ class IOLoop(Configurable):
         deadline: Union[float, datetime.timedelta],
         callback: Callable,
         *args: Any,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> object:
         """Runs the ``callback`` at the time ``deadline`` from the I/O loop.
 
@@ -705,7 +705,7 @@ class IOLoop(Configurable):
         self,
         executor: Optional[concurrent.futures.Executor],
         func: Callable[..., _T],
-        *args: Any
+        *args: Any,
     ) -> "Future[_T]":
         """Runs a function in a ``concurrent.futures.Executor``. If
         ``executor`` is ``None``, the IO loop's default executor will be used.

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -819,7 +819,7 @@ class IOLoop(Configurable):
         self._pending_tasks.discard(f)
 
 
-class _Timeout(object):
+class _Timeout:
     """An IOLoop timeout, a UNIX timestamp and a callback"""
 
     # Reduce memory overhead when there are lots of pending callbacks
@@ -848,7 +848,7 @@ class _Timeout(object):
         return self.tdeadline <= other.tdeadline
 
 
-class PeriodicCallback(object):
+class PeriodicCallback:
     """Schedules the given callback to be called periodically.
 
     The callback is called every ``callback_time`` milliseconds when

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -114,7 +114,7 @@ class StreamBufferFullError(Exception):
     """Exception raised by `IOStream` methods when the buffer is full."""
 
 
-class _StreamBuffer(object):
+class _StreamBuffer:
     """
     A specialized buffer that tries to avoid copies when large pieces
     of data are encountered.
@@ -204,7 +204,7 @@ class _StreamBuffer(object):
         self._first_pos = pos
 
 
-class BaseIOStream(object):
+class BaseIOStream:
     """A utility class to write to and read from a non-blocking file or socket.
 
     We support a non-blocking ``write()`` and a family of ``read_*()``

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -859,7 +859,7 @@ class BaseIOStream:
                     else:
                         buf = bytearray(self.read_chunk_size)
                     bytes_read = self.read_from_fd(buf)
-                except (socket.error, IOError, OSError) as e:
+                except OSError as e:
                     # ssl.SSLError is a subclass of socket.error
                     if self._is_connreset(e):
                         # Treat ECONNRESET as a connection close rather than
@@ -966,7 +966,7 @@ class BaseIOStream:
                 self._total_write_done_index += num_bytes
             except BlockingIOError:
                 break
-            except (socket.error, IOError, OSError) as e:
+            except OSError as e:
                 if not self._is_connreset(e):
                     # Broken pipe errors are usually caused by connection
                     # reset, and its better to not log EPIPE errors to
@@ -1180,7 +1180,7 @@ class IOStream(BaseIOStream):
             # In non-blocking mode we expect connect() to raise an
             # exception with EINPROGRESS or EWOULDBLOCK.
             pass
-        except socket.error as e:
+        except OSError as e:
             # On freebsd, other errors such as ECONNREFUSED may be
             # returned immediately when attempting to connect to
             # localhost, so handle them the same way as an error
@@ -1271,7 +1271,7 @@ class IOStream(BaseIOStream):
     def _handle_connect(self) -> None:
         try:
             err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
-        except socket.error as e:
+        except OSError as e:
             # Hurd doesn't allow SO_ERROR for loopback sockets because all
             # errors for such sockets are reported synchronously.
             if errno_from_exception(e) == errno.ENOPROTOOPT:
@@ -1305,7 +1305,7 @@ class IOStream(BaseIOStream):
                 self.socket.setsockopt(
                     socket.IPPROTO_TCP, socket.TCP_NODELAY, 1 if value else 0
                 )
-            except socket.error as e:
+            except OSError as e:
                 # Sometimes setsockopt will fail if the socket is closed
                 # at the wrong time.  This can happen with HTTPServer
                 # resetting the value to ``False`` between requests.
@@ -1342,7 +1342,7 @@ class SSLIOStream(IOStream):
         # If the socket is already connected, attempt to start the handshake.
         try:
             self.socket.getpeername()
-        except socket.error:
+        except OSError:
             pass
         else:
             # Indirectly start the handshake, which will run on the next
@@ -1387,7 +1387,7 @@ class SSLIOStream(IOStream):
             # in Python 3.7, this error is a subclass of SSLError
             # and will be handled by the previous block instead.
             return self.close(exc_info=err)
-        except socket.error as err:
+        except OSError as err:
             # Some port scans (e.g. nmap in -sT mode) have been known
             # to cause do_handshake to raise EBADF and ENOTCONN, so make
             # those errors quiet as well.
@@ -1606,7 +1606,7 @@ class PipeIOStream(BaseIOStream):
     def read_from_fd(self, buf: Union[bytearray, memoryview]) -> Optional[int]:
         try:
             return self._fio.readinto(buf)  # type: ignore
-        except (IOError, OSError) as e:
+        except OSError as e:
             if errno_from_exception(e) == errno.EBADF:
                 # If the writing half of a pipe is closed, select will
                 # report it as readable but reads will fail with EBADF.

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -569,8 +569,8 @@ class GettextLocale(Locale):
         if plural_message is not None:
             assert count is not None
             msgs_with_ctxt = (
-                "%s%s%s" % (context, CONTEXT_SEPARATOR, message),
-                "%s%s%s" % (context, CONTEXT_SEPARATOR, plural_message),
+                f"{context}{CONTEXT_SEPARATOR}{message}",
+                f"{context}{CONTEXT_SEPARATOR}{plural_message}",
                 count,
             )
             result = self.ngettext(*msgs_with_ctxt)
@@ -579,7 +579,7 @@ class GettextLocale(Locale):
                 result = self.ngettext(message, plural_message, count)
             return result
         else:
-            msg_with_ctxt = "%s%s%s" % (context, CONTEXT_SEPARATOR, message)
+            msg_with_ctxt = f"{context}{CONTEXT_SEPARATOR}{message}"
             result = self.gettext(msg_with_ctxt)
             if CONTEXT_SEPARATOR in result:
                 # Translation not found

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -221,7 +221,7 @@ def get_supported_locales() -> Iterable[str]:
     return _supported_locales
 
 
-class Locale(object):
+class Locale:
     """Object representing a locale.
 
     After calling one of `load_translations` or `load_gettext_translations`,

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -28,7 +28,7 @@ if typing.TYPE_CHECKING:
 __all__ = ["Condition", "Event", "Semaphore", "BoundedSemaphore", "Lock"]
 
 
-class _TimeoutGarbageCollector(object):
+class _TimeoutGarbageCollector:
     """Base class for objects that periodically clean up timed-out waiters.
 
     Avoids memory leak in a common pattern like:
@@ -155,7 +155,7 @@ class Condition(_TimeoutGarbageCollector):
         self.notify(len(self._waiters))
 
 
-class Event(object):
+class Event:
     """An event blocks coroutines until its internal flag is set to True.
 
     Similar to `threading.Event`.
@@ -255,7 +255,7 @@ class Event(object):
             return timeout_fut
 
 
-class _ReleasingContextManager(object):
+class _ReleasingContextManager:
     """Releases a Lock or Semaphore at the end of a "with" statement.
 
     with (yield semaphore.acquire()):
@@ -484,7 +484,7 @@ class BoundedSemaphore(Semaphore):
         super().release()
 
 
-class Lock(object):
+class Lock:
     """A lock for coroutines.
 
     A Lock begins unlocked, and `acquire` locks it immediately. While it is

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -111,7 +111,7 @@ class Condition(_TimeoutGarbageCollector):
     """
 
     def __repr__(self) -> str:
-        result = "<%s" % (self.__class__.__name__,)
+        result = f"<{self.__class__.__name__}"
         if self._waiters:
             result += " waiters[%s]" % len(self._waiters)
         return result + ">"
@@ -200,7 +200,7 @@ class Event:
         self._waiters = set()  # type: Set[Future[None]]
 
     def __repr__(self) -> str:
-        return "<%s %s>" % (
+        return "<{} {}>".format(
             self.__class__.__name__,
             "set" if self.is_set() else "clear",
         )
@@ -389,12 +389,10 @@ class Semaphore(_TimeoutGarbageCollector):
 
     def __repr__(self) -> str:
         res = super().__repr__()
-        extra = (
-            "locked" if self._value == 0 else "unlocked,value:{0}".format(self._value)
-        )
+        extra = "locked" if self._value == 0 else f"unlocked,value:{self._value}"
         if self._waiters:
-            extra = "{0},waiters:{1}".format(extra, len(self._waiters))
-        return "<{0} [{1}]>".format(res[1:-1], extra)
+            extra = f"{extra},waiters:{len(self._waiters)}"
+        return f"<{res[1:-1]} [{extra}]>"
 
     def release(self) -> None:
         """Increment the counter and wake one waiter."""
@@ -525,7 +523,7 @@ class Lock:
         self._block = BoundedSemaphore(value=1)
 
     def __repr__(self) -> str:
-        return "<%s _block=%s>" % (self.__class__.__name__, self._block)
+        return f"<{self.__class__.__name__} _block={self._block}>"
 
     def acquire(
         self, timeout: Optional[Union[float, datetime.timedelta]] = None

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -187,7 +187,7 @@ class LogFormatter(logging.Formatter):
             # byte strings wherever possible).
             record.message = _safe_unicode(message)
         except Exception as e:
-            record.message = "Bad message (%r): %r" % (e, record.__dict__)
+            record.message = f"Bad message ({e!r}): {record.__dict__!r}"
 
         record.asctime = self.formatTime(record, cast(str, self.datefmt))
 

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -645,7 +645,7 @@ def ssl_wrap_socket(
     ssl_options: Union[Dict[str, Any], ssl.SSLContext],
     server_hostname: Optional[str] = None,
     server_side: Optional[bool] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> ssl.SSLSocket:
     """Returns an ``ssl.SSLSocket`` wrapping the given socket.
 

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -126,14 +126,14 @@ def bind_sockets(
             continue
         try:
             sock = socket.socket(af, socktype, proto)
-        except socket.error as e:
+        except OSError as e:
             if errno_from_exception(e) == errno.EAFNOSUPPORT:
                 continue
             raise
         if os.name != "nt":
             try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            except socket.error as e:
+            except OSError as e:
                 if errno_from_exception(e) != errno.ENOPROTOOPT:
                     # Hurd doesn't support SO_REUSEADDR.
                     raise
@@ -204,7 +204,7 @@ if hasattr(socket, "AF_UNIX"):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        except socket.error as e:
+        except OSError as e:
             if errno_from_exception(e) != errno.ENOPROTOOPT:
                 # Hurd doesn't support SO_REUSEADDR
                 raise

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -207,18 +207,18 @@ class OptionParser:
 
         .. versionadded:: 3.1
         """
-        return dict(
-            (opt.name, opt.value())
+        return {
+            opt.name: opt.value()
             for name, opt in self._options.items()
             if not group or group == opt.group_name
-        )
+        }
 
     def as_dict(self) -> Dict[str, Any]:
         """The names and values of all options.
 
         .. versionadded:: 3.1
         """
-        return dict((opt.name, opt.value()) for name, opt in self._options.items())
+        return {opt.name: opt.value() for name, opt in self._options.items()}
 
     def define(
         self,

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -188,7 +188,7 @@ class OptionParser:
 
         .. versionadded:: 3.1
         """
-        return set(opt.group_name for opt in self._options.values())
+        return {opt.group_name for opt in self._options.values()}
 
     def group_dict(self, group: str) -> Dict[str, Any]:
         """The names and values of options in a group.

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -130,7 +130,7 @@ class Error(Exception):
     pass
 
 
-class OptionParser(object):
+class OptionParser:
     """A collection of options, a dictionary with object-like access.
 
     Normally accessed via static functions in the `tornado.options` module,
@@ -498,7 +498,7 @@ class OptionParser(object):
         return _Mockable(self)
 
 
-class _Mockable(object):
+class _Mockable:
     """`mock.patch` compatible wrapper for `OptionParser`.
 
     As of ``mock`` version 1.0.1, when an object uses ``__getattr__``
@@ -528,7 +528,7 @@ class _Mockable(object):
         setattr(self._options, name, self._originals.pop(name))
 
 
-class _Option(object):
+class _Option:
     # This class could almost be made generic, but the way the types
     # interact with the multiple argument makes this tricky. (default
     # and the callback use List[T], but type is still Type[T]).

--- a/tornado/platform/caresresolver.py
+++ b/tornado/platform/caresresolver.py
@@ -73,7 +73,7 @@ class CaresResolver(Resolver):
             )
             result, error = yield fut
             if error:
-                raise IOError(
+                raise OSError(
                     "C-Ares returned error %s: %s while resolving %s"
                     % (error, pycares.errno.strerror(error), host)
                 )
@@ -87,7 +87,7 @@ class CaresResolver(Resolver):
             else:
                 address_family = socket.AF_UNSPEC
             if family != socket.AF_UNSPEC and family != address_family:
-                raise IOError(
+                raise OSError(
                     "Requested socket family %d but got %d" % (family, address_family)
                 )
             addrinfo.append((typing.cast(int, address_family), (address, port)))

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -185,7 +185,7 @@ def task_id() -> Optional[int]:
     return _task_id
 
 
-class Subprocess(object):
+class Subprocess:
     """Wraps ``subprocess.Popen`` with IOStream support.
 
     The constructor is the same as ``subprocess.Popen`` with the following

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -328,13 +328,13 @@ class Queue(Generic[_T]):
             self._getters.popleft()
 
     def __repr__(self) -> str:
-        return "<%s at %s %s>" % (type(self).__name__, hex(id(self)), self._format())
+        return f"<{type(self).__name__} at {hex(id(self))} {self._format()}>"
 
     def __str__(self) -> str:
-        return "<%s %s>" % (type(self).__name__, self._format())
+        return f"<{type(self).__name__} {self._format()}>"
 
     def _format(self) -> str:
-        result = "maxsize=%r" % (self.maxsize,)
+        result = f"maxsize={self.maxsize!r}"
         if getattr(self, "_queue", None):
             result += " queue=%r" % self._queue
         if self._getters:

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -582,9 +582,9 @@ class PathMatches(Matcher):
         # unnamed groups, we want to use either groups
         # or groupdict but not both.
         if self.regex.groupindex:
-            path_kwargs = dict(
-                (str(k), _unquote_or_none(v)) for (k, v) in match.groupdict().items()
-            )
+            path_kwargs = {
+                str(k): _unquote_or_none(v) for (k, v) in match.groupdict().items()
+            }
         else:
             path_args = [_unquote_or_none(s) for s in match.groups()]
 

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -438,7 +438,7 @@ class ReversibleRuleRouter(ReversibleRouter, RuleRouter):
         return None
 
 
-class Rule(object):
+class Rule:
     """A routing rule."""
 
     def __init__(
@@ -487,7 +487,7 @@ class Rule(object):
         )
 
 
-class Matcher(object):
+class Matcher:
     """Represents a matcher for request features."""
 
     def match(self, request: httputil.HTTPServerRequest) -> Optional[Dict[str, Any]]:

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -478,7 +478,7 @@ class Rule:
         return self.matcher.reverse(*args)
 
     def __repr__(self) -> str:
-        return "%s(%r, %s, kwargs=%r, name=%r)" % (
+        return "{}({!r}, {}, kwargs={!r}, name={!r})".format(
             self.__class__.__name__,
             self.matcher,
             self.target,
@@ -686,7 +686,7 @@ class URLSpec(Rule):
         self.kwargs = kwargs
 
     def __repr__(self) -> str:
-        return "%s(%r, %s, kwargs=%r, name=%r)" % (
+        return "{}({!r}, {}, kwargs={!r}, name={!r})".format(
             self.__class__.__name__,
             self.regex.pattern,
             self.handler_class,

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -238,7 +238,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
         request, callback, timeout_handle = self.waiting[key]
         self.queue.remove((key, request, callback))
 
-        error_message = "Timeout {0}".format(info) if info else "Timeout"
+        error_message = f"Timeout {info}" if info else "Timeout"
         timeout_response = HTTPResponse(
             request,
             599,
@@ -399,7 +399,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             if self.request.user_agent:
                 self.request.headers["User-Agent"] = self.request.user_agent
             elif self.request.headers.get("User-Agent") is None:
-                self.request.headers["User-Agent"] = "Tornado/{}".format(version)
+                self.request.headers["User-Agent"] = f"Tornado/{version}"
             if not self.request.allow_nonstandard_methods:
                 # Some HTTP methods nearly always have bodies while others
                 # almost never do. Fail in this case unless the user has
@@ -485,7 +485,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         :info string key: More detailed timeout information.
         """
         self._timeout = None
-        error_message = "Timeout {0}".format(info) if info else "Timeout"
+        error_message = f"Timeout {info}" if info else "Timeout"
         if self.final_callback is not None:
             self._handle_exception(
                 HTTPTimeoutError, HTTPTimeoutError(error_message), None
@@ -605,7 +605,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             # Reassemble the start line.
             self.request.header_callback("%s %s %s\r\n" % first_line)
             for k, v in self.headers.get_all():
-                self.request.header_callback("%s: %s\r\n" % (k, v))
+                self.request.header_callback(f"{k}: {v}\r\n")
             self.request.header_callback("\r\n")
 
     def _should_follow_redirect(self) -> bool:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -250,9 +250,7 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
 
 
 class _HTTPConnection(httputil.HTTPMessageDelegate):
-    _SUPPORTED_METHODS = set(
-        ["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
-    )
+    _SUPPORTED_METHODS = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}
 
     def __init__(
         self,

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -318,13 +318,13 @@ class TCPClient:
             # If the user requires binding also to a specific IP/port.
             try:
                 socket_obj.bind((source_ip_bind, source_port_bind))
-            except socket.error:
+            except OSError:
                 socket_obj.close()
                 # Fail loudly if unable to use the IP/port.
                 raise
         try:
             stream = IOStream(socket_obj, max_buffer_size=max_buffer_size)
-        except socket.error as e:
+        except OSError as e:
             fu = Future()  # type: Future[IOStream]
             fu.set_exception(e)
             return stream, fu

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -38,7 +38,7 @@ if typing.TYPE_CHECKING:
 _INITIAL_CONNECT_TIMEOUT = 0.3
 
 
-class _Connector(object):
+class _Connector:
     """A stateless implementation of the "Happy Eyeballs" algorithm.
 
     "Happy Eyeballs" is documented in RFC6555 as the recommended practice
@@ -199,7 +199,7 @@ class _Connector(object):
             stream.close()
 
 
-class TCPClient(object):
+class TCPClient:
     """A non-blocking TCP connection factory.
 
     .. versionchanged:: 5.0

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -40,7 +40,7 @@ if typing.TYPE_CHECKING:
     from typing import Callable, List  # noqa: F401
 
 
-class TCPServer(object):
+class TCPServer:
     r"""A non-blocking, single-threaded TCP server.
 
     To use `TCPServer`, define a subclass which overrides the `handle_stream`

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -352,7 +352,7 @@ class TCPServer:
                     return connection.close()
                 else:
                     raise
-            except socket.error as err:
+            except OSError as err:
                 # If the connection is closed immediately after it is created
                 # (as in a port scan), we can get one of several errors.
                 # wrap_socket makes an internal call to getpeername,

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -936,10 +936,10 @@ def _parse(
 
         # Intermediate ("else", "elif", etc) blocks
         intermediate_blocks = {
-            "else": set(["if", "for", "while", "try"]),
-            "elif": set(["if"]),
-            "except": set(["try"]),
-            "finally": set(["try"]),
+            "else": {"if", "for", "while", "try"},
+            "elif": {"if"},
+            "except": {"try"},
+            "finally": {"try"},
         }
         allowed_parents = intermediate_blocks.get(operator)
         if allowed_parents is not None:
@@ -1038,7 +1038,7 @@ def _parse(
         elif operator in ("break", "continue"):
             if not in_loop:
                 reader.raise_parse_error(
-                    "%s outside %s block" % (operator, set(["for", "while"]))
+                    "%s outside %s block" % (operator, {"for", "while"})
                 )
             body.chunks.append(_Statement(contents, line))
             continue

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -610,7 +610,7 @@ class _ApplyBlock(_Node):
             self.body.generate(writer)
             writer.write_line("return _tt_utf8('').join(_tt_buffer)", self.line)
         writer.write_line(
-            "_tt_append(_tt_utf8(%s(%s())))" % (self.method, method_name), self.line
+            f"_tt_append(_tt_utf8({self.method}({method_name}())))", self.line
         )
 
 
@@ -944,12 +944,10 @@ def _parse(
         allowed_parents = intermediate_blocks.get(operator)
         if allowed_parents is not None:
             if not in_block:
-                reader.raise_parse_error(
-                    "%s outside %s block" % (operator, allowed_parents)
-                )
+                reader.raise_parse_error(f"{operator} outside {allowed_parents} block")
             if in_block not in allowed_parents:
                 reader.raise_parse_error(
-                    "%s block cannot be attached to %s block" % (operator, in_block)
+                    f"{operator} block cannot be attached to {in_block} block"
                 )
             body.chunks.append(_IntermediateControlBlock(contents, line))
             continue
@@ -1038,7 +1036,7 @@ def _parse(
         elif operator in ("break", "continue"):
             if not in_loop:
                 reader.raise_parse_error(
-                    "%s outside %s block" % (operator, {"for", "while"})
+                    "{} outside {} block".format(operator, {"for", "while"})
                 )
             body.chunks.append(_Statement(contents, line))
             continue

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -249,7 +249,7 @@ def filter_whitespace(mode: str, text: str) -> str:
         raise Exception("invalid whitespace mode %s" % mode)
 
 
-class Template(object):
+class Template:
     """A compiled template.
 
     We compile into Python from the given template_string. You can generate
@@ -389,7 +389,7 @@ class Template(object):
         return ancestors
 
 
-class BaseLoader(object):
+class BaseLoader:
     """Base class for template loaders.
 
     You must use a template loader to use template constructs like
@@ -500,7 +500,7 @@ class DictLoader(BaseLoader):
         return Template(self.dict[name], name=name, loader=self)
 
 
-class _Node(object):
+class _Node:
     def each_child(self) -> Iterable["_Node"]:
         return ()
 
@@ -720,7 +720,7 @@ class ParseError(Exception):
         return "%s at %s:%d" % (self.message, self.filename, self.lineno)
 
 
-class _CodeWriter(object):
+class _CodeWriter:
     def __init__(
         self,
         file: TextIO,
@@ -740,7 +740,7 @@ class _CodeWriter(object):
         return self._indent
 
     def indent(self) -> "ContextManager":
-        class Indenter(object):
+        class Indenter:
             def __enter__(_) -> "_CodeWriter":
                 self._indent += 1
                 return self
@@ -755,7 +755,7 @@ class _CodeWriter(object):
         self.include_stack.append((self.current_template, line))
         self.current_template = template
 
-        class IncludeTemplate(object):
+        class IncludeTemplate:
             def __enter__(_) -> "_CodeWriter":
                 return self
 
@@ -778,7 +778,7 @@ class _CodeWriter(object):
         print("    " * indent + line + line_comment, file=self.file)
 
 
-class _TemplateReader(object):
+class _TemplateReader:
     def __init__(self, name: str, text: str, whitespace: str) -> None:
         self.name = name
         self.text = text

--- a/tornado/test/circlerefs_test.py
+++ b/tornado/test/circlerefs_test.py
@@ -105,7 +105,7 @@ def assert_no_cycle_garbage():
 class CircleRefsTest(unittest.TestCase):
     def test_known_leak(self):
         # Construct a known leak scenario to make sure the test harness works.
-        class C(object):
+        class C:
             def __init__(self, name):
                 self.name = name
                 self.a: typing.Optional[C] = None
@@ -199,7 +199,7 @@ class CircleRefsTest(unittest.TestCase):
 
         with concurrent.futures.ThreadPoolExecutor(1) as thread_pool:
 
-            class Factory(object):
+            class Factory:
                 executor = thread_pool
 
                 @tornado.concurrent.run_on_executor

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -94,7 +94,7 @@ class CapError(Exception):
     pass
 
 
-class BaseCapClient(object):
+class BaseCapClient:
     def __init__(self, port):
         self.port = port
 
@@ -124,7 +124,7 @@ class GeneratorCapClient(BaseCapClient):
         raise gen.Return(self.process_response(data))
 
 
-class ClientTestMixin(object):
+class ClientTestMixin:
     client_class = None  # type: typing.Callable
 
     def setUp(self):
@@ -174,7 +174,7 @@ class GeneratorClientTest(ClientTestMixin, AsyncTestCase):
 class RunOnExecutorTest(AsyncTestCase):
     @gen_test
     def test_no_calling(self):
-        class Object(object):
+        class Object:
             def __init__(self):
                 self.executor = futures.thread.ThreadPoolExecutor(1)
 
@@ -188,7 +188,7 @@ class RunOnExecutorTest(AsyncTestCase):
 
     @gen_test
     def test_call_with_no_args(self):
-        class Object(object):
+        class Object:
             def __init__(self):
                 self.executor = futures.thread.ThreadPoolExecutor(1)
 
@@ -202,7 +202,7 @@ class RunOnExecutorTest(AsyncTestCase):
 
     @gen_test
     def test_call_with_executor(self):
-        class Object(object):
+        class Object:
             def __init__(self):
                 self.__executor = futures.thread.ThreadPoolExecutor(1)
 
@@ -216,7 +216,7 @@ class RunOnExecutorTest(AsyncTestCase):
 
     @gen_test
     def test_async_await(self):
-        class Object(object):
+        class Object:
             def __init__(self):
                 self.executor = futures.thread.ThreadPoolExecutor(1)
 

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -51,13 +51,9 @@ class DigestAuthHandler(RequestHandler):
             assert param_dict["nonce"] == nonce
             assert param_dict["username"] == self.username
             assert param_dict["uri"] == self.request.path
-            h1 = md5(
-                utf8("%s:%s:%s" % (self.username, realm, self.password))
-            ).hexdigest()
-            h2 = md5(
-                utf8("%s:%s" % (self.request.method, self.request.path))
-            ).hexdigest()
-            digest = md5(utf8("%s:%s:%s" % (h1, nonce, h2))).hexdigest()
+            h1 = md5(utf8(f"{self.username}:{realm}:{self.password}")).hexdigest()
+            h2 = md5(utf8(f"{self.request.method}:{self.request.path}")).hexdigest()
+            digest = md5(utf8(f"{h1}:{nonce}:{h2}")).hexdigest()
             if digest == param_dict["response"]:
                 self.write("ok")
             else:
@@ -66,7 +62,7 @@ class DigestAuthHandler(RequestHandler):
             self.set_status(401)
             self.set_header(
                 "WWW-Authenticate",
-                'Digest realm="%s", nonce="%s", opaque="%s"' % (realm, nonce, opaque),
+                f'Digest realm="{realm}", nonce="{nonce}", opaque="{opaque}"',
             )
 
 

--- a/tornado/test/escape_test.py
+++ b/tornado/test/escape_test.py
@@ -247,7 +247,7 @@ class EscapeTestCase(unittest.TestCase):
     def test_url_escape_unicode(self):
         tests = [
             # byte strings are passed through as-is
-            ("\u00e9".encode("utf8"), "%C3%A9"),
+            ("\u00e9".encode(), "%C3%A9"),
             ("\u00e9".encode("latin1"), "%E9"),
             # unicode strings become utf8
             ("\u00e9", "%C3%A9"),

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -853,7 +853,7 @@ class WaitIteratorTest(AsyncTestCase):
                     "WaitIterator dict status incorrect",
                 )
             else:
-                self.fail("got bad WaitIterator index {}".format(dg.current_index))
+                self.fail(f"got bad WaitIterator index {dg.current_index}")
 
             i += 1
         self.assertIsNone(g.current_index, "bad nil current index")

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -581,7 +581,7 @@ class GenCoroutineTest(AsyncTestCase):
         # without waiting for garbage collection.
         @gen.coroutine
         def inner():
-            class Foo(object):
+            class Foo:
                 pass
 
             local_var = Foo()

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -146,7 +146,7 @@ class InvalidGzipHandler(RequestHandler):
         # Triggering the potential bug seems to depend on input length.
         # This length is taken from the bad-response example reported in
         # https://github.com/tornadoweb/tornado/pull/2875 (uncompressed).
-        text = "".join("Hello World {}\n".format(i) for i in range(9000))[:149051]
+        text = "".join(f"Hello World {i}\n" for i in range(9000))[:149051]
         body = gzip.compress(text.encode(), compresslevel=6) + b"\00"
         self.write(body)
 
@@ -701,7 +701,7 @@ X-XSS-Protection: 1;
         self.assertLess(abs(response.start_time - start_time), 1.0)
 
         for k, v in response.time_info.items():
-            self.assertTrue(0 <= v < 1.0, "time_info[%s] out of bounds: %s" % (k, v))
+            self.assertTrue(0 <= v < 1.0, f"time_info[{k}] out of bounds: {v}")
 
     def test_zero_timeout(self):
         response = self.fetch("/hello", connect_timeout=0)

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -115,7 +115,7 @@ class BaseSSLTest(AsyncHTTPSTestCase):
         return Application([("/", HelloWorldRequestHandler, dict(protocol="https"))])
 
 
-class SSLTestMixin(object):
+class SSLTestMixin:
     def get_ssl_options(self):
         return dict(
             ssl_version=self.get_ssl_version(),

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -380,7 +380,7 @@ class TypeCheckHandler(RequestHandler):
     def check_type(self, name, obj, expected_type):
         actual_type = type(obj)
         if expected_type != actual_type:
-            self.errors[name] = "expected %s, got %s" % (expected_type, actual_type)
+            self.errors[name] = f"expected {expected_type}, got {actual_type}"
 
 
 class PostEchoHandler(RequestHandler):

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -282,13 +282,11 @@ class HTTPConnectionTest(AsyncHTTPTestCase):
                 [
                     b"Content-Disposition: form-data; name=argument",
                     b"",
-                    "\u00e1".encode("utf-8"),
+                    "\u00e1".encode(),
                     b"--1234567890",
-                    'Content-Disposition: form-data; name="files"; filename="\u00f3"'.encode(
-                        "utf8"
-                    ),
+                    'Content-Disposition: form-data; name="files"; filename="\u00f3"'.encode(),
                     b"",
-                    "\u00fa".encode("utf-8"),
+                    "\u00fa".encode(),
                     b"--1234567890--",
                     b"",
                 ]

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -265,7 +265,7 @@ class TestIOLoop(AsyncTestCase):
         # Use a socket since they are supported by IOLoop on all platforms.
         # Unfortunately, sockets don't support the .closed attribute for
         # inspecting their close status, so we must use a wrapper.
-        class SocketWrapper(object):
+        class SocketWrapper:
             def __init__(self, sockobj):
                 self.sockobj = sockobj
                 self.closed = False

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -57,7 +57,7 @@ class HelloHandler(RequestHandler):
         self.write("Hello")
 
 
-class TestIOStreamWebMixin(object):
+class TestIOStreamWebMixin:
     def _make_client_iostream(self):
         raise NotImplementedError()
 
@@ -177,7 +177,7 @@ class TestIOStreamWebMixin(object):
             stream.read_bytes(1)
 
 
-class TestReadWriteMixin(object):
+class TestReadWriteMixin:
     # Tests where one stream reads and the other writes.
     # These should work for BaseIOStream implementations.
 

--- a/tornado/test/log_test.py
+++ b/tornado/test/log_test.py
@@ -89,7 +89,7 @@ class LogFormatterTest(unittest.TestCase):
 
     def test_utf8_logging(self):
         with ignore_bytes_warning():
-            self.logger.error("\u00e9".encode("utf8"))
+            self.logger.error("\u00e9".encode())
         if issubclass(bytes, basestring_type):
             # on python 2, utf8 byte strings (and by extension ascii byte
             # strings) are passed through as-is.

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -30,7 +30,7 @@ else:
     from tornado.platform.caresresolver import CaresResolver
 
 
-class _ResolverTestMixin(object):
+class _ResolverTestMixin:
     resolver = None  # type: typing.Any
 
     @gen_test
@@ -48,7 +48,7 @@ class _ResolverTestMixin(object):
 
 # It is impossible to quickly and consistently generate an error in name
 # resolution, so test this case separately, using mocks as needed.
-class _ResolverErrorTestMixin(object):
+class _ResolverErrorTestMixin:
     resolver = None  # type: typing.Any
 
     @gen_test

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
     from typing import List  # noqa: F401
 
 
-class Email(object):
+class Email:
     def __init__(self, value):
         if isinstance(value, str) and "@" in value:
             self._value = value

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -135,7 +135,7 @@ class OptionsTest(unittest.TestCase):
     def test_iter(self):
         options = self._sample_options()
         # OptionParsers always define 'help'.
-        self.assertEqual(set(["a", "b", "help"]), set(iter(options)))
+        self.assertEqual({"a", "b", "help"}, set(iter(options)))
 
     def test_getitem(self):
         options = self._sample_options()
@@ -166,7 +166,7 @@ class OptionsTest(unittest.TestCase):
 
         frame = sys._getframe(0)
         this_file = frame.f_code.co_filename
-        self.assertEqual(set(["b_group", "", this_file]), options.groups())
+        self.assertEqual({"b_group", "", this_file}, options.groups())
 
         b_group_dict = options.group_dict("b_group")
         self.assertEqual({"b": 2}, b_group_dict)

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -68,7 +68,7 @@ def test_runner_factory(stderr):
         def run(self, test):
             result = super().run(test)
             if result.skipped:
-                skip_reasons = set(reason for (test, reason) in result.skipped)
+                skip_reasons = {reason for (test, reason) in result.skipped}
                 self.stream.write(  # type: ignore
                     textwrap.fill(
                         "Some tests were skipped because: %s"

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -215,14 +215,14 @@ class SimpleHTTPClientTestMixin:
             self.triggers.popleft()()
             self.triggers.popleft()()
             self.wait(condition=lambda: (len(self.triggers) == 2 and len(seen) == 2))
-            self.assertEqual(set(seen), set([0, 1]))
+            self.assertEqual(set(seen), {0, 1})
             self.assertEqual(len(client.queue), 0)
 
             # Finish all the pending requests
             self.triggers.popleft()()
             self.triggers.popleft()()
             self.wait(condition=lambda: len(seen) == 4)
-            self.assertEqual(set(seen), set([0, 1, 2, 3]))
+            self.assertEqual(set(seen), {0, 1, 2, 3})
             self.assertEqual(len(self.triggers), 0)
 
     @gen_test

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -142,7 +142,7 @@ class RespondInPrepareHandler(RequestHandler):
         self.finish("forbidden")
 
 
-class SimpleHTTPClientTestMixin(object):
+class SimpleHTTPClientTestMixin:
     def create_client(self, **kwargs):
         raise NotImplementedError()
 

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -251,7 +251,7 @@ class SimpleHTTPClientTestMixin:
     def test_default_user_agent(self: typing.Any):
         response = self.fetch("/user_agent", method="GET")
         self.assertEqual(200, response.code)
-        self.assertEqual(response.body.decode(), "Tornado/{}".format(version))
+        self.assertEqual(response.body.decode(), f"Tornado/{version}")
 
     def test_see_other_redirect(self: typing.Any):
         for code in (302, 303):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -197,7 +197,7 @@ class TestConnectorSplit(unittest.TestCase):
 
 
 class ConnectorTest(AsyncTestCase):
-    class FakeStream(object):
+    class FakeStream:
         def __init__(self):
             self.closed = False
 

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -83,7 +83,7 @@ class TCPClientTest(AsyncTestCase):
         # The port used here doesn't matter, but some systems require it
         # to be non-zero if we do not also pass AI_PASSIVE.
         addrinfo = self.io_loop.run_sync(lambda: Resolver().resolve("localhost", 80))
-        families = set(addr[0] for addr in addrinfo)
+        families = {addr[0] for addr in addrinfo}
         if socket.AF_INET6 not in families:
             self.skipTest("localhost does not resolve to ipv6")
 

--- a/tornado/test/tcpserver_test.py
+++ b/tornado/test/tcpserver_test.py
@@ -93,7 +93,7 @@ class TCPServerTest(AsyncTestCase):
         def connect(c):
             try:
                 yield c.connect(server_addr)
-            except EnvironmentError:
+            except OSError:
                 pass
             else:
                 connected_clients.append(c)

--- a/tornado/test/util.py
+++ b/tornado/test/util.py
@@ -48,7 +48,7 @@ def _detect_ipv6():
     try:
         sock = socket.socket(socket.AF_INET6)
         sock.bind(("::1", 0))
-    except socket.error:
+    except OSError:
         return False
     finally:
         if sock is not None:

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1151,7 +1151,7 @@ class StaticFileTest(WebTestCase):
         # make sure the uncompressed file still has the correct type
         response = self.fetch("/static/sample.xml")
         self.assertIn(
-            response.headers.get("Content-Type"), set(("text/xml", "application/xml"))
+            response.headers.get("Content-Type"), {"text/xml", "application/xml"}
         )
 
     def test_static_url(self):
@@ -2937,7 +2937,7 @@ class XSRFTest(SimpleHandlerTestCase):
 
     def test_refresh_token(self):
         token = self.xsrf_token
-        tokens_seen = set([token])
+        tokens_seen = {token}
         # A user's token is stable over time.  Refreshing the page in one tab
         # might update the cookie while an older tab still has the old cookie
         # in its DOM.  Simulate this scenario by passing a constant token

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2422,7 +2422,7 @@ class BaseFlowControlHandler(RequestHandler):
         self.write(dict(methods=self.methods))
 
 
-class BaseStreamingRequestFlowControlTest(object):
+class BaseStreamingRequestFlowControlTest:
     def get_httpserver_options(self):
         # Use a small chunk size so flow control is relevant even though
         # all the data arrives at once.

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -158,7 +158,7 @@ class SecureCookieV1Test(unittest.TestCase):
         )
         # tamper with the cookie
         handler._cookies["foo"] = utf8(
-            "1234|5678%s|%s" % (to_basestring(timestamp), to_basestring(sig))
+            f"1234|5678{to_basestring(timestamp)}|{to_basestring(sig)}"
         )
         # it gets rejected
         with ExpectLog(gen_log, "Cookie timestamp in future"):
@@ -625,7 +625,7 @@ class TypeCheckHandler(RequestHandler):
     def check_type(self, name, obj, expected_type):
         actual_type = type(obj)
         if expected_type != actual_type:
-            self.errors[name] = "expected %s, got %s" % (expected_type, actual_type)
+            self.errors[name] = f"expected {expected_type}, got {actual_type}"
 
 
 class DecodeArgHandler(RequestHandler):
@@ -1511,7 +1511,7 @@ class CustomStaticFileTest(WebTestCase):
                 extension_index = path.rindex(".")
                 before_version = path[:extension_index]
                 after_version = path[(extension_index + 1) :]
-                return "/static/%s.%s.%s" % (
+                return "/static/{}.{}.{}".format(
                     before_version,
                     version_hash,
                     after_version,
@@ -1520,7 +1520,7 @@ class CustomStaticFileTest(WebTestCase):
             def parse_url_path(self, url_path):
                 extension_index = url_path.rindex(".")
                 version_index = url_path.rindex(".", 0, extension_index)
-                return "%s%s" % (url_path[:version_index], url_path[extension_index:])
+                return f"{url_path[:version_index]}{url_path[extension_index:]}"
 
             @classmethod
             def get_absolute_path(cls, settings, path):
@@ -1976,11 +1976,11 @@ class UIMethodUIModuleTest(SimpleHandlerTestCase):
 
     def get_app_kwargs(self):
         def my_ui_method(handler, x):
-            return "In my_ui_method(%s) with handler value %s." % (x, handler.value())
+            return f"In my_ui_method({x}) with handler value {handler.value()}."
 
         class MyModule(UIModule):
             def render(self, x):
-                return "In MyModule(%s) with handler value %s." % (
+                return "In MyModule({}) with handler value {}.".format(
                     x,
                     typing.cast(UIMethodUIModuleTest.Handler, self.handler).value(),
                 )
@@ -2038,7 +2038,7 @@ class SetLazyPropertiesTest(SimpleHandlerTestCase):
             raise NotImplementedError()
 
         def get(self):
-            self.write("Hello %s (%s)" % (self.current_user, self.locale.code))
+            self.write(f"Hello {self.current_user} ({self.locale.code})")
 
     def test_set_properties(self):
         # Ensure that current_user can be assigned to normally for apps
@@ -2400,7 +2400,7 @@ class BaseFlowControlHandler(RequestHandler):
     @contextlib.contextmanager
     def in_method(self, method):
         if self.method is not None:
-            self.test.fail("entered method %s while in %s" % (method, self.method))
+            self.test.fail(f"entered method {method} while in {self.method}")
         self.method = method
         self.methods.append(method)
         try:

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -570,7 +570,7 @@ class WebSocketTest(WebSocketBaseTestCase):
         # server is only running on ipv4. Test for this edge case and skip
         # the test if it happens.
         addrinfo = yield Resolver().resolve("localhost", port)
-        families = set(addr[0] for addr in addrinfo)
+        families = {addr[0] for addr in addrinfo}
         if socket.AF_INET not in families:
             self.skipTest("localhost does not resolve to ipv4")
             return

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -661,7 +661,7 @@ class WebSocketNativeCoroutineTest(WebSocketBaseTestCase):
         self.assertEqual(res, "hello2")
 
 
-class CompressionTestMixin(object):
+class CompressionTestMixin:
     MESSAGE = "Hello world. Testing 123 123"
 
     def get_app(self):
@@ -766,7 +766,7 @@ class DefaultCompressionTest(CompressionTestMixin, WebSocketBaseTestCase):
         self.assertEqual(bytes_out, bytes_in + 12)
 
 
-class MaskFunctionMixin(object):
+class MaskFunctionMixin:
     # Subclasses should define self.mask(mask, data)
     def mask(self, mask: bytes, data: bytes) -> bytes:
         raise NotImplementedError()

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -466,7 +466,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
 
     def get_url(self, path: str) -> str:
         """Returns an absolute url for the given path on the test server."""
-        return "%s://127.0.0.1:%s%s" % (self.get_protocol(), self.get_http_port(), path)
+        return f"{self.get_protocol()}://127.0.0.1:{self.get_http_port()}{path}"
 
     def tearDown(self) -> None:
         self.http_server.stop()

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -65,7 +65,7 @@ class ObjectDict(Dict[str, Any]):
         self[name] = value
 
 
-class GzipDecompressor(object):
+class GzipDecompressor:
     """Streaming gzip decompressor.
 
     The interface is like that of `zlib.decompressobj` (without some of the
@@ -201,7 +201,7 @@ def re_unescape(s: str) -> str:
     return _re_unescape_pattern.sub(_re_unescape_replacement, s)
 
 
-class Configurable(object):
+class Configurable:
     """Base class for configurable interfaces.
 
     A configurable interface is an (abstract) class whose constructor
@@ -336,7 +336,7 @@ class Configurable(object):
         base.__impl_kwargs = saved[1]
 
 
-class ArgReplacer(object):
+class ArgReplacer:
     """Replaces one value in an ``args, kwargs`` pair.
 
     Inspects the function signature to find an argument by name

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -252,7 +252,7 @@ class Configurable:
         if impl.configurable_base() is not base:
             # The impl class is itself configurable, so recurse.
             return impl(*args, **init_kwargs)
-        instance = super(Configurable, cls).__new__(impl)
+        instance = super().__new__(impl)
         # initialize vs __init__ chosen for compatibility with AsyncHTTPClient
         # singleton magic.  If we get rid of that we can switch to __init__
         # here too.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -608,7 +608,7 @@ class RequestHandler:
             return _unicode(value)
         except UnicodeDecodeError:
             raise HTTPError(
-                400, "Invalid unicode in %s: %r" % (name or "url", value[:40])
+                400, "Invalid unicode in {}: {!r}".format(name or "url", value[:40])
             )
 
     @property
@@ -671,7 +671,7 @@ class RequestHandler:
         value = escape.native_str(value)
         if re.search(r"[\x00-\x20]", name + value):
             # Don't let us accidentally inject bad stuff
-            raise ValueError("Invalid cookie %r: %r" % (name, value))
+            raise ValueError(f"Invalid cookie {name!r}: {value!r}")
         if not hasattr(self, "_new_cookie"):
             self._new_cookie = (
                 http.cookies.SimpleCookie()
@@ -1859,7 +1859,7 @@ class RequestHandler:
         self.application.log_request(self)
 
     def _request_summary(self) -> str:
-        return "%s %s (%s)" % (
+        return "{} {} ({})".format(
             self.request.method,
             self.request.uri,
             self.request.remote_ip,
@@ -2758,7 +2758,7 @@ class StaticFileHandler(RequestHandler):
                 # and less than the first-byte-pos.
                 self.set_status(416)  # Range Not Satisfiable
                 self.set_header("Content-Type", "text/plain")
-                self.set_header("Content-Range", "bytes */%s" % (size,))
+                self.set_header("Content-Range", f"bytes */{size}")
                 return
             if end is not None and end > size:
                 # Clients sometimes blindly use a large range to limit their
@@ -2812,7 +2812,7 @@ class StaticFileHandler(RequestHandler):
         version_hash = self._get_cached_version(self.absolute_path)
         if not version_hash:
             return None
-        return '"%s"' % (version_hash,)
+        return f'"{version_hash}"'
 
     def set_headers(self) -> None:
         """Sets the content and caching headers on the response.
@@ -3111,7 +3111,7 @@ class StaticFileHandler(RequestHandler):
         if not version_hash:
             return url
 
-        return "%s?v=%s" % (url, version_hash)
+        return f"{url}?v={version_hash}"
 
     def parse_url_path(self, url_path: str) -> str:
         """Converts a static URL path into a filesystem path.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1788,9 +1788,9 @@ class RequestHandler:
             if self.request.method not in self.SUPPORTED_METHODS:
                 raise HTTPError(405)
             self.path_args = [self.decode_argument(arg) for arg in args]
-            self.path_kwargs = dict(
-                (k, self.decode_argument(v, name=k)) for (k, v) in kwargs.items()
-            )
+            self.path_kwargs = {
+                k: self.decode_argument(v, name=k) for (k, v) in kwargs.items()
+            }
             # If XSRF cookies are turned on, reject form submissions without
             # the proper cookie
             if self.request.method not in (
@@ -2275,7 +2275,7 @@ class Application(ReversibleRouter):
 
     def _load_ui_methods(self, methods: Any) -> None:
         if isinstance(methods, types.ModuleType):
-            self._load_ui_methods(dict((n, getattr(methods, n)) for n in dir(methods)))
+            self._load_ui_methods({n: getattr(methods, n) for n in dir(methods)})
         elif isinstance(methods, list):
             for m in methods:
                 self._load_ui_methods(m)
@@ -2290,7 +2290,7 @@ class Application(ReversibleRouter):
 
     def _load_ui_modules(self, modules: Any) -> None:
         if isinstance(modules, types.ModuleType):
-            self._load_ui_modules(dict((n, getattr(modules, n)) for n in dir(modules)))
+            self._load_ui_modules({n: getattr(modules, n) for n in dir(modules)})
         elif isinstance(modules, list):
             for m in modules:
                 self._load_ui_modules(m)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -3224,17 +3224,15 @@ class GZipContentEncoding(OutputTransform):
 
     # Whitelist of compressible mime types (in addition to any types
     # beginning with "text/").
-    CONTENT_TYPES = set(
-        [
-            "application/javascript",
-            "application/x-javascript",
-            "application/xml",
-            "application/atom+xml",
-            "application/json",
-            "application/xhtml+xml",
-            "image/svg+xml",
-        ]
-    )
+    CONTENT_TYPES = {
+        "application/javascript",
+        "application/x-javascript",
+        "application/xml",
+        "application/atom+xml",
+        "application/json",
+        "application/xhtml+xml",
+        "image/svg+xml",
+    }
     # Python's GzipFile defaults to level 9, while most other gzip
     # tools (including gzip itself) default to 6, which is probably a
     # better CPU/size tradeoff.

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -176,7 +176,7 @@ class _ArgDefaultMarker:
 _ARG_DEFAULT = _ArgDefaultMarker()
 
 
-class RequestHandler(object):
+class RequestHandler:
     """Base class for HTTP request handlers.
 
     Subclasses must define at least one of the methods defined in the
@@ -3187,7 +3187,7 @@ class FallbackHandler(RequestHandler):
         self.on_finish()
 
 
-class OutputTransform(object):
+class OutputTransform:
     """A transform modifies the result of an HTTP request (e.g., GZip encoding)
 
     Applications are not expected to create their own OutputTransforms
@@ -3339,7 +3339,7 @@ def authenticated(
     return wrapper
 
 
-class UIModule(object):
+class UIModule:
     """A re-usable, modular UI unit on a page.
 
     UI modules often execute additional queries, and they can include
@@ -3487,7 +3487,7 @@ class TemplateModule(UIModule):
         return "".join(self._get_resources("html_body"))
 
 
-class _UIModuleNamespace(object):
+class _UIModuleNamespace:
     """Lazy namespace which creates UIModule proxies bound to a handler."""
 
     def __init__(

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -212,7 +212,7 @@ class WebSocketHandler(tornado.web.RequestHandler):
         self,
         application: tornado.web.Application,
         request: httputil.HTTPServerRequest,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         super().__init__(application, request, **kwargs)
         self.ws_connection = None  # type: Optional[WebSocketProtocol]
@@ -1015,7 +1015,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             max_message_size=self.params.max_message_size,
             **self._get_compressor_options(
                 other_side, agreed_parameters, compression_options
-            )
+            ),
         )
 
     def _write_frame(

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -115,7 +115,7 @@ class _DecompressTooLargeError(Exception):
     pass
 
 
-class _WebSocketParams(object):
+class _WebSocketParams:
     def __init__(
         self,
         ping_interval: Optional[float] = None,
@@ -698,7 +698,7 @@ class WebSocketProtocol(abc.ABC):
         raise NotImplementedError()
 
 
-class _PerMessageDeflateCompressor(object):
+class _PerMessageDeflateCompressor:
     def __init__(
         self,
         persistent: bool,
@@ -746,7 +746,7 @@ class _PerMessageDeflateCompressor(object):
         return data[:-4]
 
 
-class _PerMessageDeflateDecompressor(object):
+class _PerMessageDeflateDecompressor:
     def __init__(
         self,
         persistent: bool,

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -998,14 +998,12 @@ class WebSocketProtocol13(WebSocketProtocol):
         compression_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         # TODO: handle invalid parameters gracefully
-        allowed_keys = set(
-            [
-                "server_no_context_takeover",
-                "client_no_context_takeover",
-                "server_max_window_bits",
-                "client_max_window_bits",
-            ]
-        )
+        allowed_keys = {
+            "server_no_context_takeover",
+            "client_no_context_takeover",
+            "server_max_window_bits",
+            "client_max_window_bits",
+        }
         for key in agreed_parameters:
             if key not in allowed_keys:
                 raise ValueError("unsupported compression parameter %r" % key)

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -56,7 +56,7 @@ def to_wsgi_str(s: bytes) -> str:
     return s.decode("latin1")
 
 
-class WSGIContainer(object):
+class WSGIContainer:
     r"""Makes a WSGI-compatible application runnable on Tornado's HTTP server.
 
     .. warning::

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -185,7 +185,7 @@ class WSGIContainer:
         status_code_str, reason = data["status"].split(" ", 1)
         status_code = int(status_code_str)
         headers = data["headers"]  # type: List[Tuple[str, str]]
-        header_set = set(k.lower() for (k, v) in headers)
+        header_set = {k.lower() for (k, v) in headers}
         body = escape.utf8(body)
         if status_code != 304:
             if "content-length" not in header_set:

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -38,7 +38,7 @@ from tornado import httputil
 from tornado.ioloop import IOLoop
 from tornado.log import access_log
 
-from typing import List, Tuple, Optional, Callable, Any, Dict, Text
+from typing import List, Tuple, Optional, Callable, Any, Dict
 from types import TracebackType
 import typing
 
@@ -204,7 +204,7 @@ class WSGIContainer:
         request.connection.finish()
         self._log(status_code, request)
 
-    def environ(self, request: httputil.HTTPServerRequest) -> Dict[Text, Any]:
+    def environ(self, request: httputil.HTTPServerRequest) -> Dict[str, Any]:
         """Converts a `tornado.httputil.HTTPServerRequest` to a WSGI environment.
 
         .. versionchanged:: 6.3


### PR DESCRIPTION
Adopt various new language features throughout the codebase. These changes are all automated by pyupgrade, but I had to modify pyupgrade to disable a change that was incorrect (it wanted to remove a call to `str.encode` which was used for its side effect to avoid import deadlocks), and to split things up into multiple commits for easier review. The last commit, which converts to fstrings, required running pyupgrade in two passes.

Closes #3391