### PR TITLE
Add support for binding Unix sockets in Linux's abstract namespace.

### DIFF
--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -209,6 +209,9 @@ if hasattr(socket, "AF_UNIX"):
                 # Hurd doesn't support SO_REUSEADDR
                 raise
         sock.setblocking(False)
+        # File names comprising of an initial null-byte denote an abstract
+        # namespace, on Linux, and therefore are not subject to file system
+        # orientated processing.
         if not file.startswith("\0"):
             try:
                 st = os.stat(file)

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -209,17 +209,20 @@ if hasattr(socket, "AF_UNIX"):
                 # Hurd doesn't support SO_REUSEADDR
                 raise
         sock.setblocking(False)
-        try:
-            st = os.stat(file)
-        except FileNotFoundError:
-            pass
-        else:
-            if stat.S_ISSOCK(st.st_mode):
-                os.remove(file)
+        if not file.startswith("\0"):
+            try:
+                st = os.stat(file)
+            except FileNotFoundError:
+                pass
             else:
-                raise ValueError("File %s exists and is not a socket", file)
-        sock.bind(file)
-        os.chmod(file, mode)
+                if stat.S_ISSOCK(st.st_mode):
+                    os.remove(file)
+                else:
+                    raise ValueError("File %s exists and is not a socket", file)
+            sock.bind(file)
+            os.chmod(file, mode)
+        else:
+            sock.bind(file)
         sock.listen(backlog)
         return sock
 


### PR DESCRIPTION
Linux offers an "abstract namespace" for Unix sockets, distinguished by the address comprising an initial null byte. Specifying a `file` argument describing an abstract namespace  address to `netutil.bind_unix_socket(…)` fails as a consequence of the additional, file-system orientated, processing performed: https://github.com/tornadoweb/tornado/blob/bdfc017c66817359158185561cee7878680cd841/tornado/netutil.py#L212-L222 The proposed changes avoid performing the file-system orientated processing for abstract namespace addresses.