### PR TITLE
Support ThreadPoolExecutor to serve simultaneous sync requests

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -262,10 +262,10 @@ class FinalReturnTest(WebTestCase):
         self.assertIsInstance(self.final_return, Future)
         self.assertTrue(self.final_return.done())
 
-    def test_render_method_return_future(self):
+    def test_render_method_return_none(self):
         response = self.fetch(self.get_url("/render"))
         self.assertEqual(response.code, 200)
-        self.assertIsInstance(self.final_return, Future)
+        self.assertTrue(self.final_return is None)
 
 
 class CookieTest(WebTestCase):


### PR DESCRIPTION
I know tornado is meant to be used as an async webserver. But perhaps due to hype or whatever reason, people has used it as a sync webserver. That's exactly my case, I have a project that runs on tornado, but uses mongoengine (async mongo ORM) to connect to the db. There is a lot of code to refactor so it is not really viable.

Now we are starting to feel the drawbacks, as our code is about 60% of the time idling waiting IO (in blocking sync). A good solution would have been to use wsgi to spawn some thread workers, but as tornado 6 it is no longer supported. So this fork allows to process several sync requests in OS-threads workers. It achieves that by passing a ThreadPoolExecutor to the Application object when created. It detects sync code and runs it with `IOLoop.current().run_in_executor()`.

I also think that this approach enforces a better separation of responsibility in the code, what makes it in general a better code.

```
return tornado.web.Application(
        ...
        tornado_workers_executor=ThreadPoolExecutor(4, 'tornado_workers_executor')
    )
```

The bigger change that comes with this is that you should NEVER call self.finish() in your code. You should just set the following to prevent further response modifications:

self._finished = True