### PR TITLE
setup: Simplify build of abi3 wheels and add tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-15]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18
 
+      - name: Audit ABI3 compliance
+        # This may be moved into cibuildwheel itself in the future. See
+        # https://github.com/pypa/cibuildwheel/issues/1342
+        run: "pip install abi3audit && abi3audit --verbose --summary ./wheelhouse/*.whl"
+
       - uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,6 @@ import os
 import platform
 import setuptools
 
-try:
-    import wheel.bdist_wheel
-except ImportError:
-    wheel = None
-
 
 kwargs = {}
 
@@ -56,17 +51,7 @@ if (
         )
     ]
 
-if wheel is not None:
-    # From https://github.com/joerick/python-abi3-package-sample/blob/main/setup.py
-    class bdist_wheel_abi3(wheel.bdist_wheel.bdist_wheel):
-        def get_tag(self):
-            python, abi, plat = super().get_tag()
-
-            if python.startswith("cp"):
-                return "cp39", "abi3", plat
-            return python, abi, plat
-
-    kwargs["cmdclass"] = {"bdist_wheel": bdist_wheel_abi3}
+    kwargs["options"] = {"bdist_wheel": {"py_limited_api": "cp39"}}
 
 
 setuptools.setup(


### PR DESCRIPTION
Our hacky override of the `bdist_wheel` command is no longer necessary and will stop working in future versions of setuptools. Remove it, and add tests with the `abi3audit` package to ensure that our official releases remain abi3-compatible. 

This PR replaces #3425 which fixed the future-setuptools compatibility but left the override in place. 