### PR TITLE
Fix a docstring typo for the usage of asyncio.Event.wait

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -89,7 +89,7 @@ class HTTPServer(TCPServer, Configurable, httputil.HTTPServerConnectionDelegate)
             async def main():
                 server = HTTPServer()
                 server.listen(8888)
-                await asyncio.Event.wait()
+                await asyncio.Event().wait()
 
             asyncio.run(main())
 

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -75,7 +75,7 @@ class TCPServer:
             async def main():
                 server = TCPServer()
                 server.listen(8888)
-                await asyncio.Event.wait()
+                await asyncio.Event().wait()
 
             asyncio.run(main())
 


### PR DESCRIPTION
I noticed this code snippet will always fail:

```python
await asyncio.Event.wait()
```

because `wait` is an instance method. The correct incantation exists in other parts of the documentation, so this is probably just a little typo.