### PR TITLE
ioloop_test: Skip a test that no longer works on py3.14

### DIFF
--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -782,6 +782,9 @@ class TestIOLoopConfiguration(unittest.TestCase):
         )
         self.assertEqual(cls, "AsyncIOMainLoop")
 
+    @unittest.skipIf(
+        sys.version_info >= (3, 14), "implicit event loop creation not available"
+    )
     def test_asyncio_main(self):
         cls = self.run_python(
             "from tornado.platform.asyncio import AsyncIOMainLoop",


### PR DESCRIPTION
This test uses implicit event loop creation but
avoided deprecation warnings because it ran in a
subprocess. Surprisingly, it is the only test we
have left for this pattern.