### PR TITLE
httputil: Fix quadratic performance of cookie parsing

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   releases/v6.4.2
    releases/v6.4.1
    releases/v6.4.0
    releases/v6.3.3

--- a/docs/releases/v6.4.2.rst
+++ b/docs/releases/v6.4.2.rst
@@ -1,0 +1,12 @@
+What's new in Tornado 6.4.2
+===========================
+
+Nov 21, 2024
+------------
+
+Security Improvements
+~~~~~~~~~~~~~~~~~~~~~
+
+- Parsing of the cookie header is now much more efficient. The older algorithm sometimes had
+  quadratic performance which allowed for a denial-of-service attack in which the server would spend
+  excessive CPU time parsing cookies and block the event loop. This change fixes CVE-2024-7592.

--- a/tornado/__init__.py
+++ b/tornado/__init__.py
@@ -22,8 +22,8 @@
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-version = "6.4.1"
-version_info = (6, 4, 0, 1)
+version = "6.4.2"
+version_info = (6, 4, 2, 0)
 
 import importlib
 import typing

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -1057,15 +1057,20 @@ def qs_to_qsl(qs: Dict[str, List[AnyStr]]) -> Iterable[Tuple[str, AnyStr]]:
             yield (k, v)
 
 
-_OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
-_QuotePatt = re.compile(r"[\\].")
-_nulljoin = "".join
+_unquote_sub = re.compile(r"\\(?:([0-3][0-7][0-7])|(.))").sub
+
+
+def _unquote_replace(m: re.Match) -> str:
+    if m[1]:
+        return chr(int(m[1], 8))
+    else:
+        return m[2]
 
 
 def _unquote_cookie(s: str) -> str:
     """Handle double quotes and escaping in cookie values.
 
-    This method is copied verbatim from the Python 3.5 standard
+    This method is copied verbatim from the Python 3.13 standard
     library (http.cookies._unquote) so we don't have to depend on
     non-public interfaces.
     """
@@ -1086,30 +1091,7 @@ def _unquote_cookie(s: str) -> str:
     #    \012 --> \n
     #    \"   --> "
     #
-    i = 0
-    n = len(s)
-    res = []
-    while 0 <= i < n:
-        o_match = _OctalPatt.search(s, i)
-        q_match = _QuotePatt.search(s, i)
-        if not o_match and not q_match:  # Neither matched
-            res.append(s[i:])
-            break
-        # else:
-        j = k = -1
-        if o_match:
-            j = o_match.start(0)
-        if q_match:
-            k = q_match.start(0)
-        if q_match and (not o_match or k < j):  # QuotePatt matched
-            res.append(s[i:k])
-            res.append(s[k + 1])
-            i = k + 2
-        else:  # OctalPatt matched
-            res.append(s[i:j])
-            res.append(chr(int(s[j + 1 : j + 4], 8)))
-            i = j + 4
-    return _nulljoin(res)
+    return _unquote_sub(_unquote_replace, s)
 
 
 def parse_cookie(cookie: str) -> Dict[str, str]:

--- a/tornado/test/twisted_test.py
+++ b/tornado/test/twisted_test.py
@@ -18,10 +18,7 @@ import unittest
 from tornado.testing import AsyncTestCase, gen_test
 
 try:
-    from twisted.internet.defer import (  # type: ignore
-        inlineCallbacks,
-        returnValue,
-    )
+    from twisted.internet.defer import inlineCallbacks  # type: ignore
 
     have_twisted = True
 except ImportError:
@@ -43,7 +40,7 @@ class ConvertDeferredTest(AsyncTestCase):
                 # inlineCallbacks doesn't work with regular functions;
                 # must have a yield even if it's unreachable.
                 yield
-            returnValue(42)
+            return 42
 
         res = yield fn()
         self.assertEqual(res, 42)


### PR DESCRIPTION
Maliciously-crafted cookies can cause Tornado to
spend an unreasonable amount of CPU time and block
the event loop.
    
This change replaces the quadratic algorithm with
a more efficient one. The implementation is copied
from the Python 3.13 standard library (the
previous one was from Python 3.5).
    
Fixes CVE-2024-52804
See CVE-2024-7592 for a similar vulnerability in cpython.
    
Thanks to @kexinoh for the report.