### PR TITLE
httputil: Fix quadratic performance of cookie parsing

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -1065,15 +1065,20 @@ def qs_to_qsl(qs: Dict[str, List[AnyStr]]) -> Iterable[Tuple[str, AnyStr]]:
             yield (k, v)
 
 
-_OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
-_QuotePatt = re.compile(r"[\\].")
-_nulljoin = "".join
+_unquote_sub = re.compile(r"\\(?:([0-3][0-7][0-7])|(.))").sub
+
+
+def _unquote_replace(m: re.Match) -> str:
+    if m[1]:
+        return chr(int(m[1], 8))
+    else:
+        return m[2]
 
 
 def _unquote_cookie(s: str) -> str:
     """Handle double quotes and escaping in cookie values.
 
-    This method is copied verbatim from the Python 3.5 standard
+    This method is copied verbatim from the Python 3.13 standard
     library (http.cookies._unquote) so we don't have to depend on
     non-public interfaces.
     """
@@ -1094,30 +1099,7 @@ def _unquote_cookie(s: str) -> str:
     #    \012 --> \n
     #    \"   --> "
     #
-    i = 0
-    n = len(s)
-    res = []
-    while 0 <= i < n:
-        o_match = _OctalPatt.search(s, i)
-        q_match = _QuotePatt.search(s, i)
-        if not o_match and not q_match:  # Neither matched
-            res.append(s[i:])
-            break
-        # else:
-        j = k = -1
-        if o_match:
-            j = o_match.start(0)
-        if q_match:
-            k = q_match.start(0)
-        if q_match and (not o_match or k < j):  # QuotePatt matched
-            res.append(s[i:k])
-            res.append(s[k + 1])
-            i = k + 2
-        else:  # OctalPatt matched
-            res.append(s[i:j])
-            res.append(chr(int(s[j + 1 : j + 4], 8)))
-            i = j + 4
-    return _nulljoin(res)
+    return _unquote_sub(_unquote_replace, s)
 
 
 def parse_cookie(cookie: str) -> Dict[str, str]:


### PR DESCRIPTION
Maliciously-crafted cookies can cause Tornado to
spend an unreasonable amount of CPU time and block the event loop.

This change replaces the quadratic algorithm with
a more efficient one. The implementation is copied from the Python 3.13 standard library (the
previous one was from Python 3.5).

Fixes CVE-2024-52804
See CVE-2024-7592 for a similar vulnerability in cpython.

Thanks to github.com/kexinoh for the report.

This is the master-branch version of #3446
