### PR TITLE
gh-123067: Fix quadratic complexity in parsing "-quoted cookie values with backslashes

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -1065,8 +1065,14 @@ def qs_to_qsl(qs: Dict[str, List[AnyStr]]) -> Iterable[Tuple[str, AnyStr]]:
             yield (k, v)
 
 
-_OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
-_QuotePatt = re.compile(r"[\\].")
+_unquote_sub = re.compile(r'\\(?:([0-3][0-7][0-7])|(.))').sub
+def _unquote_replace(m):
+    if m[1]:
+        return chr(int(m[1], 8))
+    else:
+        return m[2]
+
+
 _nulljoin = "".join
 
 
@@ -1094,30 +1100,7 @@ def _unquote_cookie(s: str) -> str:
     #    \012 --> \n
     #    \"   --> "
     #
-    i = 0
-    n = len(s)
-    res = []
-    while 0 <= i < n:
-        o_match = _OctalPatt.search(s, i)
-        q_match = _QuotePatt.search(s, i)
-        if not o_match and not q_match:  # Neither matched
-            res.append(s[i:])
-            break
-        # else:
-        j = k = -1
-        if o_match:
-            j = o_match.start(0)
-        if q_match:
-            k = q_match.start(0)
-        if q_match and (not o_match or k < j):  # QuotePatt matched
-            res.append(s[i:k])
-            res.append(s[k + 1])
-            i = k + 2
-        else:  # OctalPatt matched
-            res.append(s[i:j])
-            res.append(chr(int(s[j + 1 : j + 4], 8)))
-            i = j + 4
-    return _nulljoin(res)
+    return _unquote_sub(_unquote_replace, str)
 
 
 def parse_cookie(cookie: str) -> Dict[str, str]:


### PR DESCRIPTION
 (GH-123075)

I propose this fix just to open a Issue related with this CVE. Because I make a transpose of CPython original code to here

This fixes CVE-2024-7592.
(cherry picked from commit 44e4583)