### PR TITLE
Update max message size

### DIFF
--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -95,7 +95,7 @@ if TYPE_CHECKING:
             pass
 
 
-_default_max_message_size = 10 * 1024 * 1024
+_default_max_message_size = os.environ.get("TORNADO_MAX_MESSAGE_SIZE", 100 * 1024 * 1024)
 
 
 class WebSocketError(Exception):


### PR DESCRIPTION
Tornado is used to proxy web applications in Jupyter (https://github.com/jupyterhub/jupyter-server-proxy/blob/main/jupyter_server_proxy/websocket.py#L52).

Many applications use socket communication, and messages (for example, files) can be larger than 10MB.

Can we set the _default_max_message_size variable from ENV? For example, as I propose in this PR.

I also ask, is it possible to immediately change the default value to 1024 (1GB), as it has already been done in Jupyter or code-server?

Now the default value is 10MB (in my proposal, I carefully increased it to 100MB)

I came to this decision and PR thanks to this issue (https://github.com/coder/code-server/issues/7139)