### PR TITLE
Improve type signature for `_RuleList`

### DIFF
--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -184,7 +184,7 @@ from tornado.escape import url_escape, url_unescape, utf8
 from tornado.log import app_log
 from tornado.util import basestring_type, import_object, re_unescape, unicode_type
 
-from typing import Any, Union, Optional, Awaitable, List, Dict, Pattern, Tuple, overload
+from typing import Any, Union, Optional, Awaitable, List, Dict, Pattern, Tuple, overload, Sequence
 
 
 class Router(httputil.HTTPServerConnectionDelegate):
@@ -286,7 +286,7 @@ class _DefaultMessageDelegate(httputil.HTTPMessageDelegate):
 
 # _RuleList can either contain pre-constructed Rules or a sequence of
 # arguments to be passed to the Rule constructor.
-_RuleList = List[
+_RuleList = Sequence[
     Union[
         "Rule",
         List[Any],  # Can't do detailed typechecking of lists.


### PR DESCRIPTION
This PR improves the type signature for `_RuleList` to be more forgiving. Minimal repro:

```python3
from tornado.web import Application, RequestHandler

class SampleHandler(RequestHandler):
    def get(self):
        self.write("Hello world")

handlers = [
    (r"/", SampleHandler),
]

application = Application(handlers)
```

Before Patch:
```shell
$ mypy repro.py
repro.py:11: error: Argument 1 to "Application" has incompatible type "list[tuple[str, type[SampleHandler]]]"; expected "list[Rule | list[Any] | tuple[str | Matcher, Any] | tuple[str | Matcher, Any, dict[str, Any]] | tuple[str | Matcher, Any, dict[str, Any], str]] | None"  [arg-type]
repro.py:11: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
repro.py:11: note: Consider using "Sequence" instead, which is covariant
Found 1 error in 1 file (checked 1 source file)
```
After Patch:
```
$ mypy repro.py
Success: no issues found in 1 source file
```

Thank you for maintaining tornado, we (@mitmproxy) are super happy users for over a decade! 😃✨🍰 