### PR TITLE
Add windows arm64 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ archs = "x86_64 universal2"
 test-skip = "*_universal2:arm64"
 
 [tool.cibuildwheel.windows]
+archs = "AMD64 x86 ARM64"
 # TODO: figure out what's going on with these occasional log messages.
 test-command = "python -m tornado.test --fail-if-logs=false"
+test-skip = "*-win_arm64"
 
 [tool.cibuildwheel.linux]
 # Build wheels for the native platform (i.e. x86) as well as an emulated


### PR DESCRIPTION
Simple change to cross-compile a windows arm64 wheel. (#3456)

While this cannot be tested in the CI until GitHub starts supporting [Windows arm64 machines for open source projects](https://github.com/orgs/community/discussions/148648#discussioncomment-11920058), I did test the wheel this produced locally on an arm64 Windows machine and it passed all tests.