### PR TITLE
Adapt to deprecation warnings in Python 3.14 alphas

### DIFF
--- a/docs/asyncio.rst
+++ b/docs/asyncio.rst
@@ -3,3 +3,13 @@
 
 .. automodule:: tornado.platform.asyncio
    :members:
+
+
+   ..
+      AnyThreadEventLoopPolicy is created dynamically in getattr, so
+      introspection won't find it automatically. This has the unfortunate
+      side effect of moving it to the top of the page but it's better than
+      having it missing entirely.
+
+   .. autoclass:: AnyThreadEventLoopPolicy
+      :members:

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -111,10 +111,6 @@ class LeakTest(unittest.TestCase):
     def setUp(self):
         # Trigger a cleanup of the mapping so we start with a clean slate.
         AsyncIOLoop(make_current=False).close()
-        # If we don't clean up after ourselves other tests may fail on
-        # py34.
-        self.orig_policy = asyncio.get_event_loop_policy()
-        asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
 
     def tearDown(self):
         try:
@@ -124,7 +120,6 @@ class LeakTest(unittest.TestCase):
             pass
         else:
             loop.close()
-        asyncio.set_event_loop_policy(self.orig_policy)
 
     def test_ioloop_close_leak(self):
         orig_count = len(IOLoop._ioloop_for_asyncio)

--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -9,7 +9,10 @@ _import_everything = b"""
 # Explicitly disallow the default event loop so that an error will be raised
 # if something tries to touch it.
 import asyncio
-asyncio.set_event_loop(None)
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    asyncio.set_event_loop(None)
 
 import importlib
 import tornado

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -132,7 +132,7 @@ class TestIOLoop(AsyncTestCase):
         # Very crude test, just to make sure that we cover this case.
         # This also happens to be the first test where we run an IOLoop in
         # a non-main thread.
-        other_ioloop = IOLoop()
+        other_ioloop = IOLoop(make_current=False)
         thread = threading.Thread(target=other_ioloop.start)
         thread.start()
         with ignore_deprecation():
@@ -152,7 +152,7 @@ class TestIOLoop(AsyncTestCase):
             closing.set()
             other_ioloop.close(all_fds=True)
 
-        other_ioloop = IOLoop()
+        other_ioloop = IOLoop(make_current=False)
         thread = threading.Thread(target=target)
         thread.start()
         closing.wait()
@@ -276,8 +276,12 @@ class TestIOLoop(AsyncTestCase):
 
         sockobj, port = bind_unused_port()
         socket_wrapper = SocketWrapper(sockobj)
-        io_loop = IOLoop()
-        io_loop.add_handler(socket_wrapper, lambda fd, events: None, IOLoop.READ)
+        io_loop = IOLoop(make_current=False)
+        io_loop.run_sync(
+            lambda: io_loop.add_handler(
+                socket_wrapper, lambda fd, events: None, IOLoop.READ
+            )
+        )
         io_loop.close(all_fds=True)
         self.assertTrue(socket_wrapper.closed)
 

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -210,7 +210,7 @@ class SimpleHTTPClientTestMixin(AsyncTestCase):
             SimpleAsyncHTTPClient(), SimpleAsyncHTTPClient(force_instance=True)
         )
         # different IOLoops use different objects
-        with closing(IOLoop()) as io_loop2:
+        with closing(IOLoop(make_current=False)) as io_loop2:
 
             async def make_client():
                 await gen.sleep(0)

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -155,6 +155,19 @@ class AsyncTestCase(unittest.TestCase):
                 category=DeprecationWarning,
                 module=r"tornado\..*",
             )
+        if (3, 14) <= py_ver:
+            # TODO: This is a temporary hack pending resolution of
+            # https://github.com/python/cpython/issues/130322
+            # If set_event_loop is undeprecated, we can remove it; if not
+            # we need substantial changes to this class to use asyncio.Runner
+            # like IsolatedAsyncioTestCase does.
+            setup_with_context_manager(self, warnings.catch_warnings())
+            warnings.filterwarnings(
+                "ignore",
+                message="'asyncio.set_event_loop' is deprecated",
+                category=DeprecationWarning,
+                module="tornado.testing",
+            )
         super().setUp()
         if type(self).get_new_ioloop is not AsyncTestCase.get_new_ioloop:
             warnings.warn("get_new_ioloop is deprecated", DeprecationWarning)


### PR DESCRIPTION
Python 3.14 deprecates the asyncio event loop policy system, so make (most of) the necessary changes.

The deprecation of set_event_loop is extremely disruptive to AsyncTestCase, so I've asked if it can remain undeprecated in https://github.com/python/cpython/issues/130322.  The testing.py changes are temporary until this is resolved.

Fixes #3458