### PR TITLE
ci: Use native arm builders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-15]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-15]
 
     steps:
       - uses: actions/checkout@v4
@@ -61,14 +61,9 @@ jobs:
         name: Install Python
         with:
           python-version: ${{ env.python-version }}
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18
+        uses: pypa/cibuildwheel@v2.22
 
       - name: Audit ABI3 compliance
         # This may be moved into cibuildwheel itself in the future. See

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,7 @@ jobs:
   zizmor:
     name: Analyze action configs with zizmor
     runs-on: ubuntu-22.04
+    needs: test_quick
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,14 @@ archs = "AMD64 x86 ARM64"
 test-command = "python -m tornado.test --fail-if-logs=false"
 # Arm builds are cross-compiled and cannot be tested on the x86 host
 test-skip = "*-win_arm64"
+
+[tool.cibuildwheel.linux]
+# This configuration has a bug which appears unrelated to Tornado:
+# https://github.com/python/cpython/issues/130522
+# If the underlying bug is not fixed by the time 3.14 is released,
+# we may need to skip that in musllinux_i686 as well.
+#
+# Note that because we use the stable ABI, the wheels built for
+# cp39-musllinux_i686 will still be available for users of 3.13, this just
+# means we won't be testing them in this configuration.
+test-skip = "cp313-musllinux_i686"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,25 +11,10 @@ test-command = "python -m tornado.test"
 
 [tool.cibuildwheel.macos]
 archs = "x86_64 universal2"
-# The arm portion of a universal wheel is a cross-compile and cannot
-# be tested on an x86 host. This must be configured explicitly to silence
-# a warning.
-test-skip = "*_universal2:arm64"
 
 [tool.cibuildwheel.windows]
 archs = "AMD64 x86 ARM64"
 # TODO: figure out what's going on with these occasional log messages.
 test-command = "python -m tornado.test --fail-if-logs=false"
+# Arm builds are cross-compiled and cannot be tested on the x86 host
 test-skip = "*-win_arm64"
-
-[tool.cibuildwheel.linux]
-# Build wheels for the native platform (i.e. x86) as well as an emulated
-# build for aarch64.
-archs = "auto aarch64"
-
-[[tool.cibuildwheel.overrides]]
-# The emulated arm build is quite slow, so only run a portion of the test
-# suite. websocket_test is the most platform-dependent part of the tests
-# because it uses the C speedups module.
-select = "*linux_aarch64"
-test-command = "python -m tornado.test tornado.test.websocket_test"


### PR DESCRIPTION
This speeds up the build job dramatically by eliminating the need for
emulation.

MacOS builds have also shifted to run on arm hosts instead of x86 hosts,
and it's now possible to run tests for both arm and x86 on the same
host.

New timings:
- macOS: 9:00
- ubuntu (intel): 10:15
- ubuntu (arm): 6:55
- windows: 14:50

Previously, the ubuntu build (for intel + emulated arm) took 22 minutes, so we've subtracted 7 minutes from the job run time (windows is now the long pole) and 5 minutes of total running time. Note that we're expanding the test coverage by running the full test suite on arm now, so an apples-to-apples comparison would show even more time savings.