### PR TITLE
Format HTTPError.log_message only if args provided

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2520,8 +2520,6 @@ class HTTPError(Exception):
         self.log_message = log_message
         self.args = args
         self.reason = kwargs.get("reason", None)
-        if log_message and not args:
-            self.log_message = log_message.replace("%", "%%")
 
     def __str__(self) -> str:
         message = "HTTP %d: %s" % (
@@ -2529,7 +2527,8 @@ class HTTPError(Exception):
             self.reason or httputil.responses.get(self.status_code, "Unknown"),
         )
         if self.log_message:
-            return message + " (" + (self.log_message % self.args) + ")"
+            log_message = (self.log_message % self.args) if self.args else self.log_message
+            return message + " (" + log_message + ")"
         else:
             return message
 

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2518,14 +2518,23 @@ class HTTPError(Exception):
         **kwargs: Any,
     ) -> None:
         self.status_code = status_code
-        self.log_message = log_message
+        self._log_message = log_message
         self.args = args
         self.reason = kwargs.get("reason", None)
 
+    @property
+    def log_message(self) -> Optional[str]:
+        """
+        A backwards compatible way of accessing log_message.
+        """
+        if self._log_message and not self.args:
+            return self._log_message.replace("%", "%%")
+        return self._log_message
+
     def get_message(self) -> Optional[str]:
-        if self.log_message and self.args:
-            return self.log_message % self.args
-        return self.log_message
+        if self._log_message and self.args:
+            return self._log_message % self.args
+        return self._log_message
 
     def __str__(self) -> str:
         message = "HTTP %d: %s" % (


### PR DESCRIPTION
Attempts to fix the [jupyter_server/issues/1503](https://github.com/jupyter-server/jupyter_server/issues/1503) issue

For details please see the linked issue. TLDR is that if the `log_message` contents have the literal '%' those are getting converted to '%%' when no formatting args are specified. When `HTTPError.__str__` is called, log_message is always %-formatted even when no formatting args are specified, and the '%' literal replacement is likely to avoid issues here.

This pr performs %-formatting of log_message only when required (args are specified) to avoid having to do the literal replacement.

While not completely a parallel example this is more or less what python's logging module does when creating a string out of a LogRecord:

https://github.com/python/cpython/blob/e06bebb87e1b33f7251196e1ddb566f528c3fc98/Lib/logging/__init__.py#L391-L402

If this is intentionally done for some special reason such as security then maybe this issue could be tackled solely on the jupyter side.

related to: #1393 

cc: @ptch314