### PR TITLE
#3142: Improve usability of multi() and multi_future() type annotations

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -91,7 +91,18 @@ except ImportError:
     contextvars = None  # type: ignore
 
 import typing
-from typing import Union, Any, Callable, List, Type, Tuple, Awaitable, Dict, overload
+from typing import (
+    Mapping,
+    Union,
+    Any,
+    Callable,
+    List,
+    Type,
+    Tuple,
+    Awaitable,
+    Dict,
+    overload,
+)
 
 if typing.TYPE_CHECKING:
     from typing import Sequence, Deque, Optional, Set, Iterable  # noqa: F401
@@ -426,7 +437,7 @@ class WaitIterator:
 
 
 def multi(
-    children: Union[List[_Yieldable], Dict[Any, _Yieldable]],
+    children: Union[Sequence[_Yieldable], Mapping[Any, _Yieldable]],
     quiet_exceptions: "Union[Type[Exception], Tuple[Type[Exception], ...]]" = (),
 ) -> "Union[Future[List], Future[Dict]]":
     """Runs multiple asynchronous operations in parallel.
@@ -480,7 +491,7 @@ Multi = multi
 
 
 def multi_future(
-    children: Union[List[_Yieldable], Dict[Any, _Yieldable]],
+    children: Union[Sequence[_Yieldable], Mapping[Any, _Yieldable]],
     quiet_exceptions: "Union[Type[Exception], Tuple[Type[Exception], ...]]" = (),
 ) -> "Union[Future[List], Future[Dict]]":
     """Wait for multiple asynchronous futures in parallel.

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -101,11 +101,12 @@ from typing import (
     Tuple,
     Awaitable,
     Dict,
+    Sequence,
     overload,
 )
 
 if typing.TYPE_CHECKING:
-    from typing import Sequence, Deque, Optional, Set, Iterable  # noqa: F401
+    from typing import Deque, Optional, Set, Iterable  # noqa: F401
 
 _T = typing.TypeVar("_T")
 


### PR DESCRIPTION
This diff resolves https://github.com/tornadoweb/tornado/issues/3142 .

Minimal repro:

```python
from tornado import gen


async def foo() -> int:
    return 1


async def bar() -> str:
    return "hello"


awaitables = [foo(), bar()]

gen.multi(awaitables)
```

Before patch:

```
🚂  mypy repro.py
/Users/jrheard/dev/tornado/tornado/tcpclient.py:274: error: Argument 1 to "_create_stream" of "TCPClient" has incompatible type "int | None"; expected "int"  [arg-type]
/Users/jrheard/dev/tornado/tornado/curl_httpclient.py:366: error: Argument 2 to "_curl_header_callback" of "CurlAsyncHTTPClient" has incompatible type "Callable[[str], None] | None"; expected "Callable[[str], None]"  [arg-type]
repro.py:14: error: Argument 1 to "multi" has incompatible type "list[Coroutine[Any, Any, object]]"; expected "list[Awaitable[Any] | list[Awaitable[Any]] | dict[Any, Awaitable[Any]] | Future[Any] | None] | dict[Any, Awaitable[Any] | list[Awaitable[Any]] | dict[Any, Awaitable[Any]] | Future[Any] | None]"  [arg-type]
repro.py:14: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
repro.py:14: note: Consider using "Sequence" instead, which is covariant
Found 3 errors in 3 files (checked 1 source file)
```

After patch:

```
🚂  mypy repro.py
/Users/jrheard/dev/tornado/tornado/tcpclient.py:274: error: Argument 1 to "_create_stream" of "TCPClient" has incompatible type "int | None"; expected "int"  [arg-type]
/Users/jrheard/dev/tornado/tornado/curl_httpclient.py:366: error: Argument 2 to "_curl_header_callback" of "CurlAsyncHTTPClient" has incompatible type "Callable[[str], None] | None"; expected "Callable[[str], None]"  [arg-type]
Found 2 errors in 2 files (checked 1 source file)
```

I'm not sure what to make of those two remaining type errors - they appear to me to be pre-existing. LMK if I'm confused about that please!

CCing @bdarnell because I notice you commented on the original issue :)

Thanks for your work on this project!