### PR TITLE
Fixed the bug that the handler cannot get the main thread context on the Windows platform.

### DIFF
--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -495,7 +495,7 @@ class SelectorThread:
         # starting.
         self._real_loop.call_soon(
             lambda: self._real_loop.create_task(thread_manager_anext()),
-            context=self._main_thread_ctx
+            context=self._main_thread_ctx,
         )
 
         self._readers: Dict[_FileDescriptorLike, Callable] = {}
@@ -623,8 +623,7 @@ class SelectorThread:
 
             try:
                 self._real_loop.call_soon_threadsafe(
-                    self._handle_select, rs, ws,
-                    context=self._main_thread_ctx
+                    self._handle_select, rs, ws, context=self._main_thread_ctx
                 )
             except RuntimeError:
                 # "Event loop is closed". Swallow the exception for

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -494,7 +494,8 @@ class SelectorThread:
         # clean up if we get to this point but the event loop is closed without
         # starting.
         self._real_loop.call_soon(
-            lambda: self._real_loop.create_task(thread_manager_anext()), context=self._main_thread_ctx
+            lambda: self._real_loop.create_task(thread_manager_anext()),
+            context=self._main_thread_ctx
         )
 
         self._readers: Dict[_FileDescriptorLike, Callable] = {}
@@ -621,7 +622,10 @@ class SelectorThread:
                     raise
 
             try:
-                self._real_loop.call_soon_threadsafe(self._handle_select, rs, ws, context=self._main_thread_ctx)
+                self._real_loop.call_soon_threadsafe(
+                    self._handle_select, rs, ws,
+                    context=self._main_thread_ctx
+                )
             except RuntimeError:
                 # "Event loop is closed". Swallow the exception for
                 # consistency with PollIOLoop (and logical consistency

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -25,6 +25,7 @@ the same event loop.
 import asyncio
 import atexit
 import concurrent.futures
+import contextvars
 import errno
 import functools
 import select
@@ -472,6 +473,8 @@ class SelectorThread:
     _closed = False
 
     def __init__(self, real_loop: asyncio.AbstractEventLoop) -> None:
+        self._main_thread_ctx = contextvars.copy_context()
+
         self._real_loop = real_loop
 
         self._select_cond = threading.Condition()
@@ -491,7 +494,7 @@ class SelectorThread:
         # clean up if we get to this point but the event loop is closed without
         # starting.
         self._real_loop.call_soon(
-            lambda: self._real_loop.create_task(thread_manager_anext())
+            lambda: self._real_loop.create_task(thread_manager_anext()), context=self._main_thread_ctx
         )
 
         self._readers: Dict[_FileDescriptorLike, Callable] = {}
@@ -618,7 +621,7 @@ class SelectorThread:
                     raise
 
             try:
-                self._real_loop.call_soon_threadsafe(self._handle_select, rs, ws)
+                self._real_loop.call_soon_threadsafe(self._handle_select, rs, ws, context=self._main_thread_ctx)
             except RuntimeError:
                 # "Event loop is closed". Swallow the exception for
                 # consistency with PollIOLoop (and logical consistency

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -276,11 +276,14 @@ class SelectorThreadContextvarsTest(AsyncHTTPTestCase):
         class Handler(RequestHandler):
             async def get(self):
                 # On the Windows platform,
-                # when a asyncio.events.Handle is created in the SelectorThread without providing a context, 
+                # when a asyncio.events.Handle is created 
+                # in the SelectorThread without providing a context, 
                 # it will copy the current thread's context, 
-                # which can lead to the loss of the main thread's context when executing the handle. 
+                # which can lead to the loss of the main thread's context 
+                # when executing the handle. 
                 # Therefore, it is necessary to 
-                # save a copy of the main thread's context in the SelectorThread for creating the handle.
+                # save a copy of the main thread's context in the SelectorThread 
+                # for creating the handle.
                 self.write(tornado_test_ctx.get())
 
         return Application([(self.test_endpoint, Handler)])

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import asyncio
+import contextvars
 import threading
 import time
 import unittest
@@ -261,3 +262,28 @@ class AnyThreadEventLoopPolicyTest(unittest.TestCase):
             asyncio.set_event_loop_policy(self.AnyThreadEventLoopPolicy())
             self.assertIsInstance(self.executor.submit(IOLoop.current).result(), IOLoop)
             self.executor.submit(lambda: asyncio.get_event_loop().close()).result()  # type: ignore
+
+
+class SelectorThreadContextvarsTest(AsyncHTTPTestCase):
+    ctx_value = 'foo'
+    test_endpoint = '/'
+    tornado_test_ctx = contextvars.ContextVar('tornado_test_ctx', default='default')
+    tornado_test_ctx.set(ctx_value)
+
+    def get_app(self) -> Application:
+        tornado_test_ctx = self.tornado_test_ctx
+
+        class Handler(RequestHandler):
+            async def get(self):
+                # On the Windows platform,
+                # when a asyncio.events.Handle is created in the SelectorThread without providing a context, 
+                # it will copy the current thread's context, 
+                # which can lead to the loss of the main thread's context when executing the handle. 
+                # Therefore, it is necessary to 
+                # save a copy of the main thread's context in the SelectorThread for creating the handle.
+                self.write(tornado_test_ctx.get())
+
+        return Application([(self.test_endpoint, Handler)])
+
+    def test_context_vars(self):
+        self.assertEqual(self.ctx_value, self.fetch(self.test_endpoint).body.decode())

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -26,8 +26,14 @@ from tornado.platform.asyncio import (
     to_asyncio_future,
     AddThreadSelectorEventLoop,
 )
-from tornado.testing import AsyncTestCase, gen_test, setup_with_context_manager
+from tornado.testing import (
+    AsyncTestCase,
+    gen_test,
+    setup_with_context_manager,
+    AsyncHTTPTestCase,
+)
 from tornado.test.util import ignore_deprecation
+from tornado.web import Application, RequestHandler
 
 
 class AsyncIOLoopTest(AsyncTestCase):
@@ -276,13 +282,13 @@ class SelectorThreadContextvarsTest(AsyncHTTPTestCase):
         class Handler(RequestHandler):
             async def get(self):
                 # On the Windows platform,
-                # when a asyncio.events.Handle is created 
-                # in the SelectorThread without providing a context, 
-                # it will copy the current thread's context, 
-                # which can lead to the loss of the main thread's context 
-                # when executing the handle. 
-                # Therefore, it is necessary to 
-                # save a copy of the main thread's context in the SelectorThread 
+                # when a asyncio.events.Handle is created
+                # in the SelectorThread without providing a context,
+                # it will copy the current thread's context,
+                # which can lead to the loss of the main thread's context
+                # when executing the handle.
+                # Therefore, it is necessary to
+                # save a copy of the main thread's context in the SelectorThread
                 # for creating the handle.
                 self.write(tornado_test_ctx.get())
 

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -271,9 +271,9 @@ class AnyThreadEventLoopPolicyTest(unittest.TestCase):
 
 
 class SelectorThreadContextvarsTest(AsyncHTTPTestCase):
-    ctx_value = 'foo'
-    test_endpoint = '/'
-    tornado_test_ctx = contextvars.ContextVar('tornado_test_ctx', default='default')
+    ctx_value = "foo"
+    test_endpoint = "/"
+    tornado_test_ctx = contextvars.ContextVar("tornado_test_ctx", default="default")
     tornado_test_ctx.set(ctx_value)
 
     def get_app(self) -> Application:


### PR DESCRIPTION
## platform

windows


## minimal reproducible demo


```python
import tornado.ioloop
import tornado.web

import contextvars

v = contextvars.ContextVar('v', default='default')


# Define a request handler
class MainHandler(tornado.web.RequestHandler):
    def get(self):
        print(v.get())
        self.write("Hello, World!")


# Define the application
def make_app():
    return tornado.web.Application([
        (r"/", MainHandler),
    ])


# Start the server
if __name__ == "__main__":
    v.set('foo')
    app = make_app()
    app.listen(8888)  # Listen on port 8888
    print("Server is running on http://localhost:8888")
    tornado.ioloop.IOLoop.current().start()
```

Run and visit http://localhost:8888, then print default