### PR TITLE
Don't define Py_LIMITED_API and don't re-enable GIL under free-threading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if (
             # Use the stable ABI so our wheels are compatible across python
             # versions.
             py_limited_api=can_use_limited_api,
-            define_macros=[("Py_LIMITED_API", "0x03090000")],
+            define_macros=[("Py_LIMITED_API", "0x03090000")] if can_use_limited_api else [],
         )
     ]
 

--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -65,7 +65,7 @@ static PyModuleDef_Slot slots[] = {
 #if (!defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030c0000) || Py_LIMITED_API >= 0x030c0000
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if !defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030d0000
+#if (!defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030d0000) || Py_LIMITED_API >= 0x030d0000
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif
     {0, NULL}

--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -56,24 +56,22 @@ static PyMethodDef methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+static PyModuleDef_Slot slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL}
+};
+
 static struct PyModuleDef speedupsmodule = {
    PyModuleDef_HEAD_INIT,
    "speedups",
    NULL,
-   -1,
-   methods
+   0,
+   methods,
+   slots,
 };
 
 PyMODINIT_FUNC
 PyInit_speedups(void) {
-    PyObject *m = PyModule_Create(&speedupsmodule);
-    if (!m) {
-        return NULL;
-    }
-
-#ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
-
-    return m;
+    return PyModuleDef_Init(&speedupsmodule);
 }

--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -57,8 +57,12 @@ static PyMethodDef methods[] = {
 };
 
 static PyModuleDef_Slot slots[] = {
+#if PY_VERSION_HEX >= 0x030c0000
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL}
 };
 

--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -51,16 +51,21 @@ static PyObject* websocket_mask(PyObject* self, PyObject* args) {
     return result;
 }
 
+static int speedups_exec(PyObject *module) {
+    return 0;
+}
+
 static PyMethodDef methods[] = {
     {"websocket_mask",  websocket_mask, METH_VARARGS, ""},
     {NULL, NULL, 0, NULL}
 };
 
 static PyModuleDef_Slot slots[] = {
-#if PY_VERSION_HEX >= 0x030c0000
+    {Py_mod_exec, speedups_exec},
+#if (!defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030c0000) || Py_LIMITED_API >= 0x030c0000
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d0000
+#if !defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030d0000
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif
     {0, NULL}

--- a/tornado/speedups.c
+++ b/tornado/speedups.c
@@ -66,5 +66,14 @@ static struct PyModuleDef speedupsmodule = {
 
 PyMODINIT_FUNC
 PyInit_speedups(void) {
-    return PyModule_Create(&speedupsmodule);
+    PyObject *m = PyModule_Create(&speedupsmodule);
+    if (!m) {
+        return NULL;
+    }
+
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
+    return m;
 }


### PR DESCRIPTION
- Defining the `Py_LIMITED_API` macro leads to build failures
- Do not re-enable GIL when importing `tornado.speedups` since it's thread-safe.