### PR TITLE
httputil: Process the Host header more strictly

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2362,7 +2362,7 @@ class StreamingRequestBodyTest(WebTestCase):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         s.connect(("127.0.0.1", self.get_http_port()))
         stream = IOStream(s)
-        stream.write(b"GET " + url + b" HTTP/1.1\r\n")
+        stream.write(b"GET " + url + b" HTTP/1.1\r\nHost: 127.0.0.1\r\n")
         if connection_close:
             stream.write(b"Connection: close\r\n")
         stream.write(b"Transfer-Encoding: chunked\r\n\r\n")


### PR DESCRIPTION
- It is now an error to have multiple Host headers
- The Host header is now mandatory except in HTTP/1.0 mode
- Host headers containing characters that are disallowed by RFC 3986 are now rejected

Fixes #3468