### PR TITLE
httputil: Reject header lines beginning with invalid whitespace

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -248,7 +248,7 @@ class HTTPHeaders(StrMutableMapping):
         if not line:
             # Empty line, or the final CRLF of a header block.
             return
-        if line[0].isspace():
+        if line[0] in HTTP_WHITESPACE:
             # continuation of a multi-line header
             # TODO(7.0): Remove support for line folding.
             if self._last_key is None:

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -287,11 +287,20 @@ Foo: even
             [("Asdf", "qwer zxcv"), ("Foo", "bar baz"), ("Foo", "even more lines")],
         )
 
-    def test_malformed_continuation(self):
+    def test_continuation(self):
+        data = "Foo: bar\r\n\tasdf"
+        headers = HTTPHeaders.parse(data)
+        self.assertEqual(headers["Foo"], "bar asdf")
+
         # If the first line starts with whitespace, it's a
         # continuation line with nothing to continue, so reject it
         # (with a proper error).
         data = " Foo: bar"
+        self.assertRaises(HTTPInputError, HTTPHeaders.parse, data)
+
+        # \f (formfeed) is whitespace according to str.isspace, but
+        # not according to the HTTP spec.
+        data = "Foo: bar\r\n\fasdf"
         self.assertRaises(HTTPInputError, HTTPHeaders.parse, data)
 
     def test_unicode_newlines(self):


### PR DESCRIPTION
The obs-fold feature is defined only for tabs and spaces. The str.isspace() method also accepts other whitespace characters. These characters are not valid in HTTP headers and should be treated as errors instead of triggering line folding.

Fixes #3480