### PR TITLE
Test cp313t in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
             tox_env: py312-full
           - python: '3.13'
             tox_env: py313-full
+          - python: '3.13t'
+            tox_env: py313t-full
           - python: '3.14.0-alpha.1 - 3.14'
             tox_env: py314-full
           - python: 'pypy-3.10'
@@ -139,7 +141,8 @@ jobs:
           # For speed, we only build one python version and one arch. We throw away the wheels
           # built here; the real build is defined in build.yml.
           CIBW_ARCHS: native
-          CIBW_BUILD: cp313-manylinux*
+          CIBW_BUILD: cp313-manylinux* cp313t-manylinux*
+          CIBW_ENABLE: cpython-freethreading
 
           # Alternatively, uncomment the following lines (and replace the previous CIBW_BUILD)
           # to test a freethreading build of python.

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 [tox]
 envlist =
         # Basic configurations: Run the tests for each python version.
-        py39-full,py310-full,py311-full,py312-full,py313-full,pypy3-full
+        py39-full,py310-full,py311-full,py312-full,py313-full,py313t-full,pypy3-full
 
         # Build and test the docs with sphinx.
         docs
@@ -41,7 +41,7 @@ deps =
 
 setenv =
        # Treat the extension as mandatory in testing (but not on pypy)
-       {py3,py39,py310,py311,py312,py313,py314}: TORNADO_EXTENSION=1
+       {py3,py39,py310,py311,py312,py313,py313t,py314}: TORNADO_EXTENSION=1
        # CI workers are often overloaded and can cause our tests to exceed
        # the default timeout of 5s.
        ASYNC_TEST_TIMEOUT=25


### PR DESCRIPTION
- This adds building wheels for cp313t in CI.
- Also adds config for running the test suite under 3.13t. (this will probably fail due to the pycurl and pycares dependencies for now)