### PR TITLE
testing: Remove deprecation warning filter for set_event_loop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
             tox_env: py312-full
           - python: '3.13'
             tox_env: py313-full
-          - python: '3.14.0-alpha.1 - 3.14'
+          - python: '3.14.0-beta.1 - 3.14'
             tox_env: py314-full
           - python: 'pypy-3.10'
             # Pypy is a lot slower due to jit warmup costs, so don't run the

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ black==24.4.2
     # via -r requirements.in
 build==1.2.1
     # via pip-tools
-cachetools==5.3.3
+cachetools==5.5.2
     # via tox
 certifi==2024.7.4
     # via requests
@@ -32,7 +32,7 @@ docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
-filelock==3.14.0
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv
@@ -54,7 +54,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-packaging==24.1
+packaging==25.0
     # via
     #   black
     #   build
@@ -65,7 +65,7 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via -r requirements.in
-platformdirs==4.2.2
+platformdirs==4.3.8
     # via
     #   black
     #   tox
@@ -78,7 +78,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.18.0
     # via sphinx
-pyproject-api==1.6.1
+pyproject-api==1.9.1
     # via tox
 pyproject-hooks==1.1.0
     # via
@@ -109,7 +109,7 @@ sphinxcontrib-qthelp==1.0.7
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-tox==4.15.1
+tox==4.26.0
     # via -r requirements.in
 types-pycurl==7.45.3.20240421
     # via -r requirements.in
@@ -117,7 +117,7 @@ typing-extensions==4.12.2
     # via mypy
 urllib3==2.2.2
     # via requests
-virtualenv==20.26.6
+virtualenv==20.31.2
     # via tox
 wheel==0.43.0
     # via pip-tools

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -155,19 +155,6 @@ class AsyncTestCase(unittest.TestCase):
                 category=DeprecationWarning,
                 module=r"tornado\..*",
             )
-        if (3, 14) <= py_ver:
-            # TODO: This is a temporary hack pending resolution of
-            # https://github.com/python/cpython/issues/130322
-            # If set_event_loop is undeprecated, we can remove it; if not
-            # we need substantial changes to this class to use asyncio.Runner
-            # like IsolatedAsyncioTestCase does.
-            setup_with_context_manager(self, warnings.catch_warnings())
-            warnings.filterwarnings(
-                "ignore",
-                message="'asyncio.set_event_loop' is deprecated",
-                category=DeprecationWarning,
-                module="tornado.testing",
-            )
         super().setUp()
         if type(self).get_new_ioloop is not AsyncTestCase.get_new_ioloop:
             warnings.warn("get_new_ioloop is deprecated", DeprecationWarning)


### PR DESCRIPTION
The deprecation warning for this function was reverted for 3.14b1.

See https://github.com/python/cpython/issues/130322