### PR TITLE
httputil: Fix support for non-latin1 filenames in multipart uploads

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   releases/v6.5.1
    releases/v6.5.0
    releases/v6.4.2
    releases/v6.4.1

--- a/docs/releases/v6.5.1.rst
+++ b/docs/releases/v6.5.1.rst
@@ -1,0 +1,11 @@
+What's new in Tornado 6.5.1
+===========================
+
+May 22, 2025
+------------
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed a bug in ``multipart/form-data`` parsing that could incorrectly reject filenames containing
+  characters above U+00FF (i.e. most characters outside the Latin alphabet).

--- a/tornado/__init__.py
+++ b/tornado/__init__.py
@@ -22,8 +22,8 @@
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-version = "6.5"
-version_info = (6, 5, 0, 0)
+version = "6.5.1"
+version_info = (6, 5, 1, 0)
 
 import importlib
 import typing

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -155,7 +155,7 @@ Foo
             self.assertEqual(file["filename"], filename)
             self.assertEqual(file["body"], b"Foo")
 
-    def test_non_ascii_filename(self):
+    def test_non_ascii_filename_rfc5987(self):
         data = b"""\
 --1234
 Content-Disposition: form-data; name="files"; filename="ab.txt"; filename*=UTF-8''%C3%A1b.txt
@@ -168,6 +168,23 @@ Foo
         parse_multipart_form_data(b"1234", data, args, files)
         file = files["files"][0]
         self.assertEqual(file["filename"], "áb.txt")
+        self.assertEqual(file["body"], b"Foo")
+
+    def test_non_ascii_filename_raw(self):
+        data = """\
+--1234
+Content-Disposition: form-data; name="files"; filename="测试.txt"
+
+Foo
+--1234--""".encode(
+            "utf-8"
+        ).replace(
+            b"\n", b"\r\n"
+        )
+        args, files = form_data_args()
+        parse_multipart_form_data(b"1234", data, args, files)
+        file = files["files"][0]
+        self.assertEqual(file["filename"], "测试.txt")
         self.assertEqual(file["body"], b"Foo")
 
     def test_boundary_starts_and_ends_with_quotes(self):


### PR DESCRIPTION
The change to be stricter about characters allowed in HTTP headers inadvertently broke support for non-latin1 filenames in multipart uploads (this was missed in testing because our i18n test case only used characters in latin1). This commit adds a hacky workaround without changing any APIs to make it safe for a 6.5.1 patch release; a more robust solution will follow for future releases.

Fixes #3502