### PR TITLE
ci: Use Windows ARM builders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, windows-11-arm, macos-15]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,11 @@ build = "cp39* cp310* cp311* cp312* cp313*"
 test-command = "python -m tornado.test"
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 universal2"
+archs = "universal2"
 
 [tool.cibuildwheel.windows]
-archs = "AMD64 x86 ARM64"
 # TODO: figure out what's going on with these occasional log messages.
 test-command = "python -m tornado.test --fail-if-logs=false"
-# Arm builds are cross-compiled and cannot be tested on the x86 host
-test-skip = "*-win_arm64"
 
 [tool.cibuildwheel.linux]
 # This configuration has a bug which appears unrelated to Tornado:


### PR DESCRIPTION
Now that native ARM builders are available for windows, we can use them instead of cross-compiling. This improves parallelism in our build and speeds things up a bit, plus we can test the windows-arm builds now.

Also stop producing x86_64 builds for macos, since they are redundant with the universal2 builds (the x86_64 builds were useful with older version of pip, but they've been fully supported for 5 years now).