### PR TITLE
Add overloads to gen.multi(). Closes #3514.

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -436,6 +436,19 @@ class WaitIterator:
             raise getattr(builtins, "StopAsyncIteration")()
         return self.next()
 
+@overload
+def multi(
+    children: Sequence[_Yieldable],
+    quiet_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = (),
+) -> Future[List]:
+    ...
+
+@overload
+def multi(
+    children: Mapping[Any, _Yieldable],
+    quiet_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = (),
+) -> Future[Dict]:
+    ...
 
 def multi(
     children: Union[Sequence[_Yieldable], Mapping[Any, _Yieldable]],


### PR DESCRIPTION
This diff resolves https://github.com/tornadoweb/tornado/issues/3514 .

Repro file: https://github.com/jrheard/tornado-gen-repro/blob/main/main.py

When I install tornado's master branch and run mypy on that file, I get this output:

```
🚂  uv run mypy .
main.py:24: error: Argument 1 to "takes_list" has incompatible type "list[Any] | dict[Any, Any]"; expected "list[int]"  [arg-type]
main.py:25: error: Argument 1 to "takes_dict" has incompatible type "list[Any] | dict[Any, Any]"; expected "dict[str, int]"  [arg-type]
Found 2 errors in 1 file (checked 1 source file)
```

When I install this `gen-multi-overload` branch and run mypy on that file, I get this output:

```
🚂  uv run mypy .
Success: no issues found in 1 source file
```

This branch has is clean on mypy 1.15.0:

```
🚂  mypy tornado
Success: no issues found in 75 source files
```