### PR TITLE
httputil: Restore the host argument to HTTPServerRequest

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -459,6 +459,11 @@ class HTTPServerRequest:
 
     .. versionchanged:: 4.0
        Moved from ``tornado.httpserver.HTTPRequest``.
+
+    .. deprecated:: 6.5.2
+       The ``host`` argument to the ``HTTPServerRequest`` constructor is deprecated. Use
+       ``headers["Host"]`` instead. This argument was mistakenly removed in Tornado 6.5.0 and
+       temporarily restored in 6.5.2.
     """
 
     path = None  # type: str
@@ -474,7 +479,7 @@ class HTTPServerRequest:
         version: str = "HTTP/1.0",
         headers: Optional[HTTPHeaders] = None,
         body: Optional[bytes] = None,
-        # host: Optional[str] = None,
+        host: Optional[str] = None,
         files: Optional[Dict[str, List["HTTPFile"]]] = None,
         connection: Optional["HTTPConnection"] = None,
         start_line: Optional["RequestStartLine"] = None,
@@ -494,7 +499,7 @@ class HTTPServerRequest:
         self.protocol = getattr(context, "protocol", "http")
 
         try:
-            self.host = self.headers["Host"]
+            self.host = host or self.headers["Host"]
         except KeyError:
             if version == "HTTP/1.0":
                 # HTTP/1.0 does not require the Host header.


### PR DESCRIPTION
This argument was mistakenly removed in Tornado 6.5.0 with no warning; it is now back but deprecated. The host header should be used instead.

Updates #3468