### PR TITLE
docs: Fix a broken link in release notes

### DIFF
--- a/docs/releases/v6.5.2.rst
+++ b/docs/releases/v6.5.2.rst
@@ -11,7 +11,7 @@ Bug fixes
 - Improved logging for invalid ``Host`` headers. This was previously logged as an uncaught
   exception with a stack trace, now it is simply a 400 response (logged as a warning in the
   access log).
-- Restored the ``host`` argument to ``.HTTPServerRequest``. This argument is deprecated
+- Restored the ``host`` argument to `.HTTPServerRequest`. This argument is deprecated
   and will be removed in the future, but its removal with no warning in 6.5.0 was a mistake.
 - Removed a debugging print statement that was left in the code.
 - Improved type hints for ``gen.multi``.


### PR DESCRIPTION
Updates #3532