### PR TITLE
Passes through asyncio.CancelledError in tornado.gen.coroutine

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -241,7 +241,7 @@ def coroutine(
                     future_set_result_unless_cancelled(
                         future, _value_from_stopiteration(e)
                     )
-                except Exception:
+                except (Exception, asyncio.CancelledError):
                     future_set_exc_info(future, sys.exc_info())
                 else:
                     # Provide strong references to Runner objects as long


### PR DESCRIPTION
If a tornado.coroutine raises an asyncio.CancelledError, it is handled badly as an asyncio.CancelledError is not an Exception, but there is no special logic in the tornado.coroutine to handle this BaseException.  We suspect this bug was created in python 3.8 when asyncio.CancelledError changed from an Exception to a BaseException.

See bug report: https://github.com/tornadoweb/tornado/issues/3537