### PR TITLE
Allow CLRF when parsing headers

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -101,7 +101,7 @@ class _ABNF:
     VCHAR = re.compile(r"[\x21-\x7E]")
 
     # RFC 9110 (HTTP Semantics)
-    obs_text = re.compile(r"[\x80-\xFF]")
+    obs_text = re.compile(r"[\x80-\xFF\r\n]")
     field_vchar = re.compile(rf"(?:{VCHAR.pattern}|{obs_text.pattern})")
     # Not exactly from the RFC to simplify and combine field-content and field-value.
     field_value = re.compile(


### PR DESCRIPTION
With [0], we changed a lot of `regex.match` to `regex.fullmatch`. This has a consequence of now not allowing CRLF (`\r\n`) which is a part of the RFC 9112 when using the `parse_response_start_line` function.

With this PR, we still allow CRLF:

```
>>> _ABNF.status_line.fullmatch('HTTP/1.1 200 OK')
<re.Match object; span=(0, 15), match='HTTP/1.1 200 OK'>
>>> _ABNF.status_line.fullmatch('HTTP/1.1 200 OK\r\n')
<re.Match object; span=(0, 17), match='HTTP/1.1 200 OK\r\n'>
```

Related to https://github.com/openSUSE/salt/commit/0786d7a8433787d1ebce65a5a62d1d6213c489f5

[0] https://github.com/tornadoweb/tornado/commit/1cfc0d127a287cd732ff9f5419450a7ce1163454