### PR TITLE
Make `uri` and `method` attributes on `HTTPServerRequest` mandatory

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -487,7 +487,9 @@ class HTTPServerRequest:
     ) -> None:
         if start_line is not None:
             method, uri, version = start_line
+        assert method
         self.method = method
+        assert uri
         self.uri = uri
         self.version = version
         self.headers = headers or HTTPHeaders()

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -526,15 +526,15 @@ class HTTPServerRequestTest(unittest.TestCase):
         # All parameters are formally optional, but uri is required
         # (and has been for some time).  This test ensures that no
         # more required parameters slip in.
-        HTTPServerRequest(uri="/")
+        HTTPServerRequest(method="GET", uri="/")
 
     def test_body_is_a_byte_string(self):
-        request = HTTPServerRequest(uri="/")
+        request = HTTPServerRequest(method="GET", uri="/")
         self.assertIsInstance(request.body, bytes)
 
     def test_repr_does_not_contain_headers(self):
         request = HTTPServerRequest(
-            uri="/", headers=HTTPHeaders({"Canary": ["Coal Mine"]})
+            method="GET", uri="/", headers=HTTPHeaders({"Canary": ["Coal Mine"]})
         )
         self.assertNotIn("Canary", repr(request))
 


### PR DESCRIPTION
This adds assertion checks during initialisation of `HTTPServerRequest` object, to ensure the corresponding attributes of the object being created, won't end up being `None`. This allows the type checker to assume the value of the attribute is `str` and never `None`, which I argue aids typed Tornado applications. To be clear, it is still permitted to provide `None` or omit specification for both `uri` and `method` parameters to the constructor if the `start_line` parameter specifies [good] values instead.

This is also motivated by the idea that per HTTP, requests _always_ feature a method and a URI, and so the `HTTPServerRequest` modelling wasn't optimal allowing `None` for either. As for _typed_ Tornado applications using e.g. `self.request.uri` as part of request handling -- i.e. in code with `self` being a `RequestHandler` -- these can now safely assume e.g. `uri` or `method` are `str` and not `str | None` / `Optional[str]` which would require ad-hoc assertions ala `assert self.request.uri is not None` (or `assert self.request.uri`) in _application code_. That would IMO be a case of "surprising the user" -- as most everyone would expect an HTTP request to have its URI and method be "mandatory" attributes -- not allowing `None` for value.

Again, because semantics of `start_line` are preserved, the initialisation of the object _may_ omit parameters `uri` and/or `method` if `start_line` specifies valid values for these instead. In any case, it is the _attributes_ of the object being constructed, that end up being effectively validated with `assert` -- which make the type checker (tested with MyPy 1.18.2 here) assume `str` instead of `str | None`.

It's also important that this doesn't break existing Tornado applications, since the type of both attributes is effectively narrowed down, meaning that applications that would otherwise assume `str | None` can continue to do so safely -- "may be `None`" is compatible with "won't ever be `None`", obviously.