### PR TITLE
Clean up some compatibility for older Python versions

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -64,15 +64,8 @@ class DummyExecutor(futures.Executor):
             future_set_exc_info(future, sys.exc_info())
         return future
 
-    if sys.version_info >= (3, 9):
-
-        def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
-            pass
-
-    else:
-
-        def shutdown(self, wait: bool = True) -> None:
-            pass
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        pass
 
 
 dummy_executor = DummyExecutor()

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -61,12 +61,6 @@ if typing.TYPE_CHECKING:
     from asyncio import Future  # noqa: F401
     import unittest  # noqa: F401
 
-    # This can be done unconditionally in the base class of HTTPHeaders
-    # after we drop support for Python 3.8.
-    StrMutableMapping = collections.abc.MutableMapping[str, str]
-else:
-    StrMutableMapping = collections.abc.MutableMapping
-
 # To be used with str.strip() and related methods.
 HTTP_WHITESPACE = " \t"
 
@@ -141,7 +135,7 @@ def _normalize_header(name: str) -> str:
     return "-".join([w.capitalize() for w in name.split("-")])
 
 
-class HTTPHeaders(StrMutableMapping):
+class HTTPHeaders(collections.abc.MutableMapping[str, str]):
     """A dictionary that maintains ``Http-Header-Case`` for all keys.
 
     Supports multiple values per key via a pair of new methods,


### PR DESCRIPTION
I spotted a couple of bits of compatibility code for Python 3.8 and below; tornado already requires at least Python 3.10, so these can be simplified.