### PR TITLE
Add check for same-origin requests for unsafe methods

### DIFF
--- a/docs/web.rst
+++ b/docs/web.rst
@@ -151,6 +151,7 @@
 
       The `Application` object serving this request
 
+   .. automethod:: RequestHandler.check_allowed_origin
    .. automethod:: RequestHandler.check_etag_header
    .. automethod:: RequestHandler.check_xsrf_cookie
    .. automethod:: RequestHandler.compute_etag

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -3195,6 +3195,45 @@ class XSRFCookieKwargsTest(SimpleHandlerTestCase):
         self.assertTrue(abs((expires - header_expires).total_seconds()) < 10)
 
 
+class CheckSameOriginTest(SimpleHandlerTestCase):
+    class Handler(RequestHandler):
+        def post(self):
+            self.write("ok")
+
+    def get_app_kwargs(self):
+        return dict(check_same_origin=True)
+
+    def _post(self, headers):
+        return self.fetch("/", method="POST", body="x=1", headers=headers)
+
+    def test_sec_fetch_site_success(self):
+        response = self._post({"Sec-Fetch-Site": "same-origin"})
+        self.assertEqual(response.code, 200)
+
+    def test_sec_fetch_site_fail(self):
+        with ExpectLog(gen_log, ".*Cross-origin request"):
+            response = self._post({"Sec-Fetch-Site": "cross-site"})
+        self.assertEqual(response.code, 403)
+
+    def test_fallback_success(self):
+        response = self._post({"Origin": self.get_url("")})
+        self.assertEqual(response.code, 200)
+
+    def test_fallback_referrer_success(self):
+        response = self._post({"Referrer": self.get_url("/foo/bar")})
+        self.assertEqual(response.code, 200)
+
+    def test_fallback_fail(self):
+        with ExpectLog(gen_log, ".*Cross-origin request"):
+            response = self._post({"Origin": "https://evil.example.com/"})
+        self.assertEqual(response.code, 403)
+
+    def test_fallback_no_origin(self):
+        with ExpectLog(gen_log, ".*No Origin/Referrer"):
+            response = self._post({})
+        self.assertEqual(response.code, 403)
+
+
 class FinishExceptionTest(SimpleHandlerTestCase):
     class Handler(RequestHandler):
         def get(self):

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -3201,7 +3201,7 @@ class CheckSameOriginTest(SimpleHandlerTestCase):
             self.write("ok")
 
     def get_app_kwargs(self):
-        return dict(check_fetch_header=True, check_origin=self.get_url(""))
+        return dict(check_allowed_origin=True)
 
     def _post(self, headers):
         return self.fetch("/", method="POST", body="x=1", headers=headers)

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -3201,7 +3201,7 @@ class CheckSameOriginTest(SimpleHandlerTestCase):
             self.write("ok")
 
     def get_app_kwargs(self):
-        return dict(check_same_origin=True)
+        return dict(check_fetch_header=True, check_origin=self.get_url(""))
 
     def _post(self, headers):
         return self.fetch("/", method="POST", body="x=1", headers=headers)
@@ -3229,9 +3229,8 @@ class CheckSameOriginTest(SimpleHandlerTestCase):
         self.assertEqual(response.code, 403)
 
     def test_fallback_no_origin(self):
-        with ExpectLog(gen_log, ".*No Origin/Referrer"):
-            response = self._post({})
-        self.assertEqual(response.code, 403)
+        response = self._post({})
+        self.assertEqual(response.code, 200)
 
 
 class FinishExceptionTest(SimpleHandlerTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1692,24 +1692,27 @@ class RequestHandler:
             + '"/>'
         )
 
-    def check_same_origin(self) -> None:
+    def check_fetch_header(self) -> bool:
         """Verify that non-safe methods come from a same-origin request"""
-        headers = self.request.headers
-        if (sfs := headers.get("Sec-Fetch-Site")) is not None:
+        if (sfs := self.request.headers.get("Sec-Fetch-Site")) is not None:
             # All major browsers send the Sec-Fetch-Site header since ~2023
             # for 'potentially trustworthy' URLs (roughly, HTTPS or localhost)
-            if sfs not in ('same-origin', 'none'):
+            if sfs not in ("same-origin", "none"):
                 raise HTTPError(403, "Cross-origin request with unsafe method")
+            return True
+        return False
 
-        else:
-            # Fallback: The Origin or Referrer header gives the domain
-            # the request came from, Host should tell us where we're running.
-            src_origin = headers.get("Origin") or headers.get("Referrer")
-            if src_origin is None:
-                raise HTTPError(403, "No Origin/Referrer header with unsafe method")
-            src_scheme, src_netloc = urllib.parse.urlsplit(src_origin)[:2]
-            if src_scheme != self.request.protocol or src_netloc != self.request.host:
-                raise HTTPError(403, "Cross-origin request with unsafe method")
+    def check_request_origin(self) -> None:
+        # Fallback: The Origin or Referrer header gives the domain
+        # the request came from, Host should tell us where we're running.
+        headers = self.request.headers
+        src_origin = headers.get("Origin") or headers.get("Referrer")
+        if src_origin is None:
+            return  # Probably non-browser request
+        src_scheme, src_netloc = urllib.parse.urlsplit(src_origin)[:2]
+        target_origin = self.application.settings["check_origin"]
+        if f"{src_scheme}://{src_netloc}" != target_origin:
+            raise HTTPError(403, "Cross-origin request with unsafe method")
 
     def static_url(
         self, path: str, include_host: bool | None = None, **kwargs: Any
@@ -1850,8 +1853,10 @@ class RequestHandler:
             if self.request.method not in ("GET", "HEAD", "OPTIONS"):
                 if self.application.settings.get("xsrf_cookies"):
                     self.check_xsrf_cookie()
-                if self.application.settings.get("check_same_origin"):
-                    self.check_same_origin()
+                if self.application.settings.get("check_fetch_header"):
+                    checked = self.check_fetch_header()
+                    if not checked and self.application.settings.get("check_origin"):
+                        self.check_request_origin()
 
             result = self.prepare()
             if result is not None:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1692,6 +1692,25 @@ class RequestHandler:
             + '"/>'
         )
 
+    def check_same_origin(self) -> None:
+        """Verify that non-safe methods come from a same-origin request"""
+        headers = self.request.headers
+        if (sfs := headers.get("Sec-Fetch-Site")) is not None:
+            # All major browsers send the Sec-Fetch-Site header since ~2023
+            # for 'potentially trustworthy' URLs (roughly, HTTPS or localhost)
+            if sfs not in ('same-origin', 'none'):
+                raise HTTPError(403, "Cross-origin request with unsafe method")
+
+        else:
+            # Fallback: The Origin or Referrer header gives the domain
+            # the request came from, Host should tell us where we're running.
+            src_origin = headers.get("Origin") or headers.get("Referrer")
+            if src_origin is None:
+                raise HTTPError(403, "No Origin/Referrer header with unsafe method")
+            src_scheme, src_netloc = urllib.parse.urlsplit(src_origin)[:2]
+            if src_scheme != self.request.protocol or src_netloc != self.request.host:
+                raise HTTPError(403, "Cross-origin request with unsafe method")
+
     def static_url(
         self, path: str, include_host: bool | None = None, **kwargs: Any
     ) -> str:
@@ -1828,12 +1847,11 @@ class RequestHandler:
             }
             # If XSRF cookies are turned on, reject form submissions without
             # the proper cookie
-            if self.request.method not in (
-                "GET",
-                "HEAD",
-                "OPTIONS",
-            ) and self.application.settings.get("xsrf_cookies"):
-                self.check_xsrf_cookie()
+            if self.request.method not in ("GET", "HEAD", "OPTIONS"):
+                if self.application.settings.get("xsrf_cookies"):
+                    self.check_xsrf_cookie()
+                if self.application.settings.get("check_same_origin"):
+                    self.check_same_origin()
 
             result = self.prepare()
             if result is not None:

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -1692,27 +1692,39 @@ class RequestHandler:
             + '"/>'
         )
 
-    def check_fetch_header(self) -> bool:
-        """Verify that non-safe methods come from a same-origin request"""
+    def check_allowed_origin(self) -> None:
+        """Check if a request should be rejected as cross-origin.
+
+        If the setting check_allowed_origin is True, this is called for non-safe
+        HTTP requests (i.e. not GET, HEAD or OPTIONS). It raises HTTPError 403
+        to reject a request.
+        """
+        origin = self.request.headers.get("Origin")
+        if origin is not None:
+            origin = origin.lower()
+            if origin in self.application.settings.get("allowed_origins", ()):
+                return  # Origin in explicit allowlist
+
         if (sfs := self.request.headers.get("Sec-Fetch-Site")) is not None:
             # All major browsers send the Sec-Fetch-Site header since ~2023
             # for 'potentially trustworthy' URLs (roughly, HTTPS or localhost)
-            if sfs not in ("same-origin", "none"):
-                raise HTTPError(403, "Cross-origin request with unsafe method")
-            return True
-        return False
+            if sfs in ("same-origin", "none"):
+                return  # OK according to Sec-Fetch-Site
+            raise HTTPError(
+                403,
+                f"Cross-origin request with unsafe method (Sec-Fetch-Site: {sfs})",
+            )
 
-    def check_request_origin(self) -> None:
-        # Fallback: The Origin or Referrer header gives the domain
-        # the request came from, Host should tell us where we're running.
-        headers = self.request.headers
-        src_origin = headers.get("Origin") or headers.get("Referrer")
-        if src_origin is None:
-            return  # Probably non-browser request
-        src_scheme, src_netloc = urllib.parse.urlsplit(src_origin)[:2]
-        target_origin = self.application.settings["check_origin"]
-        if f"{src_scheme}://{src_netloc}" != target_origin:
-            raise HTTPError(403, "Cross-origin request with unsafe method")
+        if origin is None:  # Sec-Fetch-Site must also be missing to reach here
+            return  # Probably a non-browser request
+
+        host = self.request.headers.get("Host")
+        if urllib.parse.urlsplit(origin).netloc != host:
+            raise HTTPError(
+                403,
+                f"Cross-origin request with unsafe method (Origin {origin!r} does not "
+                f"match Host {host!r} or allowed_origins)",
+            )
 
     def static_url(
         self, path: str, include_host: bool | None = None, **kwargs: Any
@@ -1853,10 +1865,8 @@ class RequestHandler:
             if self.request.method not in ("GET", "HEAD", "OPTIONS"):
                 if self.application.settings.get("xsrf_cookies"):
                     self.check_xsrf_cookie()
-                if self.application.settings.get("check_fetch_header"):
-                    checked = self.check_fetch_header()
-                    if not checked and self.application.settings.get("check_origin"):
-                        self.check_request_origin()
+                if self.application.settings.get("check_allowed_origin"):
+                    self.check_allowed_origin()
 
             result = self.prepare()
             if result is not None:


### PR DESCRIPTION
Simple XSRF protection based - primarily - on the Sec-Fetch-Site header, as described in #3495.

`Sec-Fetch-Site` is pretty simple where it is used. The only question is whether to allow `same-site`, i.e. a different subdomain or port within the same registrable domain. For now, the implementation disallows it, but this could be its own setting.

The fallback, if there's no Sec-Fetch-Site header, is more complicated. `Sec-Fetch-Site` might be missing if the request:

- is made over unencrypted HTTP and not to localhost (`Sec-Fetch-*` are only sent for 'potentially trustworthy' URLs)
- comes from an old or niche browser which doesn't implement it (all major browsers have since ~2023)
- comes from a program other than a browser - Python API clients, `curl`, etc.
  - New/updated code making HTTP requests can set `Sec-Fetch-Site: none` to pass the check.
- comes via some kind of proxy which strips the header ([OWASP says](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#concerns) that "This kind of header stripping is problematic, but common").

In the fallback, we aim to compare the domain from which the request originated (`Origin` or `Referrer` header) with the domain we're serving. Origin & Referrer can both be missing - [OWASP recommends](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#identifying-source-origin-via-originreferer-header) blocking such requests, but I suspect this is overly cautious as a default in the framework. E.g. non-browser clients probably won't send either of these.

Knowing what domain & port we're actually exposed on [is also tricky](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#identifying-the-target-origin). In simple scenarios, the `Host` header gives this, but it can be replaced by proxies. Well behaved proxies can set `X-Forwarded-Host`, but they won't all be well-behaved, and if you use this, you have to work out how many layers of `X-Forwarded` to trust. Probably the best approach is to tell the application explicitly what its domain should be.

So I think the fallback should require a separate setting. I hope that the `Sec-Fetch-Site` check can be on by default in some future version, but the fallback probably can't be.

