### PR TITLE
Fix GzipDecompressor to handle concatenated gzip members

### DIFF
--- a/tornado/test/util_test.py
+++ b/tornado/test/util_test.py
@@ -1,4 +1,5 @@
 import datetime
+import gzip
 import re
 import sys
 import textwrap
@@ -15,6 +16,7 @@ from tornado.util import (
     raise_exc_info,
     re_unescape,
     timedelta_to_seconds,
+    GzipDecompressor,
 )
 
 
@@ -366,3 +368,57 @@ class VersionInfoTest(unittest.TestCase):
 
     def test_current_version(self):
         self.assert_version_info_compatible(tornado.version, tornado.version_info)
+
+
+class GzipDecompressorTest(unittest.TestCase):
+    def test_concatenated_gzip_members(self):
+        """Test that concatenated gzip members are fully decompressed."""
+        data1 = b"First gzip member content."
+        data2 = b"Second gzip member content."
+
+        member1 = gzip.compress(data1)
+        member2 = gzip.compress(data2)
+
+        concatenated = member1 + member2
+        decompressor = GzipDecompressor()
+        result = decompressor.decompress(concatenated)
+
+        expected = data1 + data2
+        self.assertEqual(
+            result, expected, "Concatenated gzip members should be fully decompressed"
+        )
+
+    def test_single_gzip_member(self):
+        """Test that single gzip member is decompressed correctly."""
+        data = b"This is some example data that will be compressed using gzip."
+        compressed = gzip.compress(data)
+
+        decompressor = GzipDecompressor()
+        result = decompressor.decompress(compressed)
+
+        self.assertEqual(result, data)
+
+    def test_multiple_concatenated_members(self):
+        """Test that three or more concatenated gzip members are fully decompressed."""
+        data1 = b"First member."
+        data2 = b"Second member."
+        data3 = b"Third member."
+
+        concatenated = gzip.compress(data1) + gzip.compress(data2) + gzip.compress(data3)
+        decompressor = GzipDecompressor()
+        result = decompressor.decompress(concatenated)
+
+        expected = data1 + data2 + data3
+        self.assertEqual(result, expected)
+
+    def test_decompress_after_flush_raises(self):
+        """Test that decompress() raises RuntimeError after flush()."""
+        data = b"Test data"
+        compressed = gzip.compress(data)
+
+        decompressor = GzipDecompressor()
+        decompressor.decompress(compressed)
+        decompressor.flush()
+
+        with self.assertRaises(RuntimeError):
+            decompressor.decompress(gzip.compress(b"More data"))

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -70,6 +70,7 @@ class GzipDecompressor:
         # http://stackoverflow.com/questions/1838699/how-can-i-decompress-a-gzip-stream-with-zlib
         # This works on cpython and pypy, but not jython.
         self.decompressobj = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        self._flushed = False
 
     def decompress(self, value: bytes, max_length: int = 0) -> bytes:
         """Decompress a chunk, returning newly-available data.
@@ -82,7 +83,36 @@ class GzipDecompressor:
         in ``unconsumed_tail``; you must retrieve this value and pass
         it back to a future call to `decompress` if it is not empty.
         """
-        return self.decompressobj.decompress(value, max_length)
+        if self._flushed:
+            raise RuntimeError("Cannot call decompress() after flush()")
+
+        data = value
+        out = bytearray()
+        remaining = max_length
+
+        while True:
+            if remaining:
+                chunk = self.decompressobj.decompress(data, remaining)
+            else:
+                chunk = self.decompressobj.decompress(data)
+
+            out.extend(chunk)
+
+            if remaining:
+                remaining = max(0, max_length - len(out))
+                if remaining == 0:
+                    break
+
+            # Handle concatenated gzip members
+            unused = getattr(self.decompressobj, "unused_data", b"")
+            if unused:
+                data = unused
+                self.decompressobj = zlib.decompressobj(16 + zlib.MAX_WBITS)
+                continue
+
+            break
+
+        return bytes(out)
 
     @property
     def unconsumed_tail(self) -> bytes:
@@ -95,7 +125,9 @@ class GzipDecompressor:
         Also checks for errors such as truncated input.
         No other methods may be called on this object after `flush`.
         """
-        return self.decompressobj.flush()
+        result = self.decompressobj.flush()
+        self._flushed = True
+        return result
 
 
 def import_object(name: str) -> Any:

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -91,20 +91,16 @@ class GzipDecompressor:
         remaining = max_length
 
         while True:
-            if remaining:
-                chunk = self.decompressobj.decompress(data, remaining)
-            else:
-                chunk = self.decompressobj.decompress(data)
-
+            chunk = self.decompressobj.decompress(data, remaining)
             out.extend(chunk)
 
-            if remaining:
-                remaining = max(0, max_length - len(out))
-                if remaining == 0:
+            if max_length:
+                remaining = max_length - len(out)
+                if remaining <= 0:
                     break
 
             # Handle concatenated gzip members
-            unused = getattr(self.decompressobj, "unused_data", b"")
+            unused = self.decompressobj.unused_data
             if unused:
                 data = unused
                 self.decompressobj = zlib.decompressobj(16 + zlib.MAX_WBITS)


### PR DESCRIPTION
## Summary

Fixes #3560 

The `GzipDecompressor` class now properly handles concatenated gzip members by checking for `unused_data` after each decompression and creating a new decompressor to continue processing subsequent members. This prevents silent data loss when decompressing multi-member gzip streams, which is a common pattern in HTTP streaming and other applications.

## Changes

- Modified `GzipDecompressor.decompress()` to loop through concatenated gzip members using `unused_data`
- Added `_flushed` flag to prevent `decompress()` calls after `flush()` has been called
- Added comprehensive test cases covering:
  - Single gzip member (regression test)
  - Two concatenated gzip members (issue reproduction)
  - Three concatenated gzip members (edge case)
  - RuntimeError after flush() (API contract)

## Test Results

All existing tests pass, and new tests verify the fix:

```bash
$ python3 -m pytest tornado/test/util_test.py::GzipDecompressorTest -v
============================== test session starts ==============================
tornado/test/util_test.py::GzipDecompressorTest::test_concatenated_gzip_members PASSED
tornado/test/util_test.py::GzipDecompressorTest::test_decompress_after_flush_raises PASSED
tornado/test/util_test.py::GzipDecompressorTest::test_multiple_concatenated_members PASSED
tornado/test/util_test.py::GzipDecompressorTest::test_single_gzip_member PASSED
============================== 4 passed in 0.02s
```

The reproduction script from the issue now works correctly:
```python
import gzip
from tornado.util import GzipDecompressor

data1 = b"This is some example data that will be compressed using gzip."
data2 = b"Here is some more example data to demonstrate gzip compression."

member1 = gzip.compress(data1)
member2 = gzip.compress(data2)
concatenated = member1 + member2

decompressor = GzipDecompressor()
decompressed_data = decompressor.decompress(concatenated)
expected_data = data1 + data2

assert decompressed_data == expected_data  # ✓ Passes with fix
```