### PR TITLE
Fix string formatting in exception constructors across codebase

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -131,7 +131,7 @@ def run_on_executor(*args: Any, **kwargs: Any) -> Callable:
     if len(args) == 1:
         return run_on_executor_decorator(args[0])
     elif len(args) != 0:
-        raise ValueError("expected 1 argument, got %d", len(args))
+        raise ValueError("expected 1 argument, got %d" % len(args))
     return run_on_executor_decorator
 
 

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -221,7 +221,7 @@ if hasattr(socket, "AF_UNIX"):
                 if stat.S_ISSOCK(st.st_mode):
                     os.remove(file)
                 else:
-                    raise ValueError("File %s exists and is not a socket", file)
+                    raise ValueError("File %s exists and is not a socket" % file)
             sock.bind(file)
             os.chmod(file, mode)
         else:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -390,7 +390,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             if username is not None:
                 assert password is not None
                 if self.request.auth_mode not in (None, "basic"):
-                    raise ValueError("unsupported auth_mode %s", self.request.auth_mode)
+                    raise ValueError("unsupported auth_mode %s" % self.request.auth_mode)
                 self.request.headers["Authorization"] = "Basic " + _unicode(
                     base64.b64encode(
                         httputil.encode_username_password(username, password)

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -438,7 +438,7 @@ class RequestHandler:
         # If \n is allowed into the header, it is possible to inject
         # additional headers or split the request.
         if RequestHandler._VALID_HEADER_CHARS.fullmatch(retval) is None:
-            raise ValueError("Unsafe header value %r", retval)
+            raise ValueError("Unsafe header value %r" % retval)
         return retval
 
     @overload
@@ -1562,7 +1562,7 @@ class RequestHandler:
                     ]
                 )
             else:
-                raise ValueError("unknown xsrf cookie version %d", output_version)
+                raise ValueError("unknown xsrf cookie version %d" % output_version)
             if version is None:
                 if self.current_user and "expires_days" not in cookie_kwargs:
                     cookie_kwargs["expires_days"] = 30
@@ -1999,14 +1999,14 @@ def stream_request_body(cls: Type[_RequestHandlerType]) -> Type[_RequestHandlerT
     for example usage.
     """  # noqa: E501
     if not issubclass(cls, RequestHandler):
-        raise TypeError("expected subclass of RequestHandler, got %r", cls)
+        raise TypeError("expected subclass of RequestHandler, got %r" % cls)
     cls._stream_request_body = True
     return cls
 
 
 def _has_stream_request_body(cls: Type[RequestHandler]) -> bool:
     if not issubclass(cls, RequestHandler):
-        raise TypeError("expected subclass of RequestHandler, got %r", cls)
+        raise TypeError("expected subclass of RequestHandler, got %r" % cls)
     return cls._stream_request_body
 
 

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -745,9 +745,8 @@ class _PerMessageDeflateCompressor:
         # There is no symbolic constant for the minimum wbits value.
         if not (8 <= max_wbits <= zlib.MAX_WBITS):
             raise ValueError(
-                "Invalid max_wbits value %r; allowed range 8-%d",
-                max_wbits,
-                zlib.MAX_WBITS,
+                "Invalid max_wbits value %r; allowed range 8-%d"
+                % (max_wbits, zlib.MAX_WBITS)
             )
         self._max_wbits = max_wbits
 
@@ -794,9 +793,8 @@ class _PerMessageDeflateDecompressor:
             max_wbits = zlib.MAX_WBITS
         if not (8 <= max_wbits <= zlib.MAX_WBITS):
             raise ValueError(
-                "Invalid max_wbits value %r; allowed range 8-%d",
-                max_wbits,
-                zlib.MAX_WBITS,
+                "Invalid max_wbits value %r; allowed range 8-%d"
+                % (max_wbits, zlib.MAX_WBITS)
             )
         self._max_wbits = max_wbits
         if persistent:
@@ -1001,7 +999,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             if ext[0] == "permessage-deflate" and self._compression_options is not None:
                 self._create_compressors("client", ext[1])
             else:
-                raise ValueError("unsupported extension %r", ext)
+                raise ValueError("unsupported extension %r" % (ext,))
 
         self.selected_subprotocol = headers.get("Sec-WebSocket-Protocol", None)
 


### PR DESCRIPTION
Several `raise` statements across the codebase pass format arguments to exception constructors using a comma instead of `%` operator:

```python
# Before (comma creates a tuple message):
raise ValueError("message %s", value)

# After (proper string formatting):
raise ValueError("message %s" % value)
```

When Python's `Exception.__init__` receives multiple arguments, `str(e)` shows the raw tuple representation instead of a formatted message. For example, `ValueError("unsupported auth_mode %s", "digest")` displays as:

```
ValueError: ('unsupported auth_mode %s', 'digest')
```

instead of:

```
ValueError: unsupported auth_mode digest
```

Affected locations:
- `web.py`: `_convert_header_value`, `xsrf_token`, `stream_request_body`, `_has_stream_request_body`
- `websocket.py`: `_PerMessageDeflateCompressor.__init__`, `_PerMessageDeflateDecompressor.__init__`, `_process_server_headers`
- `simple_httpclient.py`: HTTP basic auth mode validation
- `netutil.py`: Unix socket bind validation
- `concurrent.py`: `run_on_executor` argument validation
