### PR TITLE
Fix incorrect return type annotation for Locale.format_day

### DIFF
--- a/pr_body2.md
+++ b/pr_body2.md
@@ -1,0 +1,16 @@
+In `TCPClient._create_stream`, if `IOStream()` constructor raises `OSError`, the except handler references `stream` which was never assigned:
+
+```python
+try:
+    stream = IOStream(socket_obj, max_buffer_size=max_buffer_size)
+except OSError as e:
+    fu = Future()
+    fu.set_exception(e)
+    return stream, fu  # NameError: 'stream' is not defined
+```
+
+This causes a `NameError` that masks the original `OSError`, making it impossible to diagnose the root cause from the traceback.
+
+Additionally the socket object would be leaked since it's never closed in the error path.
+
+Fixed by returning the `socket_obj` instead of the undefined `stream` variable, and closing the socket before returning.

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -433,7 +433,7 @@ class Locale:
 
     def format_day(
         self, date: datetime.datetime, gmt_offset: int = 0, dow: bool = True
-    ) -> bool:
+    ) -> str:
         """Formats the given date as a day of week.
 
         Example: "Monday, January 22". You can remove the day of week with


### PR DESCRIPTION
`Locale.format_day` is annotated as returning `bool`, but it actually returns a formatted string (e.g. `"Monday, January 22"`).

This incorrect annotation causes type checkers to flag valid usage as errors and can mislead IDE autocompletion.
