### PR TITLE
Make tests compatible with curl 8.19.0

### DIFF
--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -622,7 +622,10 @@ X-XSS-Protection: 1;
         with self.assertRaises((ValueError, HTTPError)) as context:  # type: ignore
             request = HTTPRequest(url, network_interface="not-interface-or-ip")
             yield self.http_client.fetch(request)
-        self.assertIn("not-interface-or-ip", str(context.exception))
+        self.assertTrue(
+            "Failed binding local connection end" in str(context.exception)
+            or "not-interface-or-ip" in str(context.exception)
+        )
 
     def test_all_methods(self):
         for method in ["GET", "DELETE", "OPTIONS"]:


### PR DESCRIPTION
In 8.19.0-rc2, the error logic has been changed so any later errors are preserved. This changes what is returned by curl and therefore what tornado sees. For HTTPError variant of the test, which uses CurlAsyncHTTPClient, we get the error from pycurl and now it contains "Failed binding local connection end". This logic handles both the old version of libcurl and also the newer one.