### PR TITLE
build: Bump cibuildwheel to 3.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: ${{ env.python-version }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.4.0
 
       - name: Audit ABI3 compliance
         # This may be moved into cibuildwheel itself in the future. See


### PR DESCRIPTION
cibuildwheel 2.x is consistently failing (on macos and windows) with a "429 too many requests" error from some URL that is not clear from the logs. Use a newer version which appears to have better caching. (It also changes more than I'd like, such as a different manylinux base image, but I don't know a better way to get the branch back into releasable shape)