### PR TITLE
*: Rewrite imports with isort

### DIFF
--- a/tornado/__init__.pyi
+++ b/tornado/__init__.pyi
@@ -3,31 +3,33 @@ import typing
 version: str
 version_info: typing.Tuple[int, int, int, int]
 
-from . import auth
-from . import autoreload
-from . import concurrent
-from . import curl_httpclient
-from . import escape
-from . import gen
-from . import http1connection
-from . import httpclient
-from . import httpserver
-from . import httputil
-from . import ioloop
-from . import iostream
-from . import locale
-from . import locks
-from . import log
-from . import netutil
-from . import options
-from . import platform
-from . import process
-from . import queues
-from . import routing
-from . import simple_httpclient
-from . import tcpclient
-from . import tcpserver
-from . import template
-from . import testing
-from . import util
-from . import web
+from . import (
+    auth,
+    autoreload,
+    concurrent,
+    curl_httpclient,
+    escape,
+    gen,
+    http1connection,
+    httpclient,
+    httpserver,
+    httputil,
+    ioloop,
+    iostream,
+    locale,
+    locks,
+    log,
+    netutil,
+    options,
+    platform,
+    process,
+    queues,
+    routing,
+    simple_httpclient,
+    tcpclient,
+    tcpserver,
+    template,
+    testing,
+    util,
+    web,
+)

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -77,15 +77,13 @@ import time
 import urllib.parse
 import uuid
 import warnings
+from collections.abc import Iterable
+from typing import Any, cast
 
-from tornado import httpclient
-from tornado import escape
+from tornado import escape, httpclient
 from tornado.httputil import url_concat
 from tornado.util import unicode_type
 from tornado.web import RequestHandler
-
-from typing import Any, cast
-from collections.abc import Iterable
 
 
 class AuthError(Exception):

--- a/tornado/autoreload.py
+++ b/tornado/autoreload.py
@@ -78,15 +78,14 @@ import functools
 import importlib.abc
 import os
 import pkgutil
+import subprocess
 import sys
 import traceback
 import types
-import subprocess
 import weakref
 
-from tornado import ioloop
+from tornado import ioloop, process
 from tornado.log import gen_log
-from tornado import process
 
 try:
     import signal
@@ -265,6 +264,7 @@ def main() -> None:
     # parsing at the first positional argument. optparse supports
     # this but as far as I can tell argparse does not.
     import optparse
+
     import tornado.autoreload
 
     global _autoreload_is_main

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -26,16 +26,15 @@ directly.
 """
 
 import asyncio
-from concurrent import futures
 import functools
 import sys
 import types
+import typing
+from collections.abc import Callable
+from concurrent import futures
+from typing import Any, Union
 
 from tornado.log import app_log
-
-import typing
-from typing import Any, Union
-from collections.abc import Callable
 
 _T = typing.TypeVar("_T")
 

--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -17,30 +17,27 @@
 
 import collections
 import functools
+import inspect
 import logging
-import pycurl
 import re
 import threading
 import time
-import inspect
+from collections.abc import Callable
 from io import BytesIO
+from typing import Any
 
-from tornado import gen
-from tornado import httputil
-from tornado import ioloop
+import pycurl
 
-from tornado.escape import utf8, native_str
+from tornado import gen, httputil, ioloop
+from tornado.escape import native_str, utf8
 from tornado.httpclient import (
+    AsyncHTTPClient,
+    HTTPError,
     HTTPRequest,
     HTTPResponse,
-    HTTPError,
-    AsyncHTTPClient,
     main,
 )
 from tornado.log import app_log
-
-from typing import Any
-from collections.abc import Callable
 
 curl_log = logging.getLogger("tornado.curl_httpclient")
 

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -28,13 +28,12 @@ docstrings on each function for details.
 import html
 import json
 import re
+import typing
 import urllib.parse
+from collections.abc import Callable
+from typing import Any
 
 from tornado.util import unicode_type
-
-import typing
-from typing import Any
-from collections.abc import Callable
 
 
 def xhtml_escape(value: str | bytes) -> str:

--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -64,40 +64,37 @@ function to extend this mechanism.
 import asyncio
 import builtins
 import collections
-from collections.abc import Generator
 import concurrent.futures
 import contextvars
 import datetime
 import functools
-from functools import singledispatch
-from inspect import isawaitable
 import sys
 import types
+import typing
+from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, Sequence
+from functools import singledispatch
+from inspect import isawaitable
+from typing import (
+    Any,
+    Dict,
+    List,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 from tornado.concurrent import (
     Future,
-    is_future,
     chain_future,
-    future_set_exc_info,
     future_add_done_callback,
+    future_set_exc_info,
     future_set_result_unless_cancelled,
+    is_future,
 )
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 from tornado.util import TimeoutError
-
-import typing
-from typing import (
-    Union,
-    Any,
-    List,
-    Type,
-    Tuple,
-    Dict,
-    overload,
-)
-from collections.abc import Callable, Iterable
-from collections.abc import Mapping, Awaitable, Sequence
 
 _T = typing.TypeVar("_T")
 

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -22,23 +22,18 @@ import asyncio
 import logging
 import re
 import types
+from collections.abc import Awaitable, Callable
+from typing import Optional, Type, cast
 
+from tornado import gen, httputil, iostream
 from tornado.concurrent import (
     Future,
     future_add_done_callback,
     future_set_result_unless_cancelled,
 )
 from tornado.escape import native_str, utf8
-from tornado import gen
-from tornado import httputil
-from tornado import iostream
-from tornado.log import gen_log, app_log
+from tornado.log import app_log, gen_log
 from tornado.util import GzipDecompressor
-
-
-from typing import cast, Optional, Type
-from collections.abc import Callable
-from collections.abc import Awaitable
 
 CR_OR_LF_RE = re.compile(b"\r|\n")
 

--- a/tornado/httpclient.py
+++ b/tornado/httpclient.py
@@ -38,24 +38,22 @@ To select ``curl_httpclient``, call `AsyncHTTPClient.configure` at startup::
 
 import datetime
 import functools
-from io import BytesIO
 import ssl
 import time
 import weakref
+from collections.abc import Awaitable, Callable
+from io import BytesIO
+from typing import Any, Optional, Type, Union, cast
 
+from tornado import gen, httputil
 from tornado.concurrent import (
     Future,
-    future_set_result_unless_cancelled,
     future_set_exception_unless_cancelled,
+    future_set_result_unless_cancelled,
 )
-from tornado.escape import utf8, native_str
-from tornado import gen, httputil
+from tornado.escape import native_str, utf8
 from tornado.ioloop import IOLoop
 from tornado.util import Configurable
-
-from typing import Type, Any, Union, Optional, cast
-from collections.abc import Callable
-from collections.abc import Awaitable
 
 
 class HTTPClient:

--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -27,19 +27,15 @@ class except to start a server at the beginning of the process
 
 import socket
 import ssl
+import typing
+from collections.abc import Awaitable, Callable
+from typing import Any
 
+from tornado import httputil, iostream, netutil
 from tornado.escape import native_str
-from tornado.http1connection import HTTP1ServerConnection, HTTP1ConnectionParameters
-from tornado import httputil
-from tornado import iostream
-from tornado import netutil
+from tornado.http1connection import HTTP1ConnectionParameters, HTTP1ServerConnection
 from tornado.tcpserver import TCPServer
 from tornado.util import Configurable
-
-import typing
-from typing import Any
-from collections.abc import Callable
-from collections.abc import Awaitable
 
 
 class HTTPServer(TCPServer, Configurable, httputil.HTTPServerConnectionDelegate):

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -27,16 +27,16 @@ import copy
 import dataclasses
 import datetime
 import email.utils
-from functools import lru_cache
-from http.client import responses
 import http.cookies
 import re
-from ssl import SSLError
 import time
 import unicodedata
-from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
+from functools import lru_cache
+from http.client import responses
+from ssl import SSLError
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from tornado.escape import native_str, parse_qs_bytes, utf8, to_unicode
+from tornado.escape import native_str, parse_qs_bytes, to_unicode, utf8
 from tornado.util import ObjectDict, unicode_type
 
 # responses is unused in this file, but we re-export it to other files.
@@ -44,16 +44,16 @@ from tornado.util import ObjectDict, unicode_type
 responses
 
 import typing
+from collections.abc import Awaitable, Generator, Iterable, Iterator, Mapping
 from typing import (
     AnyStr,
 )
-from collections.abc import Iterable, Mapping, Iterator, Awaitable, Generator
 
 if typing.TYPE_CHECKING:
     # These are relatively heavy imports and aren't needed in this file
     # unless we're type-checking.
-    from asyncio import Future
     import unittest
+    from asyncio import Future
 
 # To be used with str.strip() and related methods.
 HTTP_WHITESPACE = " \t"

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -29,29 +29,27 @@ import asyncio
 import concurrent.futures
 import datetime
 import functools
+import math
 import numbers
 import os
+import random
 import sys
 import time
-import math
-import random
+import typing
 import warnings
+from collections.abc import Awaitable, Callable
 from inspect import isawaitable
+from typing import Any, Protocol, TypedDict, TypeVar
 
 from tornado.concurrent import (
     Future,
-    is_future,
     chain_future,
-    future_set_exc_info,
     future_add_done_callback,
+    future_set_exc_info,
+    is_future,
 )
 from tornado.log import app_log
 from tornado.util import Configurable, TimeoutError, import_object
-
-import typing
-from typing import Any, TypeVar, TypedDict, Protocol
-from collections.abc import Callable
-from collections.abc import Awaitable
 
 
 class _Selectable(Protocol):

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -29,26 +29,24 @@ import errno
 import io
 import numbers
 import os
+import re
 import socket
 import ssl
 import sys
-import re
-
-from tornado.concurrent import Future, future_set_result_unless_cancelled
-from tornado import ioloop
-from tornado.log import gen_log
-from tornado.netutil import ssl_wrap_socket, _client_ssl_defaults, _server_ssl_defaults
-from tornado.util import errno_from_exception
-
 import typing
+from collections.abc import Awaitable, Callable
+from re import Pattern
+from types import TracebackType
 from typing import (
     Any,
     TypeVar,
 )
-from collections.abc import Callable
-from collections.abc import Awaitable
-from re import Pattern
-from types import TracebackType
+
+from tornado import ioloop
+from tornado.concurrent import Future, future_set_result_unless_cancelled
+from tornado.log import gen_log
+from tornado.netutil import _client_ssl_defaults, _server_ssl_defaults, ssl_wrap_socket
+from tornado.util import errno_from_exception
 
 _IOStreamType = TypeVar("_IOStreamType", bound="IOStream")
 

--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -46,14 +46,12 @@ import gettext
 import glob
 import os
 import re
+from collections.abc import Iterable
+from typing import Any
 
 from tornado import escape
-from tornado.log import gen_log
-
 from tornado._locale_data import LOCALE_NAMES
-
-from typing import Any
-from collections.abc import Iterable
+from tornado.log import gen_log
 
 _default_locale = "en_US"
 _translations: dict[str, Any] = {}

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -15,12 +15,11 @@
 import collections
 import datetime
 import types
+from collections.abc import Awaitable
+from typing import Any, Optional, Type
 
 from tornado import gen, ioloop
 from tornado.concurrent import Future, future_set_result_unless_cancelled
-
-from typing import Optional, Type, Any
-from collections.abc import Awaitable
 
 __all__ = ["Condition", "Event", "Semaphore", "BoundedSemaphore", "Lock"]
 

--- a/tornado/log.py
+++ b/tornado/log.py
@@ -33,7 +33,7 @@ import logging.handlers
 import sys
 
 from tornado.escape import _unicode
-from tornado.util import unicode_type, basestring_type
+from tornado.util import basestring_type, unicode_type
 
 try:
     import colorama  # type: ignore

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -19,18 +19,16 @@ import asyncio
 import concurrent.futures
 import errno
 import os
-import sys
 import socket
 import ssl
 import stat
+import sys
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from tornado.concurrent import dummy_executor, run_on_executor
 from tornado.ioloop import IOLoop
 from tornado.util import Configurable, errno_from_exception
-
-from typing import Any
-from collections.abc import Callable
-from collections.abc import Awaitable
 
 # Note that the naming of ssl.Purpose is confusing; the purpose
 # of a context is to authenticate the opposite side of the connection.

--- a/tornado/options.py
+++ b/tornado/options.py
@@ -101,21 +101,19 @@ instances to define isolated sets of options, such as for subcommands.
 
 import datetime
 import numbers
+import os
 import re
 import sys
-import os
 import textwrap
-
-from tornado.escape import _unicode, native_str
-from tornado.log import define_logging_options
-from tornado.util import basestring_type, exec_in
-
+from collections.abc import Callable, Iterable, Iterator
 from typing import (
     Any,
     TextIO,
 )
-from collections.abc import Callable
-from collections.abc import Iterator, Iterable
+
+from tornado.escape import _unicode, native_str
+from tornado.log import define_logging_options
+from tornado.util import basestring_type, exec_in
 
 
 class Error(Exception):

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -34,16 +34,16 @@ import sys
 import threading
 import typing
 import warnings
-from tornado.gen import convert_yielded
-from tornado.ioloop import IOLoop, _Selectable
-
+from collections.abc import Callable
 from typing import (
     Any,
     Protocol,
     TypeVar,
     Union,
 )
-from collections.abc import Callable
+
+from tornado.gen import convert_yielded
+from tornado.ioloop import IOLoop, _Selectable
 
 if typing.TYPE_CHECKING:
     from typing_extensions import TypeVarTuple, Unpack

--- a/tornado/platform/caresresolver.py
+++ b/tornado/platform/caresresolver.py
@@ -1,14 +1,14 @@
-import pycares  # type: ignore
 import socket
+import typing
+from collections.abc import Generator
+from typing import Any
 
-from tornado.concurrent import Future
+import pycares  # type: ignore
+
 from tornado import gen
+from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 from tornado.netutil import Resolver, is_valid_ip
-
-import typing
-from typing import Any
-from collections.abc import Generator
 
 
 class CaresResolver(Resolver):

--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -12,14 +12,13 @@
 """Bridges between the Twisted package and Tornado."""
 
 import sys
+import typing
 
 from twisted.internet.defer import Deferred  # type: ignore
 from twisted.python import failure  # type: ignore
 
-from tornado.concurrent import Future, future_set_exc_info
 from tornado import gen
-
-import typing
+from tornado.concurrent import Future, future_set_exc_info
 
 
 def install() -> None:

--- a/tornado/process.py
+++ b/tornado/process.py
@@ -18,26 +18,24 @@ the server into multiple processes and managing subprocesses.
 """
 
 import asyncio
-import os
 import multiprocessing
+import os
 import signal
 import subprocess
 import sys
 import time
-
 from binascii import hexlify
+from collections.abc import Callable
+from typing import Any
 
+from tornado import ioloop
 from tornado.concurrent import (
     Future,
-    future_set_result_unless_cancelled,
     future_set_exception_unless_cancelled,
+    future_set_result_unless_cancelled,
 )
-from tornado import ioloop
 from tornado.iostream import PipeIOStream
 from tornado.log import gen_log
-
-from typing import Any
-from collections.abc import Callable
 
 # Re-export this exception for convenience.
 CalledProcessError = subprocess.CalledProcessError

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -30,13 +30,12 @@ from __future__ import annotations
 import collections
 import datetime
 import heapq
+from collections.abc import Awaitable
+from typing import Any, Generic, TypeVar
 
 from tornado import gen, ioloop
 from tornado.concurrent import Future, future_set_result_unless_cancelled
 from tornado.locks import Event
-
-from typing import TypeVar, Generic, Any
-from collections.abc import Awaitable
 
 _T = TypeVar("_T")
 

--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -176,21 +176,20 @@ For more information on application-level routing see docs for `~.web.Applicatio
 """
 
 import re
+from collections.abc import Awaitable, Sequence
 from functools import partial
-
-from tornado import httputil
-from tornado.httpserver import _CallableAdapter
-from tornado.escape import url_escape, url_unescape, utf8
-from tornado.log import app_log
-from tornado.util import basestring_type, import_object, re_unescape, unicode_type
-
+from re import Pattern
 from typing import (
     Any,
     Union,
     overload,
 )
-from collections.abc import Awaitable, Sequence
-from re import Pattern
+
+from tornado import httputil
+from tornado.escape import url_escape, url_unescape, utf8
+from tornado.httpserver import _CallableAdapter
+from tornado.log import app_log
+from tornado.util import basestring_type, import_object, re_unescape, unicode_type
 
 
 class Router(httputil.HTTPServerConnectionDelegate):

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -1,26 +1,3 @@
-from tornado.escape import _unicode
-from tornado import gen, version
-from tornado.httpclient import (
-    HTTPResponse,
-    HTTPError,
-    AsyncHTTPClient,
-    main,
-    _RequestProxy,
-    HTTPRequest,
-)
-from tornado import httputil
-from tornado.http1connection import HTTP1Connection, HTTP1ConnectionParameters
-from tornado.ioloop import IOLoop
-from tornado.iostream import StreamClosedError, IOStream
-from tornado.netutil import (
-    Resolver,
-    OverrideResolver,
-    _client_ssl_defaults,
-    is_valid_ip,
-)
-from tornado.log import gen_log
-from tornado.tcpclient import TCPClient
-
 import base64
 import collections
 import copy
@@ -30,13 +7,33 @@ import socket
 import ssl
 import sys
 import time
-from io import BytesIO
 import urllib.parse
-
-from typing import Any, Optional, Type
-from collections.abc import Callable
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
+from io import BytesIO
 from types import TracebackType
+from typing import Any, Optional, Type
+
+from tornado import gen, httputil, version
+from tornado.escape import _unicode
+from tornado.http1connection import HTTP1Connection, HTTP1ConnectionParameters
+from tornado.httpclient import (
+    AsyncHTTPClient,
+    HTTPError,
+    HTTPRequest,
+    HTTPResponse,
+    _RequestProxy,
+    main,
+)
+from tornado.ioloop import IOLoop
+from tornado.iostream import IOStream, StreamClosedError
+from tornado.log import gen_log
+from tornado.netutil import (
+    OverrideResolver,
+    Resolver,
+    _client_ssl_defaults,
+    is_valid_ip,
+)
+from tornado.tcpclient import TCPClient
 
 
 class HTTPTimeoutError(HTTPError):

--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -15,22 +15,20 @@
 
 """A non-blocking TCP connection factory."""
 
-import functools
-import socket
-import numbers
 import datetime
+import functools
+import numbers
+import socket
 import ssl
+from collections.abc import Callable, Iterator
+from typing import Any, Tuple
 
+from tornado import gen
 from tornado.concurrent import Future, future_add_done_callback
+from tornado.gen import TimeoutError
 from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream
-from tornado import gen
 from tornado.netutil import Resolver
-from tornado.gen import TimeoutError
-
-from typing import Any, Tuple
-from collections.abc import Callable
-from collections.abc import Iterator
 
 _INITIAL_CONNECT_TIMEOUT = 0.3
 

--- a/tornado/tcpserver.py
+++ b/tornado/tcpserver.py
@@ -19,22 +19,20 @@ import errno
 import os
 import socket
 import ssl
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
 
-from tornado import gen
-from tornado.log import app_log
+from tornado import gen, process
 from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream, SSLIOStream
+from tornado.log import app_log
 from tornado.netutil import (
-    bind_sockets,
-    add_accept_handler,
-    ssl_wrap_socket,
     _DEFAULT_BACKLOG,
+    add_accept_handler,
+    bind_sockets,
+    ssl_wrap_socket,
 )
-from tornado import process
 from tornado.util import errno_from_exception
-
-from typing import Any
-from collections.abc import Iterable, Awaitable, Callable
 
 
 class TCPServer:

--- a/tornado/template.py
+++ b/tornado/template.py
@@ -197,21 +197,19 @@ To include a literal ``{{``, ``{%``, or ``{#`` in the output, escape them as
 """
 
 import datetime
-from io import StringIO
 import linecache
 import os.path
 import posixpath
 import re
 import threading
+import typing
+from collections.abc import Callable, Iterable
+from io import StringIO
+from typing import Any, ContextManager, Optional, TextIO
 
 from tornado import escape
 from tornado.log import app_log
 from tornado.util import ObjectDict, exec_in, unicode_type
-
-from typing import Any, Optional, TextIO, ContextManager
-from collections.abc import Callable
-from collections.abc import Iterable
-import typing
 
 _DEFAULT_AUTOESCAPE = "xhtml_escape"
 

--- a/tornado/test/asyncio_test.py
+++ b/tornado/test/asyncio_test.py
@@ -16,23 +16,23 @@ import threading
 import time
 import unittest
 import warnings
-
 from concurrent.futures import ThreadPoolExecutor
+
 import tornado.platform.asyncio
 from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.platform.asyncio import (
+    AddThreadSelectorEventLoop,
     AsyncIOLoop,
     to_asyncio_future,
-    AddThreadSelectorEventLoop,
 )
+from tornado.test.util import ignore_deprecation
 from tornado.testing import (
+    AsyncHTTPTestCase,
     AsyncTestCase,
     gen_test,
     setup_with_context_manager,
-    AsyncHTTPTestCase,
 )
-from tornado.test.util import ignore_deprecation
 from tornado.web import Application, RequestHandler
 
 

--- a/tornado/test/auth_test.py
+++ b/tornado/test/auth_test.py
@@ -5,21 +5,21 @@
 
 from unittest import mock
 
+from tornado import gen
 from tornado.auth import (
-    OpenIdMixin,
-    OAuthMixin,
-    OAuth2Mixin,
-    GoogleOAuth2Mixin,
     FacebookGraphMixin,
+    GoogleOAuth2Mixin,
+    OAuth2Mixin,
+    OAuthMixin,
+    OpenIdMixin,
     TwitterMixin,
 )
 from tornado.escape import json_decode
-from tornado import gen
 from tornado.httpclient import HTTPClientError
 from tornado.httputil import url_concat
 from tornado.log import app_log
 from tornado.testing import AsyncHTTPTestCase, ExpectLog
-from tornado.web import RequestHandler, Application, HTTPError
+from tornado.web import Application, HTTPError, RequestHandler
 
 
 class OpenIdClientLoginHandler(RequestHandler, OpenIdMixin):

--- a/tornado/test/autoreload_test.py
+++ b/tornado/test/autoreload_test.py
@@ -1,12 +1,12 @@
 import os
 import shutil
 import subprocess
-from subprocess import Popen
 import sys
-from tempfile import mkdtemp
 import textwrap
 import time
 import unittest
+from subprocess import Popen
+from tempfile import mkdtemp
 
 
 class AutoreloadTest(unittest.TestCase):

--- a/tornado/test/circlerefs_test.py
+++ b/tornado/test/circlerefs_test.py
@@ -17,7 +17,7 @@ import types
 import unittest
 
 import tornado
-from tornado import web, gen, httpclient
+from tornado import gen, httpclient, web
 from tornado.test.util import skipNotCPython
 
 

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -12,20 +12,20 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from concurrent import futures
 import logging
 import re
 import socket
 import unittest
+from concurrent import futures
 
+from tornado import gen
 from tornado.concurrent import (
     Future,
     chain_future,
-    run_on_executor,
     future_set_result_unless_cancelled,
+    run_on_executor,
 )
-from tornado.escape import utf8, to_unicode
-from tornado import gen
+from tornado.escape import to_unicode, utf8
 from tornado.iostream import IOStream
 from tornado.tcpserver import TCPServer
 from tornado.testing import AsyncTestCase, bind_unused_port, gen_test

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -1,11 +1,11 @@
-from hashlib import md5
 import unittest
+from hashlib import md5
 
-from tornado.escape import utf8
-from tornado.testing import AsyncHTTPTestCase
-from tornado.test import httpclient_test
-from tornado.web import Application, RequestHandler
 from tornado import gen
+from tornado.escape import utf8
+from tornado.test import httpclient_test
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application, RequestHandler
 
 try:
     import pycurl

--- a/tornado/test/escape_test.py
+++ b/tornado/test/escape_test.py
@@ -1,21 +1,20 @@
 import unittest
+from typing import Any
 
 import tornado
 from tornado.escape import (
+    json_decode,
+    json_encode,
+    recursive_unicode,
+    squeeze,
+    to_unicode,
+    url_escape,
+    url_unescape,
     utf8,
     xhtml_escape,
     xhtml_unescape,
-    url_escape,
-    url_unescape,
-    to_unicode,
-    json_decode,
-    json_encode,
-    squeeze,
-    recursive_unicode,
 )
 from tornado.util import unicode_type
-
-from typing import Any
 
 linkify_tests: list[tuple[str | bytes, dict[str, Any], str]] = [
     # (input, linkify_kwargs, expected_output)

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -1,21 +1,20 @@
 import asyncio
-from concurrent import futures
 import contextvars
-import gc
 import datetime
+import gc
 import platform
 import sys
 import time
-import weakref
 import unittest
-
-from tornado.concurrent import Future
-from tornado.log import app_log
-from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
-from tornado.test.util import skipNotCPython
-from tornado.web import Application, RequestHandler, HTTPError
+import weakref
+from concurrent import futures
 
 from tornado import gen
+from tornado.concurrent import Future
+from tornado.log import app_log
+from tornado.test.util import skipNotCPython
+from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
+from tornado.web import Application, HTTPError, RequestHandler
 
 
 class GenBasicTest(AsyncTestCase):

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -1,35 +1,34 @@
 import base64
 import binascii
-from contextlib import closing
 import copy
-import gzip
-import threading
 import datetime
-from io import BytesIO
+import gzip
 import subprocess
 import sys
+import threading
 import time
 import unicodedata
 import unittest
+from contextlib import closing
+from io import BytesIO
 
-from tornado.escape import utf8, native_str, to_unicode
-from tornado import gen
+from tornado import gen, netutil
+from tornado.escape import native_str, to_unicode, utf8
 from tornado.httpclient import (
+    HTTPClient,
+    HTTPError,
     HTTPRequest,
     HTTPResponse,
     _RequestProxy,
-    HTTPError,
-    HTTPClient,
 )
 from tornado.httpserver import HTTPServer
+from tornado.httputil import HTTPHeaders, format_timestamp
 from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream
-from tornado.log import gen_log, app_log
-from tornado import netutil
-from tornado.testing import AsyncHTTPTestCase, bind_unused_port, gen_test, ExpectLog
+from tornado.log import app_log, gen_log
 from tornado.test.util import ignore_deprecation
+from tornado.testing import AsyncHTTPTestCase, ExpectLog, bind_unused_port, gen_test
 from tornado.web import Application, RequestHandler, url
-from tornado.httputil import format_timestamp, HTTPHeaders
 
 
 class HelloWorldHandler(RequestHandler):

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -1,11 +1,28 @@
+import datetime
+import gzip
+import logging
+import os
+import shutil
+import socket
+import ssl
+import sys
+import tempfile
+import textwrap
+import typing
+import unittest
+import urllib.parse
+import uuid
+from contextlib import closing, contextmanager
+from io import BytesIO
+
 from tornado import gen, netutil
 from tornado.escape import (
+    _unicode,
     json_decode,
     json_encode,
-    utf8,
-    _unicode,
-    recursive_unicode,
     native_str,
+    recursive_unicode,
+    utf8,
 )
 from tornado.http1connection import HTTP1Connection
 from tornado.httpclient import HTTPError
@@ -18,35 +35,17 @@ from tornado.httputil import (
 )
 from tornado.iostream import IOStream
 from tornado.locks import Event
-from tornado.log import gen_log, app_log
+from tornado.log import app_log, gen_log
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
+from tornado.test.util import abstract_base_test
 from tornado.testing import (
-    AsyncHTTPTestCase,
     AsyncHTTPSTestCase,
+    AsyncHTTPTestCase,
     AsyncTestCase,
     ExpectLog,
     gen_test,
 )
-from tornado.test.util import abstract_base_test
 from tornado.web import Application, RequestHandler, stream_request_body
-
-from contextlib import closing, contextmanager
-import datetime
-import gzip
-import logging
-import os
-import shutil
-import socket
-import ssl
-import sys
-import tempfile
-import textwrap
-import unittest
-import urllib.parse
-import uuid
-from io import BytesIO
-
-import typing
 
 
 async def read_stream_body(stream):

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -1,29 +1,27 @@
-from tornado.httputil import (
-    url_concat,
-    parse_multipart_form_data,
-    HTTPHeaders,
-    format_timestamp,
-    HTTPServerRequest,
-    parse_request_start_line,
-    parse_cookie,
-    qs_to_qsl,
-    HTTPInputError,
-    HTTPFile,
-    ParseMultipartConfig,
-)
-from tornado.escape import utf8, native_str
-from tornado.log import gen_log
-from tornado.test.util import ignore_deprecation
-
 import copy
 import datetime
 import logging
 import pickle
 import time
-import urllib.parse
 import unittest
+import urllib.parse
 
-from tornado.test.util import skipIfEmulated
+from tornado.escape import native_str, utf8
+from tornado.httputil import (
+    HTTPFile,
+    HTTPHeaders,
+    HTTPInputError,
+    HTTPServerRequest,
+    ParseMultipartConfig,
+    format_timestamp,
+    parse_cookie,
+    parse_multipart_form_data,
+    parse_request_start_line,
+    qs_to_qsl,
+    url_concat,
+)
+from tornado.log import gen_log
+from tornado.test.util import ignore_deprecation, skipIfEmulated
 
 
 def form_data_args() -> tuple[dict[str, list[bytes]], dict[str, list[HTTPFile]]]:

--- a/tornado/test/import_test.py
+++ b/tornado/test/import_test.py
@@ -59,8 +59,9 @@ class ImportTest(unittest.TestCase):
 
     def test_import_aliases(self):
         # Ensure we don't delete formerly-documented aliases accidentally.
-        import tornado
         import asyncio
+
+        import tornado
 
         self.assertIs(tornado.ioloop.TimeoutError, tornado.util.TimeoutError)
         self.assertIs(tornado.gen.TimeoutError, tornado.util.TimeoutError)

--- a/tornado/test/ioloop_test.py
+++ b/tornado/test/ioloop_test.py
@@ -1,7 +1,4 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
-from concurrent import futures
-from collections.abc import Generator
 import contextlib
 import datetime
 import functools
@@ -11,25 +8,28 @@ import sys
 import threading
 import time
 import types
-from unittest import mock
 import unittest
+from collections.abc import Generator
+from concurrent import futures
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
 
-from tornado.escape import native_str
 from tornado import gen
-from tornado.ioloop import IOLoop, TimeoutError, PeriodicCallback
+from tornado.concurrent import Future
+from tornado.escape import native_str
+from tornado.ioloop import IOLoop, PeriodicCallback, TimeoutError
 from tornado.log import app_log
-from tornado.testing import (
-    AsyncTestCase,
-    bind_unused_port,
-    ExpectLog,
-    gen_test,
-    setup_with_context_manager,
-)
 from tornado.test.util import (
     ignore_deprecation,
     skipIfNonUnix,
 )
-from tornado.concurrent import Future
+from tornado.testing import (
+    AsyncTestCase,
+    ExpectLog,
+    bind_unused_port,
+    gen_test,
+    setup_with_context_manager,
+)
 
 
 class TestIOLoop(AsyncTestCase):

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -1,36 +1,3 @@
-from tornado.concurrent import Future
-from tornado import gen
-from tornado import netutil
-from tornado.ioloop import IOLoop
-from tornado.iostream import (
-    IOStream,
-    SSLIOStream,
-    PipeIOStream,
-    StreamClosedError,
-    _StreamBuffer,
-)
-from tornado.httpclient import AsyncHTTPClient, HTTPResponse
-from tornado.httputil import HTTPHeaders
-from tornado.locks import Condition, Event
-from tornado.log import gen_log
-from tornado.netutil import ssl_options_to_context, ssl_wrap_socket
-from tornado.platform.asyncio import AddThreadSelectorEventLoop
-from tornado.tcpserver import TCPServer
-from tornado.testing import (
-    AsyncHTTPTestCase,
-    AsyncHTTPSTestCase,
-    AsyncTestCase,
-    bind_unused_port,
-    ExpectLog,
-    gen_test,
-)
-from tornado.test.util import (
-    skipIfNonUnix,
-    refusing_port,
-    ignore_deprecation,
-    abstract_base_test,
-)
-from tornado.web import RequestHandler, Application
 import asyncio
 import errno
 import hashlib
@@ -41,8 +8,41 @@ import random
 import socket
 import ssl
 import typing
-from unittest import mock
 import unittest
+from unittest import mock
+
+from tornado import gen, netutil
+from tornado.concurrent import Future
+from tornado.httpclient import AsyncHTTPClient, HTTPResponse
+from tornado.httputil import HTTPHeaders
+from tornado.ioloop import IOLoop
+from tornado.iostream import (
+    IOStream,
+    PipeIOStream,
+    SSLIOStream,
+    StreamClosedError,
+    _StreamBuffer,
+)
+from tornado.locks import Condition, Event
+from tornado.log import gen_log
+from tornado.netutil import ssl_options_to_context, ssl_wrap_socket
+from tornado.platform.asyncio import AddThreadSelectorEventLoop
+from tornado.tcpserver import TCPServer
+from tornado.test.util import (
+    abstract_base_test,
+    ignore_deprecation,
+    refusing_port,
+    skipIfNonUnix,
+)
+from tornado.testing import (
+    AsyncHTTPSTestCase,
+    AsyncHTTPTestCase,
+    AsyncTestCase,
+    ExpectLog,
+    bind_unused_port,
+    gen_test,
+)
+from tornado.web import Application, RequestHandler
 
 
 def _server_ssl_options():

--- a/tornado/test/locale_test.py
+++ b/tornado/test/locale_test.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 
 import tornado.locale
-from tornado.escape import utf8, to_unicode
+from tornado.escape import to_unicode, utf8
 from tornado.util import unicode_type
 
 

--- a/tornado/test/locks_test.py
+++ b/tornado/test/locks_test.py
@@ -11,12 +11,12 @@
 # under the License.
 
 import asyncio
-from datetime import timedelta
 import unittest
+from datetime import timedelta
 
 from tornado import gen, locks
 from tornado.gen import TimeoutError
-from tornado.testing import gen_test, AsyncTestCase
+from tornado.testing import AsyncTestCase, gen_test
 
 
 class ConditionTest(AsyncTestCase):

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -1,22 +1,21 @@
 import errno
 import signal
 import socket
-from subprocess import Popen
 import sys
 import time
+import typing
 import unittest
+from subprocess import Popen
 
 from tornado.netutil import (
     BlockingResolver,
     OverrideResolver,
     ThreadedResolver,
-    is_valid_ip,
     bind_sockets,
+    is_valid_ip,
 )
-from tornado.testing import AsyncTestCase, gen_test, bind_unused_port
-from tornado.test.util import skipIfNoNetwork, abstract_base_test
-
-import typing
+from tornado.test.util import abstract_base_test, skipIfNoNetwork
+from tornado.testing import AsyncTestCase, bind_unused_port, gen_test
 
 try:
     import pycares  # type: ignore

--- a/tornado/test/options_test.py
+++ b/tornado/test/options_test.py
@@ -1,11 +1,11 @@
 import datetime
-from io import StringIO
 import os
 import sys
-from unittest import mock
 import unittest
+from io import StringIO
+from unittest import mock
 
-from tornado.options import OptionParser, Error
+from tornado.options import Error, OptionParser
 from tornado.util import basestring_type
 
 

--- a/tornado/test/process_test.py
+++ b/tornado/test/process_test.py
@@ -10,11 +10,11 @@ import unittest
 from tornado.httpclient import HTTPClient, HTTPError
 from tornado.httpserver import HTTPServer
 from tornado.log import gen_log
-from tornado.process import fork_processes, task_id, Subprocess
+from tornado.process import Subprocess, fork_processes, task_id
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
-from tornado.testing import bind_unused_port, ExpectLog, AsyncTestCase, gen_test
 from tornado.test.util import skipIfNonUnix
-from tornado.web import RequestHandler, Application
+from tornado.testing import AsyncTestCase, ExpectLog, bind_unused_port, gen_test
+from tornado.web import Application, RequestHandler
 
 
 # Not using AsyncHTTPTestCase because we need control over the IOLoop.

--- a/tornado/test/queues_test.py
+++ b/tornado/test/queues_test.py
@@ -11,13 +11,13 @@
 # under the License.
 
 import asyncio
+import unittest
 from datetime import timedelta
 from random import random
-import unittest
 
 from tornado import gen, queues
 from tornado.gen import TimeoutError
-from tornado.testing import gen_test, AsyncTestCase
+from tornado.testing import AsyncTestCase, gen_test
 
 
 class QueueBasicTest(AsyncTestCase):

--- a/tornado/test/routing_test.py
+++ b/tornado/test/routing_test.py
@@ -10,6 +10,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import typing
+
 from tornado.httputil import (
     HTTPHeaders,
     HTTPMessageDelegate,
@@ -27,8 +29,6 @@ from tornado.routing import (
 from tornado.testing import AsyncHTTPTestCase
 from tornado.web import Application, HTTPError, RequestHandler
 from tornado.wsgi import WSGIContainer
-
-import typing
 
 
 class BasicRouter(Router):

--- a/tornado/test/runtests.py
+++ b/tornado/test/runtests.py
@@ -1,18 +1,18 @@
-from functools import reduce
 import gc
 import io
 import locale  # system locale module, not tornado.locale
 import logging
 import operator
-import textwrap
 import sys
+import textwrap
 import unittest
 import warnings
+from functools import reduce
 
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpserver import HTTPServer
 from tornado.netutil import Resolver
-from tornado.options import define, add_parse_callback, options
+from tornado.options import add_parse_callback, define, options
 from tornado.test.util import ABT_SKIP_MESSAGE
 
 TEST_MODULES = [

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -1,5 +1,4 @@
 import collections
-from contextlib import closing
 import errno
 import logging
 import os
@@ -8,9 +7,10 @@ import socket
 import ssl
 import sys
 import typing
+from contextlib import closing
 
-from tornado.escape import to_unicode, utf8
 from tornado import gen, version
+from tornado.escape import to_unicode, utf8
 from tornado.httpclient import AsyncHTTPClient, HTTPResponse
 from tornado.httpserver import HTTPServer
 from tornado.httputil import HTTPHeaders, ResponseStartLine
@@ -20,10 +20,11 @@ from tornado.locks import Event
 from tornado.log import gen_log
 from tornado.netutil import Resolver, bind_sockets
 from tornado.simple_httpclient import (
-    SimpleAsyncHTTPClient,
     HTTPStreamClosedError,
     HTTPTimeoutError,
+    SimpleAsyncHTTPClient,
 )
+from tornado.test import httpclient_test
 from tornado.test.httpclient_test import (
     ChunkHandler,
     CountdownHandler,
@@ -31,20 +32,19 @@ from tornado.test.httpclient_test import (
     RedirectHandler,
     UserAgentHandler,
 )
-from tornado.test import httpclient_test
+from tornado.test.util import (
+    abstract_base_test,
+    refusing_port,
+    skipIfNoIPv6,
+)
 from tornado.testing import (
-    AsyncHTTPTestCase,
     AsyncHTTPSTestCase,
+    AsyncHTTPTestCase,
     AsyncTestCase,
     ExpectLog,
     gen_test,
 )
-from tornado.test.util import (
-    abstract_base_test,
-    skipIfNoIPv6,
-    refusing_port,
-)
-from tornado.web import RequestHandler, Application, url, stream_request_body
+from tornado.web import Application, RequestHandler, stream_request_body, url
 
 
 class SimpleHTTPClientCommonTestCase(httpclient_test.HTTPClientCommonTestCase):

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -12,22 +12,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from contextlib import closing
 import getpass
 import socket
+import typing
 import unittest
+from contextlib import closing
 
 from tornado.concurrent import Future
+from tornado.gen import TimeoutError
 from tornado.iostream import IOStream
-from tornado.netutil import bind_sockets, Resolver
+from tornado.netutil import Resolver, bind_sockets
 from tornado.queues import Queue
 from tornado.tcpclient import TCPClient, _Connector
 from tornado.tcpserver import TCPServer
+from tornado.test.util import refusing_port, skipIfNoIPv6, skipIfNonUnix
 from tornado.testing import AsyncTestCase, gen_test
-from tornado.test.util import skipIfNoIPv6, refusing_port, skipIfNonUnix
-from tornado.gen import TimeoutError
-
-import typing
 
 # Fake address families for testing.  Used in place of AF_INET
 # and AF_INET6 because some installations do not have AF_INET6.

--- a/tornado/test/template_test.py
+++ b/tornado/test/template_test.py
@@ -2,8 +2,8 @@ import os
 import traceback
 import unittest
 
-from tornado.escape import utf8, native_str, to_unicode
-from tornado.template import Template, DictLoader, ParseError, Loader
+from tornado.escape import native_str, to_unicode, utf8
+from tornado.template import DictLoader, Loader, ParseError, Template
 from tornado.util import ObjectDict
 
 

--- a/tornado/test/testing_test.py
+++ b/tornado/test/testing_test.py
@@ -1,8 +1,3 @@
-from tornado import gen, ioloop
-from tornado.httpserver import HTTPServer
-from tornado.locks import Event
-from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, gen_test
-from tornado.web import Application
 import asyncio
 import contextlib
 import gc
@@ -12,6 +7,12 @@ import sys
 import traceback
 import unittest
 import warnings
+
+from tornado import gen, ioloop
+from tornado.httpserver import HTTPServer
+from tornado.locks import Event
+from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, bind_unused_port, gen_test
+from tornado.web import Application
 
 
 @contextlib.contextmanager

--- a/tornado/test/util_test.py
+++ b/tornado/test/util_test.py
@@ -1,22 +1,21 @@
+import datetime
 import re
 import sys
-import datetime
 import textwrap
 import unittest
+from typing import Any, cast
 
 import tornado
 from tornado.escape import utf8
 from tornado.util import (
-    raise_exc_info,
+    ArgReplacer,
     Configurable,
     exec_in,
-    ArgReplacer,
-    timedelta_to_seconds,
     import_object,
+    raise_exc_info,
     re_unescape,
+    timedelta_to_seconds,
 )
-
-from typing import cast, Any
 
 
 class RaiseExcInfoTest(unittest.TestCase):

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1,55 +1,10 @@
-import http
-
-from tornado.concurrent import Future
-from tornado import gen
-from tornado.escape import (
-    json_decode,
-    utf8,
-    to_unicode,
-    recursive_unicode,
-    native_str,
-    to_basestring,
-)
-from tornado.httpclient import HTTPClientError
-from tornado.httputil import format_timestamp
-from tornado.iostream import IOStream
-from tornado import locale
-from tornado.locks import Event
-from tornado.log import app_log, gen_log
-from tornado.simple_httpclient import SimpleAsyncHTTPClient
-from tornado.template import DictLoader
-from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
-from tornado.test.util import ignore_deprecation
-from tornado.util import ObjectDict, unicode_type
-from tornado.web import (
-    Application,
-    RequestHandler,
-    StaticFileHandler,
-    RedirectHandler as WebRedirectHandler,
-    HTTPError,
-    MissingArgumentError,
-    ErrorHandler,
-    authenticated,
-    url,
-    _create_signature_v1,
-    create_signed_value,
-    decode_signed_value,
-    get_signature_key_version,
-    UIModule,
-    Finish,
-    stream_request_body,
-    removeslash,
-    addslash,
-    GZipContentEncoding,
-)
-
 import binascii
 import contextlib
 import copy
 import datetime
 import email.utils
 import gzip
-from io import BytesIO
+import http
 import itertools
 import logging
 import os
@@ -58,6 +13,51 @@ import socket
 import typing
 import unittest
 import urllib.parse
+from io import BytesIO
+
+from tornado import gen, locale
+from tornado.concurrent import Future
+from tornado.escape import (
+    json_decode,
+    native_str,
+    recursive_unicode,
+    to_basestring,
+    to_unicode,
+    utf8,
+)
+from tornado.httpclient import HTTPClientError
+from tornado.httputil import format_timestamp
+from tornado.iostream import IOStream
+from tornado.locks import Event
+from tornado.log import app_log, gen_log
+from tornado.simple_httpclient import SimpleAsyncHTTPClient
+from tornado.template import DictLoader
+from tornado.test.util import ignore_deprecation
+from tornado.testing import AsyncHTTPTestCase, AsyncTestCase, ExpectLog, gen_test
+from tornado.util import ObjectDict, unicode_type
+from tornado.web import (
+    Application,
+    ErrorHandler,
+    Finish,
+    GZipContentEncoding,
+    HTTPError,
+    MissingArgumentError,
+)
+from tornado.web import RedirectHandler as WebRedirectHandler
+from tornado.web import (
+    RequestHandler,
+    StaticFileHandler,
+    UIModule,
+    _create_signature_v1,
+    addslash,
+    authenticated,
+    create_signed_value,
+    decode_signed_value,
+    get_signature_key_version,
+    removeslash,
+    stream_request_body,
+    url,
+)
 
 
 def relpath(*a):

--- a/tornado/test/websocket_test.py
+++ b/tornado/test/websocket_test.py
@@ -7,16 +7,16 @@ import traceback
 import typing
 import unittest
 
-from tornado.concurrent import Future
 from tornado import gen
+from tornado.concurrent import Future
 from tornado.httpclient import HTTPError, HTTPRequest
 from tornado.locks import Event
-from tornado.log import gen_log, app_log
+from tornado.log import app_log, gen_log
 from tornado.netutil import Resolver
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from tornado.template import DictLoader
 from tornado.test.util import abstract_base_test, ignore_deprecation
-from tornado.testing import AsyncHTTPTestCase, gen_test, bind_unused_port, ExpectLog
+from tornado.testing import AsyncHTTPTestCase, ExpectLog, bind_unused_port, gen_test
 from tornado.web import Application, RequestHandler
 
 try:
@@ -31,10 +31,10 @@ except ImportError:
     raise
 
 from tornado.websocket import (
+    WebSocketClosedError,
+    WebSocketError,
     WebSocketHandler,
     websocket_connect,
-    WebSocketError,
-    WebSocketClosedError,
 )
 
 try:

--- a/tornado/test/wsgi_test.py
+++ b/tornado/test/wsgi_test.py
@@ -1,7 +1,6 @@
 import asyncio
 import concurrent.futures
 import threading
-
 from wsgiref.validate import validator
 
 from tornado.routing import RuleRouter

--- a/tornado/testing.py
+++ b/tornado/testing.py
@@ -10,7 +10,6 @@
 """
 
 import asyncio
-from collections.abc import Generator
 import functools
 import inspect
 import logging
@@ -19,25 +18,22 @@ import re
 import signal
 import socket
 import sys
+import typing
 import unittest
 import warnings
+from collections.abc import Callable, Coroutine, Generator
+from types import TracebackType
+from typing import Any, Optional, Type, Union
 
-from tornado import gen
+from tornado import gen, netutil
 from tornado.httpclient import AsyncHTTPClient, HTTPResponse
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop, TimeoutError
-from tornado import netutil
+from tornado.log import app_log
 from tornado.platform.asyncio import AsyncIOMainLoop
 from tornado.process import Subprocess
-from tornado.log import app_log
-from tornado.util import raise_exc_info, basestring_type
+from tornado.util import basestring_type, raise_exc_info
 from tornado.web import Application
-
-import typing
-from typing import Any, Type, Union, Optional
-from collections.abc import Callable
-from collections.abc import Coroutine
-from types import TracebackType
 
 _ExcInfoTuple = tuple[
     type[BaseException] | None, BaseException | None, TracebackType | None

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -14,25 +14,23 @@ from __future__ import annotations
 
 import array
 import asyncio
-from inspect import getfullargspec
 import os
 import re
 import typing
 import zlib
-
+from collections.abc import Callable, Mapping, Sequence
+from inspect import getfullargspec
+from re import Match
 from typing import (
     Any,
 )
-from collections.abc import Callable
-from collections.abc import Mapping, Sequence
-from re import Match
 
 if typing.TYPE_CHECKING:
     # Additional imports only used in type comments.
     # This lets us make these imports lazy.
     import datetime
-    from types import TracebackType
     import unittest
+    from types import TracebackType
 
 # Aliases for types that are spelled differently in different Python
 # versions. bytes_type is deprecated and no longer used in Tornado

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -65,8 +65,6 @@ import gzip
 import hashlib
 import hmac
 import http.cookies
-from inspect import isclass
-from io import BytesIO
 import mimetypes
 import numbers
 import os.path
@@ -75,49 +73,45 @@ import socket
 import sys
 import threading
 import time
-import warnings
-import tornado
 import traceback
 import types
 import urllib.parse
+import warnings
+from inspect import isclass
+from io import BytesIO
 from urllib.parse import urlencode
 
+import tornado
+from tornado import escape, gen, httputil, iostream, locale, template
 from tornado.concurrent import Future, future_set_result_unless_cancelled
-from tornado import escape
-from tornado import gen
+from tornado.escape import _unicode, utf8
 from tornado.httpserver import HTTPServer
-from tornado import httputil
-from tornado import iostream
-from tornado import locale
 from tornado.log import access_log, app_log, gen_log
-from tornado import template
-from tornado.escape import utf8, _unicode
 from tornado.routing import (
     AnyMatches,
     DefaultHostMatches,
     HostMatches,
     ReversibleRouter,
-    Rule,
     ReversibleRuleRouter,
+    Rule,
     URLSpec,
     _RuleList,
 )
-from tornado.util import ObjectDict, unicode_type, _websocket_mask
+from tornado.util import ObjectDict, _websocket_mask, unicode_type
 
 url = URLSpec
 
+from collections.abc import Awaitable, Callable, Generator, Iterable
+from types import TracebackType
 from typing import (
     Any,
-    Union,
     Optional,
     Type,
     TypeVar,
+    Union,
     cast,
     overload,
 )
-from collections.abc import Callable
-from collections.abc import Awaitable, Iterable, Generator
-from types import TracebackType
 
 # The following types are accepted by RequestHandler.set_header
 # and related methods.

--- a/tornado/websocket.py
+++ b/tornado/websocket.py
@@ -18,36 +18,33 @@ import functools
 import hashlib
 import logging
 import os
-import sys
 import struct
-import tornado
-from urllib.parse import urlparse
+import sys
 import warnings
 import zlib
+from collections.abc import Awaitable, Callable
+from types import TracebackType
+from typing import (
+    Any,
+    Optional,
+    Protocol,
+    Type,
+    Union,
+    cast,
+)
+from urllib.parse import urlparse
 
+import tornado
+from tornado import gen, httpclient, httputil, simple_httpclient
 from tornado.concurrent import Future, future_set_result_unless_cancelled
-from tornado.escape import utf8, native_str, to_unicode
-from tornado import gen, httpclient, httputil
+from tornado.escape import native_str, to_unicode, utf8
 from tornado.ioloop import IOLoop
-from tornado.iostream import StreamClosedError, IOStream
-from tornado.log import gen_log, app_log
+from tornado.iostream import IOStream, StreamClosedError
+from tornado.log import app_log, gen_log
 from tornado.netutil import Resolver
-from tornado import simple_httpclient
 from tornado.queues import Queue
 from tornado.tcpclient import TCPClient
 from tornado.util import _websocket_mask
-
-from typing import (
-    cast,
-    Any,
-    Optional,
-    Union,
-    Type,
-    Protocol,
-)
-from collections.abc import Callable
-from collections.abc import Awaitable
-from types import TracebackType
 
 
 # The zlib compressor types aren't actually exposed anywhere

--- a/tornado/wsgi.py
+++ b/tornado/wsgi.py
@@ -28,20 +28,18 @@ container.
 """
 
 import concurrent.futures
-from io import BytesIO
-import tornado
 import sys
+import typing
+from collections.abc import Callable
+from io import BytesIO
+from types import TracebackType
+from typing import Any
 
+import tornado
+from tornado import escape, httputil
 from tornado.concurrent import dummy_executor
-from tornado import escape
-from tornado import httputil
 from tornado.ioloop import IOLoop
 from tornado.log import access_log
-
-from typing import Any
-from collections.abc import Callable
-from types import TracebackType
-import typing
 
 if typing.TYPE_CHECKING:
     from _typeshed.wsgi import WSGIApplication as WSGIAppType


### PR DESCRIPTION
Today's type import changes have caused a lot of churn in the import statements and we've never had a consistent style. Run a one-time cleanup with isort to tidy things up. I'm not (currently) planning to make this a CI-enforced rule.