### PR TITLE
ci: Build wheels for more architectures under emulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, windows-11-arm, macos-15]
-        arch: [auto]
+        emulated: [false]
         include:
           - os: ubuntu-24.04
+            emulated: true
             arch: "riscv64"
             name_suffix: "-riscv64"
+          - os: ubuntu-24.04
+            emulated: true
+            arch: "ppc64le"
+            name_suffix: "-ppc64le"
+          - os: ubuntu-24.04
+            emulated: true
+            arch: "s390x"
+            name_suffix: "-s390x"
 
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +81,7 @@ jobs:
           python-version: ${{ env.python-version }}
 
       - name: Set up QEMU
-        if: matrix.arch != 'auto'
+        if: matrix.emulated
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.arch }}
@@ -80,9 +89,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0
         env:
-          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ARCHS: ${{ matrix.emulated && matrix.arch || '' }}
           # Increase timeouts for emulated archs
-          CIBW_ENVIRONMENT: ${{ matrix.arch != 'auto' && 'ASYNC_TEST_TIMEOUT=30 EMULATION=1' || '' }}
+          CIBW_ENVIRONMENT: ${{ matrix.emulated && 'ASYNC_TEST_TIMEOUT=30 EMULATION=1' || '' }}
 
       - name: Audit ABI3 compliance
         # This may be moved into cibuildwheel itself in the future. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,12 @@ archs = "universal2"
 [tool.cibuildwheel.windows]
 # TODO: figure out what's going on with these occasional log messages.
 test-command = "python -m tornado.test --fail-if-logs=false"
+
+[[tool.cibuildwheel.overrides]]
+select = "*{riscv64,ppc64le,s390x}*"
+# On emulated platforms, only run the websocket tests, since those are the ones that
+# exercise the C extension and are most likely to encounter architecture-related issues.
+# The full test suite is very slow under emulation.
+# TODO: It would be nice to run the full test suite on a single python version for
+# each architecture and only run the websocket tests for other versions on emulated archs.
+test-command = "python -m tornado.test tornado.test.websocket_test"


### PR DESCRIPTION
This commit also fixes the macos build to use universal2 wheels, which was broken with the addition of riscv64 support.

Support for these architectures is experimental, but we have had a request for ppc64le in #3449. As long as emulation gives us a turnkey solution, we might as well build for them, but if the emulation pipeline turns out to be unstable we will reconsider. (armv7l is also experimentally supported by cibuildwheel and even shows up more frequently in our download stats than ppc64le and s390x, but I got a cryptic failure when I tried it so I'm leaving it out for now.)

This commit reduces the amount of testing we do for emulated builds because they are otherwise the slowest part of the build pipeline.