### PR TITLE
ci: Update versions of github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: ${{ env.python-version }}
@@ -44,7 +44,7 @@ jobs:
       - name: Build sdist
         run: "python setup.py sdist && ls -l dist"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-sdist
           path: ./dist/tornado-*.tar.gz
@@ -72,10 +72,10 @@ jobs:
             name_suffix: "-s390x"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: ${{ env.python-version }}
@@ -98,7 +98,7 @@ jobs:
         # https://github.com/pypa/cibuildwheel/issues/1342
         run: python -m pip install abi3audit && abi3audit --verbose --summary ./wheelhouse/*abi3*.whl
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-${{ matrix.os }}${{ matrix.name_suffix || '' }}
           path: ./wheelhouse/*.whl
@@ -112,7 +112,7 @@ jobs:
       # This permission is required for pypi's "trusted publisher" feature
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: dist
@@ -132,7 +132,7 @@ jobs:
       # This permission is required for pypi's "trusted publisher" feature
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
     name: Run quick tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           # [[[cog cog.outl(f"python-version: '3.{default_python_minor}'")]]]
@@ -99,10 +99,10 @@ jobs:
           # [[[end]]]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: ${{ matrix.python}}
@@ -124,10 +124,10 @@ jobs:
     needs: test_quick
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           # [[[cog cog.outl(f"python-version: '3.{default_python_minor}'")]]]
@@ -142,10 +142,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: test_quick
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         name: Install uv
       - name: Run zizmor
         run: uvx zizmor .github/workflows
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: test_quick
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Run cibuildwheel


### PR DESCRIPTION
These actions are generating deprecation warnings due to an old node.js version, and for some reason github marks this upgrade as a major version change even when there is no behavior change.