### PR TITLE
docs: fix typos in comments and documentation

### DIFF
--- a/docs/guide/intro.rst
+++ b/docs/guide/intro.rst
@@ -13,7 +13,7 @@ Tornado can be roughly divided into three major components:
 
 * A web framework (including `.RequestHandler` which is subclassed to
   create web applications, and various supporting classes).
-* Client- and server-side implementions of HTTP (`.HTTPServer` and
+* Client- and server-side implementations of HTTP (`.HTTPServer` and
   `.AsyncHTTPClient`).
 * An asynchronous networking library including the classes `.IOLoop`
   and `.IOStream`, which serve as the building blocks for the HTTP

--- a/docs/guide/structure.rst
+++ b/docs/guide/structure.rst
@@ -50,7 +50,7 @@ Python.)
 
 When the ``main`` function returns, the program exits, so most of the time for a
 web server ``main`` should run forever. Waiting on an `asyncio.Event` whose
-``set()`` method is never called is a convenient way to make an asynchronus
+``set()`` method is never called is a convenient way to make an asynchronous
 function run forever. (and if you wish to have ``main`` exit early as a part of
 a graceful shutdown procedure, you can call ``shutdown_event.set()`` to make it
 exit).

--- a/tornado/auth.py
+++ b/tornado/auth.py
@@ -855,7 +855,7 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
     * Select a project, or create a new one.
     * Depending on permissions required, you may need to set your app to
       "testing" mode and add your account as a test user, or go through
-      a verfication process. You may also need to use the "Enable
+      a verification process. You may also need to use the "Enable
       APIs and Services" command to enable specific services.
     * In the sidebar on the left, select Credentials.
     * Click CREATE CREDENTIALS and click OAuth client ID.

--- a/tornado/escape.py
+++ b/tornado/escape.py
@@ -99,7 +99,7 @@ def json_encode(value: Any) -> str:
 def json_decode(value: str | bytes) -> Any:
     """Returns Python objects for the given JSON string.
 
-    Supports both `str` and `bytes` inputs. Equvalent to `json.loads`.
+    Supports both `str` and `bytes` inputs. Equivalent to `json.loads`.
     """
     return json.loads(value)
 
@@ -393,7 +393,7 @@ def linkify(
         return f'<a href="{href}"{params}>{url}</a>'
 
     # First HTML-escape so that our strings are all safe.
-    # The regex is modified to avoid character entites other than &amp; so
+    # The regex is modified to avoid character entities other than &amp; so
     # that we won't pick up &quot;, etc.
     text = _unicode(xhtml_escape(text))
     return _URL_RE.sub(make_link, text)

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -73,7 +73,7 @@ class _ABNF:
     """
 
     # RFC 3986 (URI)
-    # The URI hostname ABNF is both complex (including detailed vaildation of IPv4 and IPv6
+    # The URI hostname ABNF is both complex (including detailed validation of IPv4 and IPv6
     # literals) and not strict enough (a lot of punctuation is allowed by the ABNF even though
     # it is not allowed by DNS). We simplify it by allowing square brackets and colons in any
     # position, not only for their use in IPv6 literals.

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -533,7 +533,7 @@ class SelectorThread:
         self._thread.start()
         self._start_select()
         try:
-            # The presense of this yield statement means that this coroutine
+            # The presence of this yield statement means that this coroutine
             # is actually an asynchronous generator, which has a special
             # shutdown protocol. We wait at this yield point until the
             # event loop's shutdown_asyncgens method is called, at which point

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -666,7 +666,7 @@ class ParseCookieTest(unittest.TestCase):
             "django_language",
             parse_cookie("abc=def; unnamed; django_language=en").keys(),
         )
-        # Even a double quote may be an unamed value.
+        # Even a double quote may be an unnamed value.
         self.assertEqual(parse_cookie('a=b; "; c=d'), {"a": "b", "": '"', "c": "d"})
         # Spaces in names and values, and an equals sign in values.
         self.assertEqual(

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -720,7 +720,7 @@ class RequestHandler:
             # Note change from _ to -.
             morsel["max-age"] = str(max_age)
         if httponly:
-            # Note that SimpleCookie ignores the value here. The presense of an
+            # Note that SimpleCookie ignores the value here. The presence of an
             # httponly (or secure) key is treated as true.
             morsel["httponly"] = True
         if secure:


### PR DESCRIPTION
Fixes nine misspellings spotted while reading through the codebase, all of them in comments, docstrings, or `.rst` documentation. No runtime behavior is affected.

| File | Change |
| ---- | ------ |
| `docs/guide/intro.rst` | `implementions` -> `implementations` |
| `docs/guide/structure.rst` | `asynchronus` -> `asynchronous` |
| `tornado/auth.py` | `verfication` -> `verification` (Google OAuth setup notes) |
| `tornado/escape.py` | `Equvalent` -> `Equivalent` (`json_decode` docstring); `entites` -> `entities` (`linkify` comment) |
| `tornado/httputil.py` | `vaildation` -> `validation` (`_ABNF` comment) |
| `tornado/platform/asyncio.py` | `presense` -> `presence` (`SelectorThread.start` comment) |
| `tornado/test/httputil_test.py` | `unamed` -> `unnamed` (matches the spelling already used on the line above) |
| `tornado/web.py` | `presense` -> `presence` (`set_cookie` comment) |

### Testing

- `python -m tornado.test` — 1234 tests pass (53 skipped for optional/platform deps)
- `black --check --diff tornado demos` — clean
- `flake8 tornado` — clean
- `sphinx-build -W -b html docs ...` — clean (warnings as errors)