### PR TITLE
Treat a zero timeout as immediate in queues and locks

### DIFF
--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -122,7 +122,7 @@ class Condition(_TimeoutGarbageCollector):
         """
         waiter: Future[bool] = Future()
         self._waiters.append(waiter)
-        if timeout:
+        if timeout is not None:
 
             def on_timeout() -> None:
                 if not waiter.done():
@@ -421,7 +421,7 @@ class Semaphore(_TimeoutGarbageCollector):
             waiter.set_result(_ReleasingContextManager(self))
         else:
             self._waiters.append(waiter)
-            if timeout:
+            if timeout is not None:
 
                 def on_timeout() -> None:
                     if not waiter.done():

--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -55,7 +55,7 @@ class QueueFull(Exception):
 
 
 def _set_timeout(future: Future, timeout: None | float | datetime.timedelta) -> None:
-    if timeout:
+    if timeout is not None:
 
         def on_timeout() -> None:
             if not future.done():

--- a/tornado/test/queues_test.py
+++ b/tornado/test/queues_test.py
@@ -118,6 +118,14 @@ class QueueGetTest(AsyncTestCase):
         self.assertEqual(0, (yield get))
 
     @gen_test
+    def test_get_zero_timeout(self):
+        q: queues.Queue[int] = queues.Queue()
+        with self.assertRaises(TimeoutError):
+            yield q.get(timeout=timedelta(seconds=0))
+        with self.assertRaises(TimeoutError):
+            yield q.get(timeout=0)
+
+    @gen_test
     def test_get_timeout_preempted(self):
         q: queues.Queue[int] = queues.Queue()
         get = q.get(timeout=timedelta(seconds=0.01))


### PR DESCRIPTION
A `timeout` of `0` or `timedelta(0)` was treated as no timeout because of a falsy check, so `Queue.get`/`Queue.put` (and `Condition.wait`/`Semaphore.acquire`) would wait indefinitely instead of timing out immediately. Switched the checks to `timeout is not None` and added a regression test.

Closes #3271