### PR TITLE
`_HasFileno` in `platform/asyncio.py` must be hashable because instances are used as dictionary key

### DIFF
--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -52,6 +52,7 @@ if typing.TYPE_CHECKING:
 class _HasFileno(Protocol):
     def fileno(self) -> int:
         pass
+
     def __hash__(self) -> int:
         pass
 

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -730,7 +730,7 @@ class AddThreadSelectorEventLoop(asyncio.AbstractEventLoop):
 
     def add_reader(
         self,
-        fd: "_FileDescriptorLike",
+        fd: "_FileDescriptorLike",  # type: ignore[override]
         callback: Callable[..., None],
         *args: "Unpack[_Ts]",
     ) -> None:
@@ -738,14 +738,14 @@ class AddThreadSelectorEventLoop(asyncio.AbstractEventLoop):
 
     def add_writer(
         self,
-        fd: "_FileDescriptorLike",
+        fd: "_FileDescriptorLike",  # type: ignore[override]
         callback: Callable[..., None],
         *args: "Unpack[_Ts]",
     ) -> None:
         return self._selector.add_writer(fd, callback, *args)
 
-    def remove_reader(self, fd: "_FileDescriptorLike") -> bool:
+    def remove_reader(self, fd: "_FileDescriptorLike") -> bool:  # type: ignore[override]
         return self._selector.remove_reader(fd)
 
-    def remove_writer(self, fd: "_FileDescriptorLike") -> bool:
+    def remove_writer(self, fd: "_FileDescriptorLike") -> bool:  # type: ignore[override]
         return self._selector.remove_writer(fd)

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -52,6 +52,8 @@ if typing.TYPE_CHECKING:
 class _HasFileno(Protocol):
     def fileno(self) -> int:
         pass
+    def __hash__(self) -> int:
+        pass
 
 
 _FileDescriptorLike = Union[int, _HasFileno]


### PR DESCRIPTION
Parent: [python/typeshed#15754](https://github.com/python/typeshed/pull/15754).