### PR TITLE
narrow except around socket.getpeername to OSError in SSL handshake handler

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1364,7 +1364,7 @@ class SSLIOStream(IOStream):
             elif err.args[0] in (ssl.SSL_ERROR_SSL, ssl.SSL_ERROR_SYSCALL):
                 try:
                     peer = self.socket.getpeername()
-                except Exception:
+                except OSError:
                     peer = "(not connected)"
                 gen_log.warning(
                     "SSL Error on %s %s: %s", self.socket.fileno(), peer, err


### PR DESCRIPTION
narrow except around socket.getpeername to OSError in SSL handshake handler

The handler at the SSL_ERROR_SSL/SSL_ERROR_SYSCALL branch of the
handshake error path wraps self.socket.getpeername() in a
try/except Exception that falls back to the literal string
'(not connected)'. getpeername() only raises OSError and its
subclasses (ENOTCONN when the socket is not yet connected,
EBADF when the fd is no longer valid, ENOTSOCK for a bad
file descriptor). It does not raise any other Exception type.

Narrowing the handler to OSError lets a real bug in our own
code (AttributeError from a typo on self.socket, NameError
after a partial module reload, TypeError from a wrong type
passed in) surface as a diagnostic instead of being
swallowed and silently replaced with the '(not connected)'
fallback string, which then gets logged as the peer address
for a real peer that we just lost the ability to look up.