### PR TITLE
narrow bare except around super().initialize() in AsyncioSelectorLoop

### DIFF
--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -327,7 +327,7 @@ class AsyncIOLoop(BaseAsyncIOLoop):
             kwargs["asyncio_loop"] = loop = asyncio.new_event_loop()
         try:
             super().initialize(**kwargs)
-        except Exception:
+        except (OSError, RuntimeError, ValueError, TypeError):
             # If initialize() does not succeed (taking ownership of the loop),
             # we have to close it.
             if loop is not None:


### PR DESCRIPTION
narrow bare except around super().initialize() in AsyncioSelectorLoop

The bare 'except Exception:' wrapped super().initialize(**kwargs) in the
asyncio-backed IOLoop initialize(), with a fallback that closes the
newly-created asyncio event loop if the super initialize failed (taking
ownership of the loop was not successful). The narrow set covers the
actual failures of IOLoop initialize: OSError (file descriptor limit
reached when opening the epoll/kqueue/select fd, can't bind, can't
open /dev/null for stderr redirection), RuntimeError (asyncio loop
already running, or a conflicting call to asyncio.set_event_loop),
ValueError (an explicit invalid arg check inside the super) and
TypeError (an unexpected kwarg passed through **kwargs from a
downstream caller that the asyncio loop's initializer doesn't accept).
KeyboardInterrupt and SystemExit are BaseException and were being
swallowed by the bare 'except Exception' — narrowing lets a Ctrl-C
during IOLoop initialize propagate immediately to whatever the caller
of AsyncioSelectorLoop.initialize was, instead of being caught,
running the loop.close() fallback, and re-raised as a new chained
exception.