### PR TITLE
narrow bare except in twisted errback to Exception

### DIFF
--- a/tornado/platform/twisted.py
+++ b/tornado/platform/twisted.py
@@ -56,7 +56,7 @@ if hasattr(gen.convert_yielded, "register"):
                 failure.raiseException()
                 # Should never happen, but just in case
                 raise Exception("errback called without error")
-            except:
+            except Exception:
                 future_set_exc_info(f, sys.exc_info())
 
         d.addCallbacks(f.set_result, errback)


### PR DESCRIPTION
## What

`tornado.platform.twisted` had a bare `except:` in the Deferred-to-Future errback. The errback calls `failure.raiseException()` (the standard way to re-raise a twisted `Failure` as its underlying exception) and has a defensive `raise Exception("errback called without error")` for the case where the Failure wrapped no exception at all. The bare `except:` then captured `sys.exc_info()` so it could be stashed on the Future.

## Why

`except:` catches every `BaseException`, including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. The intent of the handler is to capture *exception* information from the Failure so the awaiter of the Future sees the right error — narrowing to `except Exception` is the right shape:

- A real `KeyboardInterrupt` raised inside the twisted reactor (e.g. the caller pressed Ctrl-C in a different thread, or twisted itself propagated Ctrl-C from a signal handler) now propagates out to the tornado event loop instead of being silently converted to a Future exception that the awaiter would observe as a generic `"errback called without error"` message.
- A real `SystemExit` raised inside twisted (via a signal handler the user wired, or a twisted plugin that called `sys.exit` on a shutdown) similarly propagates to the IOLoop's atexit hooks instead of being hidden inside a Future result.
- `MemoryError` and `RecursionError` are not caught by `except Exception`, which is the right behaviour — a Future is the wrong place to attempt to record process-level resource exhaustion.

The two calls inside the `try` block (`failure.raiseException()` and `raise Exception(...)`) only raise `Exception` subtypes, so the narrowing doesn't lose any of the originally-intended captures.