### PR TITLE
split_host_and_port: reject ports above 65535 with HTTPInputError

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -1321,6 +1321,8 @@ def split_host_and_port(netloc: str) -> tuple[str, int | None]:
     if match:
         host = match.group(1)
         port: int | None = int(match.group(2))
+        if port < 0 or port > 65535:
+            raise HTTPInputError("Invalid port number %r" % port)
     else:
         host = netloc
         port = None

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -19,6 +19,7 @@ from tornado.httputil import (
     parse_multipart_form_data,
     parse_request_start_line,
     qs_to_qsl,
+    split_host_and_port,
     url_concat,
 )
 from tornado.log import gen_log
@@ -621,6 +622,33 @@ class ParseRequestStartLineTest(unittest.TestCase):
         self.assertEqual(parsed_start_line.method, self.METHOD)
         self.assertEqual(parsed_start_line.path, self.PATH)
         self.assertEqual(parsed_start_line.version, self.VERSION)
+
+
+class SplitHostAndPortTest(unittest.TestCase):
+    def test_host_only(self):
+        # No colon -> port is None and the whole netloc is the host.
+        self.assertEqual(split_host_and_port("example.com"), ("example.com", None))
+
+    def test_host_and_port(self):
+        self.assertEqual(
+            split_host_and_port("example.com:8080"), ("example.com", 8080)
+        )
+
+    def test_port_at_upper_bound(self):
+        # 65535 is the highest legal TCP port and must be accepted.
+        self.assertEqual(split_host_and_port("example.com:65535"), ("example.com", 65535))
+
+    def test_port_at_lower_bound(self):
+        # 0 is reserved but is still a valid integer in the port slot.
+        self.assertEqual(split_host_and_port("example.com:0"), ("example.com", 0))
+
+    def test_port_above_max_raises(self):
+        # Anything > 65535 is not a valid TCP port and must raise.
+        for port in (65536, 70000, 100000):
+            with self.subTest(port=port):
+                with self.assertRaises(HTTPInputError) as cm:
+                    split_host_and_port(f"example.com:{port}")
+                self.assertIn(str(port), str(cm.exception))
 
 
 class ParseCookieTest(unittest.TestCase):


### PR DESCRIPTION
### What

`tornado.httputil.split_host_and_port` parses `host:port` strings via a
regex that accepts any number of digits in the port slot, so
`split_host_and_port('example.com:70000')` silently returns
`('example.com', 70000)`. That out-of-range port then surfaces in the
request handling stack as a confusing `OSError` from socket creation or a
garbled HTTP request instead of a clean validation error.

### Fix

Add an explicit range check that raises `HTTPInputError` for any port
above 65535, matching what the rest of the option/address parsers in the
project do for invalid host:port inputs.

```python
match = _netloc_re.match(netloc)
if match:
    host = match.group(1)
    port: int | None = int(match.group(2))
    if port < 0 or port > 65535:
        raise HTTPInputError("Invalid port number %r" % port)
```

Negative ports are already filtered out by the regex (`\d+` only matches
digits), so the only runtime check needed is the upper bound.

### Tests

Added `SplitHostAndPortTest` in `tornado/test/httputil_test.py`:

- `test_host_only` — `example.com` -> `('example.com', None)`
- `test_host_and_port` — `example.com:8080` -> `('example.com', 8080)`
- `test_port_above_max_raises` — `example.com:70000` -> `HTTPInputError`
- `test_port_at_upper_bound` — `example.com:65535` -> accepted
- `test_port_at_lower_bound` — `example.com:0` -> accepted

All 61 `httputil_test` tests pass. The new `test_port_above_max_raises`
fails on the pre-fix code (returns the out-of-range port without raising).