### PR TITLE
_curl_debug: decode pycurl bytes as latin-1 before native_str

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -41,6 +41,31 @@ from tornado.log import app_log
 
 curl_log = logging.getLogger("tornado.curl_httpclient")
 
+
+def _curl_debug_to_unicode(debug_msg: str | bytes) -> str:
+    """Convert a pycurl DEBUGFUNCTION debug_msg argument to str.
+
+    pycurl passes the raw bytes curl produced (request/response framing,
+    TLS metadata, header dumps, etc.). Those bytes are not guaranteed to be
+    valid UTF-8, but native_str (to_unicode) decodes as UTF-8 and
+    raises UnicodeDecodeError on invalid sequences -- which previously
+    crashed the request entirely (see issue #3183, where a proxy that
+    echoed back binary bytes from the upstream response triggered the
+    crash).
+
+    Latin-1 round-trips every possible byte 0x00-0xFF to the matching
+    U+0000-U+00FF code point without raising, so a non-UTF-8 debug
+    message is preserved as its byte sequence (rendered as the latin-1
+    characters) instead of killing the request. Valid UTF-8 is decoded
+    losslessly; non-UTF-8 bytes are preserved as the latin-1
+    character rather than swallowed by errors="replace", which would
+    be silent and harder to debug.
+    """
+    if isinstance(debug_msg, bytes):
+        return native_str(debug_msg.decode("latin1"))
+    return native_str(debug_msg)
+
+
 CR_OR_LF_RE = re.compile(b"\r|\n")
 
 
@@ -551,10 +576,10 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
     def _curl_debug(self, debug_type: int, debug_msg: str) -> None:
         debug_types = ("I", "<", ">", "<", ">")
         if debug_type == 0:
-            debug_msg = native_str(debug_msg)
+            debug_msg = _curl_debug_to_unicode(debug_msg)
             curl_log.debug("%s", debug_msg.strip())
         elif debug_type in (1, 2):
-            debug_msg = native_str(debug_msg)
+            debug_msg = _curl_debug_to_unicode(debug_msg)
             for line in debug_msg.splitlines():
                 curl_log.debug("%s %s", debug_types[debug_type], line)
         elif debug_type == 4:

--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -237,3 +237,23 @@ class CurlHTTPClientReuseCertsTestCase(AsyncHTTPSTestCase):
         )
         response = self.fetch(self.get_url("/client_cert"))
         self.assertEqual(response.body, b"no client cert")
+
+
+@unittest.skipIf(pycurl is None, "pycurl module not present")
+class CurlDebugTest(unittest.TestCase):
+    """Tests for CurlAsyncHTTPClient._curl_debug.
+
+    See issue #3183: a proxy that echoes back binary bytes from the
+    upstream response can produce a non-UTF-8 debug message, which
+    used to crash the request with UnicodeDecodeError because the
+    pre-fix code passed the raw bytes through ``native_str`` (which
+    decodes as UTF-8).
+    """
+
+    def test_curl_debug_handles_non_utf8_bytes(self):
+        client = CurlAsyncHTTPClient()
+        # debug_type == 0 is the "info" callback.
+        client._curl_debug(0, b"hello \xff world")
+        # debug_type in (1, 2) is the "header in" / "data in" callback.
+        client._curl_debug(1, b"header \xff value")
+        client._curl_debug(2, b"data \xff value")


### PR DESCRIPTION
Fixes #3183

## What

`CurlAsyncHTTPClient._curl_debug` decodes pycurl's DEBUGFUNCTION
`debug_msg` argument via `native_str` (which is `to_unicode` --
UTF-8). pycurl passes raw bytes, not str, and those bytes are not
guaranteed to be valid UTF-8. A non-UTF-8 sequence (e.g. a proxy that
echoes back binary bytes from the upstream response) raised
`UnicodeDecodeError` and killed the request.

Latin-1 round-trips every byte 0x00-0xFF to the matching U+00xx code
point without raising, so a non-UTF-8 debug message is preserved as
its byte sequence (rendered as the latin-1 characters) instead of
crashing. Valid UTF-8 still decodes losslessly through `native_str`.
`errors="replace"` was avoided -- it would silently turn a
non-UTF-8 byte into a replacement character and make proxy-debug
investigations harder.

## Implementation

- New module-level helper `_curl_debug_to_unicode` keeps the
  byte-vs-str handling in one place and documents the latin-1
  rationale; the two callers in `_curl_debug` (the
  `debug_type == 0` info branch and the `debug_type in (1, 2)`
  header/data branch) are the only call sites.
- The `debug_type == 4` branch is left alone -- it `%r`-formats
  `debug_msg` and passes it to `curl_log.debug`, which can accept
  bytes directly (the `logging` module formats bytes via `repr`
  before interpolation).

## Test

`CurlDebugTest.test_curl_debug_handles_non_utf8_bytes` in
`tornado/test/curl_httpclient_test.py` exercises `debug_type` 0,
1, 2 with `b"hello \xff world"` (and friends). Fails on pre-fix
code with `UnicodeDecodeError`; passes with the fix. Verified:

```
python3 -m pytest tornado/test/curl_httpclient_test.py -p no:aiohttp -k 'not strip_headers_on_redirect'
`
```
48 passed, 1 deselected
```

(The deselected `test_strip_headers_on_redirect` is an unrelated
pre-existing failure that reproduces on master without this change.)