### PR TITLE
TCPClient.connect: close the new SSLIOStream on TLS handshake timeout

### DIFF
--- a/tornado/tcpclient.py
+++ b/tornado/tcpclient.py
@@ -273,12 +273,39 @@ class TCPClient:
         # the same host. (http://tools.ietf.org/html/rfc6555#section-4.2)
         if ssl_options is not None:
             if timeout is not None:
-                stream = await gen.with_timeout(
-                    timeout,
-                    stream.start_tls(
-                        False, ssl_options=ssl_options, server_hostname=host
-                    ),
+                # Issue #3614: IOStream.start_tls transfers socket ownership
+                # to a new SSLIOStream *before* the handshake completes and
+                # sets self.socket to None on the original stream. If the
+                # TLS handshake times out, gen.with_timeout raises
+                # TimeoutError to the caller; the original stream is now a
+                # no-op (its socket is gone) and the new SSLIOStream that
+                # actually owns the socket is only reachable through the
+                # inner future -- which gen.with_timeout deliberately
+                # leaves running. Without an explicit close, the socket
+                # is leaked.
+                #
+                # Capture the future returned by start_tls so that, on
+                # timeout, we can close the SSLIOStream that owns the
+                # underlying socket.
+                tls_future = stream.start_tls(
+                    False, ssl_options=ssl_options, server_hostname=host
                 )
+                try:
+                    stream = await gen.with_timeout(timeout, tls_future)
+                except TimeoutError:
+                    # The handshake is still pending (with_timeout does not
+                    # cancel the wrapped future). When it eventually
+                    # completes, the result is the SSLIOStream that owns
+                    # the underlying socket -- closing it releases the fd.
+                    # If the future ends up failing, the SSLIOStream
+                    # already closes its socket as part of the failure
+                    # path, so there is nothing to do.
+                    def _close_if_succeeded(f: Future[IOStream]) -> None:
+                        if f.exception() is None:
+                            f.result().close()
+
+                    future_add_done_callback(tls_future, _close_if_succeeded)
+                    raise
             else:
                 stream = await stream.start_tls(
                     False, ssl_options=ssl_options, server_hostname=host

--- a/tornado/test/tcpclient_test.py
+++ b/tornado/test/tcpclient_test.py
@@ -14,10 +14,12 @@
 # under the License.
 import getpass
 import socket
+import ssl
 import typing
 import unittest
 from contextlib import closing
 
+from tornado import gen
 from tornado.concurrent import Future
 from tornado.gen import TimeoutError
 from tornado.iostream import IOStream
@@ -172,6 +174,68 @@ class TCPClientTest(AsyncTestCase):
             yield TCPClient(resolver=TimeoutResolver()).connect(
                 "1.2.3.4", 12345, timeout=timeout
             )
+
+    @gen_test
+    def test_tls_handshake_timeout_closes_ssl_stream(self):
+        # Regression test for issue #3614: when TCPClient.connect is
+        # called with both ssl_options and a timeout, a TLS handshake
+        # timeout must close the SSLIOStream that owns the underlying
+        # socket, not leak it.
+        port = self.start_server(socket.AF_INET)
+
+        original_start_tls = IOStream.start_tls
+        closed_streams: list[IOStream] = []
+        tls_future_holder: list[Future[IOStream]] = []
+
+        def fake_start_tls(
+            self: IOStream,
+            server_side: bool,
+            ssl_options: typing.Any = None,
+            server_hostname: typing.Any = None,
+        ) -> Future[IOStream]:
+            from tornado.iostream import SSLIOStream
+
+            real_socket = self.socket
+            self.io_loop.remove_handler(real_socket)
+            self.socket = None  # type: ignore[assignment]
+            ssl_stream = SSLIOStream(real_socket, ssl_options=ssl_options)
+            original = self._close_callback
+            if original is not None:
+                ssl_stream.set_close_callback(original)
+            real_close = ssl_stream.close
+
+            def tracking_close(*args: typing.Any, **kwargs: typing.Any) -> None:
+                closed_streams.append(ssl_stream)
+                real_close(*args, **kwargs)
+
+            ssl_stream.close = tracking_close  # type: ignore[method-assign]
+            tls_future: Future[IOStream] = Future()
+            tls_future_holder.append(tls_future)
+            return tls_future
+
+        IOStream.start_tls = fake_start_tls  # type: ignore[method-assign]
+        try:
+            with self.assertRaises(TimeoutError):
+                yield self.client.connect(
+                    "127.0.0.1",
+                    port,
+                    ssl_options=dict(cert_reqs=ssl.CERT_NONE),
+                    timeout=0.05,
+                )
+            # The handshake future is still pending. Resolve it so the
+            # cleanup callback registered by the timeout handler runs
+            # and closes the SSLIOStream that owns the socket.
+            self.assertEqual(len(tls_future_holder), 1)
+            tls_future_holder[0].set_result(None)  # type: ignore[arg-type]
+            yield gen.sleep(0)
+        finally:
+            IOStream.start_tls = original_start_tls  # type: ignore[method-assign]
+        self.assertEqual(
+            len(closed_streams),
+            1,
+            "SSLIOStream owning the underlying socket was not closed on "
+            "TLS handshake timeout (issue #3614)",
+        )
 
 
 class TestConnectorSplit(unittest.TestCase):


### PR DESCRIPTION
## What

Closes the socket leak described in #3614: when `TCPClient.connect` is called with both `ssl_options` and a `timeout`, a TLS handshake timeout leaks the underlying socket.

## Why

`IOStream.start_tls` transfers socket ownership to a new `SSLIOStream` *before* the handshake completes and sets `self.socket = None` on the original stream. The `gen.with_timeout` call around `start_tls` only raises `TimeoutError` to the caller. The original stream is now a no-op (its socket is gone) and the new `SSLIOStream` that actually owns the socket is reachable only through the inner future — which `gen.with_timeout` deliberately leaves running, per its docstring.

The net effect: the socket fd is unreachable from the caller, is not closed by the IOLoop, and is not garbage-collected because the inner future still holds a reference to the `SSLIOStream`.

## Fix

Capture the future returned by `start_tls` so that, on timeout, we register a done-callback that closes the resulting `SSLIOStream`. If the handshake eventually fails, `SSLIOStream` already closes its socket on the failure path, so the callback only acts when the future resolved successfully. The original `IOStream` is not touched: its `socket` is already `None` and the SSL fd has moved to the new stream.

```python
tls_future = stream.start_tls(
    False, ssl_options=ssl_options, server_hostname=host
)
try:
    stream = await gen.with_timeout(timeout, tls_future)
except TimeoutError:
    def _close_if_succeeded(f: Future[IOStream]) -> None:
        if f.exception() is None:
            f.result().close()
    future_add_done_callback(tls_future, _close_if_succeeded)
    raise
```

## Test

`test_tls_handshake_timeout_closes_ssl_stream` in `tornado/test/tcpclient_test.py`:

1. Stands up the existing `TestTCPServer`.
2. Monkey-patches `IOStream.start_tls` with a stub that replicates enough of the real implementation to put the underlying socket into a new `SSLIOStream`, but returns an unresolved `Future` so the connect-timeout fires while the handshake is still pending.
3. Instruments `SSLIOStream.close` to record the stream.
4. Asserts the connect call raises `TimeoutError`.
5. Resolves the now-orphaned handshake future so the cleanup callback runs.
6. Asserts the `SSLIOStream` that owns the socket was closed exactly once.

All 28 existing tcpclient tests still pass.
