### PR TITLE
is_valid_ip: accept RFC 3986 bracketed IPv6 in X-Forwarded-For

### DIFF
--- a/tornado/httpserver.py
+++ b/tornado/httpserver.py
@@ -346,6 +346,10 @@ class _HTTPRequestContext:
                 break
         ip = headers.get("X-Real-Ip", ip)
         if netutil.is_valid_ip(ip):
+            # Unwrap the RFC 3986 bracketed IPv6 form so the stored
+            # remote_ip is always the bare address.
+            if len(ip) >= 2 and ip[0] == "[" and ip[-1] == "]":
+                ip = ip[1:-1]
             self.remote_ip = ip
         # AWS uses X-Forwarded-Proto
         proto_header = headers.get(

--- a/tornado/netutil.py
+++ b/tornado/netutil.py
@@ -293,12 +293,18 @@ def add_accept_handler(
 def is_valid_ip(ip: str) -> bool:
     """Returns ``True`` if the given string is a well-formed IP address.
 
-    Supports IPv4 and IPv6.
+    Supports IPv4 and IPv6. IPv6 addresses wrapped in ``[`` and ``]`` (as
+    used in URI references per RFC 3986) are also accepted.
     """
     if not ip or "\x00" in ip:
         # getaddrinfo resolves empty strings to localhost, and truncates
         # on zero bytes.
         return False
+    # Accept the RFC 3986 URI form for IPv6 addresses, e.g. "[::1]".
+    if len(ip) >= 2 and ip[0] == "[" and ip[-1] == "]":
+        ip = ip[1:-1]
+        if not ip:
+            return False
     try:
         res = socket.getaddrinfo(
             ip, 0, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, socket.AI_NUMERICHOST

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -698,6 +698,22 @@ class XHeaderTest(HandlerBaseTestCase):
             "2620:0:1cfe:face:b00c::3",
         )
 
+        # Some load balancers (e.g. Fortigate) emit IPv6 in the RFC 3986
+        # bracketed URI form. The bracketed form should be accepted and
+        # unwrapped to the bare address.
+        bracketed_ipv6 = {"X-Forwarded-For": "[2620:0:1cfe:face:b00c::3]"}
+        self.assertEqual(
+            self.fetch_json("/", headers=bracketed_ipv6)["remote_ip"],
+            "2620:0:1cfe:face:b00c::3",
+        )
+        bracketed_ipv6_in_list = {
+            "X-Forwarded-For": "::1, [2620:0:1cfe:face:b00c::3]"
+        }
+        self.assertEqual(
+            self.fetch_json("/", headers=bracketed_ipv6_in_list)["remote_ip"],
+            "2620:0:1cfe:face:b00c::3",
+        )
+
         invalid_chars = {"X-Real-IP": "4.4.4.4<script>"}
         self.assertEqual(
             self.fetch_json("/", headers=invalid_chars)["remote_ip"], "127.0.0.1"

--- a/tornado/test/netutil_test.py
+++ b/tornado/test/netutil_test.py
@@ -177,6 +177,11 @@ class IsValidIPTest(unittest.TestCase):
         self.assertTrue(is_valid_ip("4.4.4.4"))
         self.assertTrue(is_valid_ip("::1"))
         self.assertTrue(is_valid_ip("2620:0:1cfe:face:b00c::3"))
+        # IPv6 in RFC 3986 URI form (e.g. emitted by some load balancers
+        # in X-Forwarded-For headers, see issue #3561)
+        self.assertTrue(is_valid_ip("[::1]"))
+        self.assertTrue(is_valid_ip("[2620:0:d60:ac1a::10]"))
+        self.assertTrue(is_valid_ip("[2620:0:1cfe:face:b00c::3]"))
         self.assertFalse(is_valid_ip("www.google.com"))
         self.assertFalse(is_valid_ip("localhost"))
         self.assertFalse(is_valid_ip("4.4.4.4<"))
@@ -186,6 +191,10 @@ class IsValidIPTest(unittest.TestCase):
         self.assertFalse(is_valid_ip("\n"))
         self.assertFalse(is_valid_ip("\x00"))
         self.assertFalse(is_valid_ip("a" * 100))
+        # Malformed bracketed values are still rejected
+        self.assertFalse(is_valid_ip("[]"))
+        self.assertFalse(is_valid_ip("[not-an-ip]"))
+        self.assertFalse(is_valid_ip("[127.0.0.1"))
 
 
 class TestPortAllocation(unittest.TestCase):


### PR DESCRIPTION
## What

`is_valid_ip` (used to validate `X-Forwarded-For` / `X-Real-IP`
headers in `_apply_xheaders`) calls `getaddrinfo`, which rejects the
RFC 3986 URI-reference bracketed IPv6 form (e.g. `[2620:0:d60:ac1a::10]`)
with `EAI_NONAME`. Load balancers such as Fortigate emit IPv6 in this
form, so the forwarded address was silently dropped and the request
fell back to the connection peer.

Strip the brackets inside `is_valid_ip` so the bracketed form is
accepted and validated as a normal IPv6 address, and unwrap the
brackets in `_apply_xheaders` so the stored `remote_ip` is always
the bare address.

Fixes #3561.