### PR TITLE
gen: accept any _Yieldable in WaitIterator constructor (issue #3001)

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -350,23 +350,24 @@ class WaitIterator:
 
     _unfinished: dict[Future, int | str] = {}
 
-    def __init__(self, *args: Future, **kwargs: Future) -> None:
+    def __init__(self, *args: _Yieldable, **kwargs: _Yieldable) -> None:
         if args and kwargs:
             raise ValueError("You must provide args or kwargs, not both")
 
         if kwargs:
-            self._unfinished = {f: k for (k, f) in kwargs.items()}
-            futures: Sequence[Future] = list(kwargs.values())
+            self._unfinished = {convert_yielded(fut): k for (k, fut) in kwargs.items()}
         else:
-            self._unfinished = {f: i for (i, f) in enumerate(args)}
-            futures = args
+            items = args
+            self._unfinished = {
+                convert_yielded(item): i for i, item in enumerate(items)
+            }
 
         self._finished: collections.deque[Future] = collections.deque()
         self.current_index: str | int | None = None
         self.current_future: Future | None = None
         self._running_future: Future | None = None
 
-        for future in futures:
+        for future in list(self._unfinished):
             future_add_done_callback(future, self._done_callback)
 
     def done(self) -> bool:

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -929,6 +929,23 @@ class WaitIteratorTest(AsyncTestCase):
             datetime.timedelta(seconds=0.1), gen.WaitIterator(gen.sleep(0)).next()
         )
 
+    @gen_test
+    def test_iterator_accepts_coroutine(self):
+        # WaitIterator's constructor is documented to take any
+        # awaitable, not just Futures. Passing coroutines (e.g. the
+        # result of ``gen.sleep`` or ``tornado.locks.Event().wait()``)
+        # must work without raising and produce the awaited values.
+        async def produce(value: int, delay: float) -> int:
+            await gen.sleep(delay)
+            return value
+
+        g = gen.WaitIterator(produce(1, 0.01), produce(2, 0.02), produce(3, 0.0))
+        results: dict[int, int] = {}
+        while not g.done():
+            r = yield g.next()
+            results[g.current_index] = r
+        self.assertEqual(results, {0: 1, 1: 2, 2: 3})
+
 
 class RunnerGCTest(AsyncTestCase):
     def is_pypy3(self):


### PR DESCRIPTION
Fixes #3001

## What

`WaitIterator`'s constructor is documented to take any awaitable
(`tornado.gen.WaitIterator` docstring: 'Provides an iterator to yield
the results of awaitables as they finish'), but its type annotation
pinned the parameters to `Future`. mypy rejected the documented usage
`gen.WaitIterator(tornado.locks.Event().wait())` even though it
worked at runtime (the `future_add_done_callback` call inside the
constructor only worked when the input happened to already be a
`Future` — `asyncio.Future` would crash with `AttributeError` on
`add_done_callback`, and coroutines wouldn't be started at all).

The type now matches the documented behaviour: `*args` and
`**kwargs` are `_Yieldable`, and each input is normalized through
`convert_yielded` so the rest of the class can keep treating
`_unfinished` as `dict[Future, int | str]`. When the user passes
a `Future`, `convert_yielded` returns the same object
(`is_future` short-circuits), so the documented contract that
`current_future` is the input that produced the result is preserved.

## Test

New `WaitIteratorTest.test_iterator_accepts_coroutine` in
`tornado/test/gen_test.py` passes three `async def` coroutines with
different `gen.sleep` delays to `WaitIterator` and asserts all
three values come back via `current_index`. On the pre-fix code
this test crashes inside the constructor with
`AttributeError: 'coroutine' object has no attribute 'add_done_callback'`
for the first coroutine input.

Verified with
`python3 -m pytest tornado/test/gen_test.py` -> 73 passed
(72 existing + 1 new). The five pre-existing
`WaitIteratorTest` cases still pass without modification, including
`test_already_done` and `test_iterator` which assert
`current_future is f1` and friends — those inputs are `Future`
objects, and `convert_yielded` returns them unchanged.

mypy on `tornado/gen.py` reports no new errors (the only
diagnostic is the pre-existing missing-stubs note for `pycurl` in
`tornado/curl_httpclient.py`).