### PR TITLE
HTTPHeaders: raise TypeError instead of leaking AttributeError on non-string keys

### DIFF
--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -325,6 +325,10 @@ class HTTPHeaders(collections.abc.MutableMapping[str, str]):
     # MutableMapping abstract method implementations.
 
     def __setitem__(self, name: str, value: str) -> None:
+        if not isinstance(name, str):
+            raise TypeError(
+                "HTTPHeaders keys must be str, not %s" % type(name).__name__
+            )
         norm_name = _normalize_header(name)
         self._combined_cache[norm_name] = value
         self._as_list[norm_name] = [value]
@@ -338,12 +342,20 @@ class HTTPHeaders(collections.abc.MutableMapping[str, str]):
         return norm_name in self._as_list
 
     def __getitem__(self, name: str) -> str:
+        if not isinstance(name, str):
+            raise TypeError(
+                "HTTPHeaders keys must be str, not %s" % type(name).__name__
+            )
         header = _normalize_header(name)
         if header not in self._combined_cache:
             self._combined_cache[header] = ",".join(self._as_list[header])
         return self._combined_cache[header]
 
     def __delitem__(self, name: str) -> None:
+        if not isinstance(name, str):
+            raise TypeError(
+                "HTTPHeaders keys must be str, not %s" % type(name).__name__
+            )
         norm_name = _normalize_header(name)
         del self._combined_cache[norm_name]
         del self._as_list[norm_name]

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -507,6 +507,22 @@ Foo: even
         headers2 = HTTPHeaders.parse(str(headers))
         self.assertEqual(headers, headers2)
 
+    def test_non_str_key_setitem(self):
+        # The indexers and delitem should reject non-str keys with a clear
+        # TypeError rather than leaking AttributeError from inside
+        # _normalize_header's name.split('-').
+        headers = HTTPHeaders()
+        for bad in [1, 1.5, ("X-Foo",), b"X-Foo", None]:
+            with self.assertRaises(TypeError):
+                headers[bad] = "value"
+            with self.assertRaises(TypeError):
+                _ = headers[bad]
+            with self.assertRaises(TypeError):
+                del headers[bad]
+        # __contains__ should still return False for non-str keys without raising.
+        self.assertNotIn(1, headers)
+        self.assertNotIn(b"Foo", headers)
+
     def test_invalid_header_names(self):
         invalid_names = [
             "",


### PR DESCRIPTION
Fixes #3649.

When a non-string key is passed to `__setitem__`, `__getitem__`, or `__delitem__`, the underlying `_normalize_header` (decorated with `@lru_cache`) crashed inside `name.split('-')` and propagated an unhelpful `AttributeError: 'int' object has no attribute 'split'` to the caller.

`__contains__` already short-circuits with an `isinstance(name, str)` guard, but the indexers and delitem do not. This is inconsistent with `add()` and the type hint `MutableMapping[str, str]`, and the leaked `AttributeError` was hard to interpret at the call site.

This PR adds an `isinstance(name, str)` guard at the top of `__setitem__`, `__getitem__`, and `__delitem__` that raises `TypeError` with the offending key type, so the failure is explicit and consistent across the four entry points.

A new test `test_non_str_key_setitem` in `tornado/test/httputil_test.py` covers the three operations and verifies the new exception type and message. The test fails on the pre-fix code with `AttributeError` and passes with the fix.