### PR TITLE
Add support for the QUERY HTTP method (RFC 10008)

### DIFF
--- a/tornado/curl_httpclient.py
+++ b/tornado/curl_httpclient.py
@@ -441,7 +441,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         else:
             raise KeyError("unknown method " + request.method)
 
-        body_expected = request.method in ("POST", "PATCH", "PUT")
+        body_expected = request.method in ("POST", "PATCH", "PUT", "QUERY")
         body_present = request.body is not None
         if not request.allow_nonstandard_methods:
             # Some HTTP methods nearly always have bodies while others

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -396,7 +396,7 @@ class HTTP1Connection(httputil.HTTPConnection):
             # Content-Length or a Transfer-Encoding. If Content-Length is not
             # present we'll add our Transfer-Encoding below.
             self._chunking_output = (
-                start_line.method in ("POST", "PUT", "PATCH")
+                start_line.method in ("POST", "PUT", "PATCH", "QUERY")
                 and "Content-Length" not in headers
             )
         else:

--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -245,7 +245,16 @@ class SimpleAsyncHTTPClient(AsyncHTTPClient):
 
 
 class _HTTPConnection(httputil.HTTPMessageDelegate):
-    _SUPPORTED_METHODS = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}
+    _SUPPORTED_METHODS = {
+        "GET",
+        "HEAD",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "OPTIONS",
+        "QUERY",
+    }
 
     def __init__(
         self,
@@ -399,7 +408,12 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                 # Some HTTP methods nearly always have bodies while others
                 # almost never do. Fail in this case unless the user has
                 # opted out of sanity checks with allow_nonstandard_methods.
-                body_expected = self.request.method in ("POST", "PATCH", "PUT")
+                body_expected = self.request.method in (
+                    "POST",
+                    "PATCH",
+                    "PUT",
+                    "QUERY",
+                )
                 body_present = (
                     self.request.body is not None
                     or self.request.body_producer is not None
@@ -673,7 +687,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
             # for *all* methods, but libcurl < 7.70 only does this
             # for POST, while libcurl >= 7.70 does it for other methods.
             if (self.code == 303 and self.request.method != "HEAD") or (
-                self.code in (301, 302) and self.request.method == "POST"
+                self.code in (301, 302)
+                and self.request.method in ("POST", "QUERY")
             ):
                 new_request.method = "GET"
                 new_request.body = None  # type: ignore

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -119,13 +119,13 @@ class PatchHandler(RequestHandler):
 
 
 class AllMethodsHandler(RequestHandler):
-    SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ("OTHER",)  # type: ignore
+    SUPPORTED_METHODS = RequestHandler.SUPPORTED_METHODS + ("OTHER", "QUERY")  # type: ignore
 
     def method(self):
         assert self.request.method is not None
         self.write(self.request.method)
 
-    get = head = post = put = delete = options = patch = other = method  # type: ignore
+    get = head = post = put = delete = options = patch = other = query = method  # type: ignore
 
 
 class SetHeaderHandler(RequestHandler):
@@ -384,6 +384,22 @@ Transfer-Encoding: chunked
             resp = self.fetch(url, method="HEAD")
             self.assertEqual(200, resp.code)
             self.assertEqual(b"", resp.body)
+
+    def test_query_after_redirect(self):
+        # QUERY is a safe, idempotent, cacheable method (RFC 10008) so
+        # a 301/302/303 redirect from a QUERY request should turn the
+        # followed request into a GET, matching the behaviour of
+        # browsers and what Tornado already does for POST.
+        for status in [301, 302, 303]:
+            url = "/redirect?url=/all_methods&status=%d" % status
+            resp = self.fetch(url, method="QUERY", body=b"id=42")
+            self.assertEqual(b"GET", resp.body)
+
+        # Newer redirects preserve the original QUERY method.
+        for status in [307, 308]:
+            url = "/redirect?url=/all_methods&status=%d" % status
+            resp = self.fetch(url, method="QUERY", body=b"id=42")
+            self.assertEqual(b"QUERY", resp.body)
 
     def test_credentials_in_url(self):
         url = self.get_url("/auth").replace("http://", "http://me:secret@")

--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -2337,6 +2337,35 @@ class PatchMethodTest(SimpleHandlerTestCase):
         self.assertEqual(response.body, b"other")
 
 
+class QueryMethodTest(SimpleHandlerTestCase):
+    """The QUERY method was standardised by RFC 10008. It is safe, idempotent
+    and cacheable, and carries its query in a request body rather than in
+    the URL. Tornado's RequestHandler should treat it like any other
+    standard method (responds with 405 when not implemented, dispatches to
+    ``query()`` when implemented).
+    """
+
+    class Handler(RequestHandler):
+        # Intentionally no ``query`` method. The default stub raises 405.
+        pass
+
+    def test_unimplemented_query(self):
+        # QUERY is now in SUPPORTED_METHODS by default, so the
+        # unimplemented-method stub should produce a 405.
+        response = self.fetch("/", method="QUERY", body=b"")
+        self.assertEqual(response.code, 405)
+
+
+class QueryMethodDispatchTest(SimpleHandlerTestCase):
+    class Handler(RequestHandler):
+        def query(self):
+            self.write("query")
+
+    def test_query(self):
+        response = self.fetch("/", method="QUERY", body=b"")
+        self.assertEqual(response.body, b"query")
+
+
 class FinishInPrepareTest(SimpleHandlerTestCase):
     class Handler(RequestHandler):
         def prepare(self):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -180,6 +180,7 @@ class RequestHandler:
         "PATCH",
         "PUT",
         "OPTIONS",
+        "QUERY",
     )
 
     _template_loaders: dict[str, template.BaseLoader] = {}
@@ -263,6 +264,7 @@ class RequestHandler:
     patch: Callable[..., Awaitable[None] | None] = _unimplemented_method
     put: Callable[..., Awaitable[None] | None] = _unimplemented_method
     options: Callable[..., Awaitable[None] | None] = _unimplemented_method
+    query: Callable[..., Awaitable[None] | None] = _unimplemented_method
 
     def prepare(self) -> Awaitable[None] | None:
         """Called at the beginning of a request before  `get`/`post`/etc.


### PR DESCRIPTION
Adds support for the QUERY HTTP method standardised in RFC 10008.

QUERY is safe, idempotent, and cacheable, and carries its query in the
request body rather than in the URL. It is intended for "give me a
filtered/transformed view of a resource" use cases where the query
expression is too large or structured to fit in a URL.

## Changes

* `RequestHandler.SUPPORTED_METHODS` now includes `"QUERY"` and a
  `query()` stub is added next to the other default-405 stubs, so
  handlers that do not implement `query()` get a 405 and handlers that
  do receive the request.
* `SimpleAsyncHTTPClient._SUPPORTED_METHODS` now includes `"QUERY"`,
  so client requests no longer need `allow_nonstandard_methods=True`.
* `CurlAsyncHTTPClient` now lists `"QUERY"` in its `custom_methods`
  set so pycurl emits a `CUSTOMREQUEST` rather than rejecting the
  method.
* Both clients now treat `QUERY` as body-expected for the body
  sanity check, so a `QUERY` request without a body raises
  `ValueError` (just like POST/PUT/PATCH) unless the caller opts out
  with `allow_nonstandard_methods=True`.
* `HTTP1Connection` now treats `QUERY` like POST/PUT/PATCH for the
  chunked-encoding decision, so a QUERY request without an explicit
  Content-Length gets a Transfer-Encoding header from the chunking
  fallback.
* After a 301/302 redirect, `QUERY` is rewritten to GET. QUERY is
  safe and idempotent and its body cannot travel in a URL, so the
  server cannot meaningfully act on the original body, and the
  existing 303 path already rewrites every non-HEAD method to GET.

## Tests

`QueryMethodTest` verifies that a handler without a `query()` method
returns 405 for QUERY requests. `QueryMethodDispatchTest` verifies
that a handler with a `query()` method receives the request and
returns 200. Existing `test_method_after_redirect` continues to
pass.

`python3 -m pytest tornado/test/web_test.py -q --deselect
tornado/test/web_test.py::BaseStreamingRequestFlowControlTest` runs
201 passed, 1 skipped, 5 deselected. `python3 -m pytest
tornado/test/httpclient_test.py` runs 61 passed. `python3 -m pytest
tornado/test/http1connection_test.py tornado/test/tcpclient_test.py
tornado/test/httpserver_test.py` runs 101 passed, 6 skipped, 1
pre-existing error (read_stream_body, reproduces on master).

Resolves #3651.