### PR TITLE
iostream: downgrade the SSL handshake-error log to INFO

### DIFF
--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1366,7 +1366,7 @@ class SSLIOStream(IOStream):
                     peer = self.socket.getpeername()
                 except Exception:
                     peer = "(not connected)"
-                gen_log.warning(
+                gen_log.info(
                     "SSL Error on %s %s: %s", self.socket.fileno(), peer, err
                 )
                 return self.close(exc_info=err)

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -1066,7 +1066,7 @@ class TestIOStreamStartTLS(AsyncTestCase):
     def test_handshake_fail(self):
         server_future = self.server_start_tls(_server_ssl_options())
         # Certificates are verified with the default configuration.
-        with ExpectLog(gen_log, "SSL Error"):
+        with ExpectLog(gen_log, "SSL Error", level=logging.INFO):
             client_future = self.client_start_tls(server_hostname="localhost")
             with self.assertRaises(ssl.SSLError):
                 yield client_future
@@ -1077,7 +1077,7 @@ class TestIOStreamStartTLS(AsyncTestCase):
     def test_check_hostname(self):
         # Test that server_hostname parameter to start_tls is being used.
         server_future = self.server_start_tls(_server_ssl_options())
-        with ExpectLog(gen_log, "SSL Error"):
+        with ExpectLog(gen_log, "SSL Error", level=logging.INFO):
             client_future = self.client_start_tls(
                 ssl.create_default_context(), server_hostname="127.0.0.1"
             )
@@ -1231,7 +1231,7 @@ class TestIOStreamCheckHostname(AsyncTestCase):
         with ExpectLog(
             gen_log,
             ".*alert bad certificate",
-            level=logging.WARNING,
+            level=logging.INFO,
             required=platform.system() != "Windows",
         ):
             with self.assertRaises(ssl.SSLCertVerificationError):


### PR DESCRIPTION
Closes #3347.

The SSLIOStream handshake-error log was emitted at WARNING level, but
the events that cause it are almost always out of the server's control:

* A client connects with a self-signed or otherwise invalid certificate
  and fails validation. The TLS alert the client sends back then
  causes the *server's* handshake to fail with SSL_ERROR_SSL or
  SSL_ERROR_SYSCALL, which is what gets logged. The application
  cannot prevent the client from doing this.
* A TCP port scanner (nmap -sT, plain nc -z) connects and resets
  the socket before do_handshake completes.

In all of these cases the operator does not need to be warned; the
event is a normal occurrence on a server that is exposed to the
internet. Downgrading the log to INFO matches the level already
used for similar client-driven noise such as "Unsatisfiable read,
closing connection" and "Connect error". Applications that want
to surface a warning can install their own handler at the INFO
level.

The server-side error path still closes the connection and surfaces
the underlying exception via close(exc_info=err), so callers that
do care about a specific failure have not lost any information.

Tests:
- TestIOStreamStartTLS.test_handshake_fail and
  TestIOStreamStartTLS.test_check_hostname: now pass level=
  logging.INFO on their ExpectLog blocks because the SSL Error
  message is emitted at INFO instead of WARNING.
- TestIOStreamCheckHostname.test_no_match: the "alert bad
  certificate" ExpectLog on the server side is now expected at
  INFO.