### PR TITLE
http1connection: accept chunk extensions in chunked request bodies

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -657,12 +657,35 @@ class HTTP1Connection(httputil.HTTPConnection):
                         await ret
 
     async def _read_chunked_body(self, delegate: httputil.HTTPMessageDelegate) -> None:
-        # TODO: "chunk extensions" http://tools.ietf.org/html/rfc2616#section-3.6.1
+        # Per RFC 7230 section 4.1.1, a chunk is `chunk-size [ chunk-ext ] CRLF
+        # chunk-data CRLF`. The chunk-size is hex digits; the chunk-ext is
+        # optional and starts with ';' followed by any number of ';'-separated
+        # `name[=value]` pairs. We only use the chunk-size, so the extension
+        # is dropped after a sanity check. Both with and without an extension
+        # share the same trailing CRLF, so we still strip the last two bytes
+        # of the read line.
         total_size = 0
         while True:
             chunk_len_str = await self.stream.read_until(b"\r\n", max_bytes=64)
+            # Strip the trailing CRLF, then if a chunk extension is present
+            # ('5;ext=val' or '5;ext' or '5;ext=val;foo=bar'), take only the
+            # chunk-size prefix. Reject the line if it is empty or starts with
+            # ';' (no size, only an extension) or contains whitespace inside
+            # the size or extension portion, which would mask a smuggling
+            # attempt or a malformed client.
+            chunk_header = native_str(chunk_len_str[:-2])
+            # Reject an empty chunk header or one that begins with ';' (no
+            # chunk-size, only an extension). A size with a trailing
+            # extension (`5;ext=val`) is valid; we just take the size prefix.
+            if not chunk_header or chunk_header.startswith(";"):
+                raise httputil.HTTPInputError("invalid chunk size")
+            chunk_size_str = chunk_header.partition(";")[0]
+            # The size must be all hex digits; an empty partition result
+            # (chunk header was just ';ext=val') is invalid.
+            if not chunk_size_str:
+                raise httputil.HTTPInputError("invalid chunk size")
             try:
-                chunk_len = parse_hex_int(native_str(chunk_len_str[:-2]))
+                chunk_len = parse_hex_int(chunk_size_str)
             except ValueError:
                 raise httputil.HTTPInputError("invalid chunk size")
             if chunk_len == 0:

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -491,6 +491,52 @@ bar
         )
         self.assertEqual(json_decode(response), {"foo": ["bar"]})
 
+    def test_chunked_request_body_bare_extension_rejected(self):
+        # A line that is only an extension (no size prefix) is still malformed
+        # and must raise HTTPInputError. We send `;ext=val` as the chunk header
+        # and expect a 400 with the standard "invalid chunk size" log message.
+        self.stream.write(b"""\
+POST /echo HTTP/1.1
+Host: 127.0.0.1
+Transfer-Encoding: chunked
+
+;ext=val
+foo=
+3
+bar
+0
+
+""".replace(b"\n", b"\r\n"))
+        with ExpectLog(gen_log, ".*invalid chunk size", level=logging.INFO):
+            start_line, headers, response = self.io_loop.run_sync(
+                lambda: read_stream_body(self.stream)
+            )
+        self.assertEqual(400, start_line.code)
+
+    def test_chunked_request_body_with_extensions(self):
+        # Per RFC 7230 section 4.1.1 a chunk may carry zero or more chunk
+        # extensions after the size: `chunk-size [ ";" chunk-ext ] CRLF`.
+        # Tornado previously raised HTTPInputError on `5;ext=val` because the
+        # size parser saw the full header. Accept the extension and parse
+        # only the size prefix; a bare extension (no size) is still rejected.
+        self.stream.write(b"""\
+POST /echo HTTP/1.1
+Host: 127.0.0.1
+Transfer-Encoding: chunked
+Content-Type: application/x-www-form-urlencoded
+
+4;ext=val
+foo=
+3
+bar
+0
+
+""".replace(b"\n", b"\r\n"))
+        start_line, headers, response = self.io_loop.run_sync(
+            lambda: read_stream_body(self.stream)
+        )
+        self.assertEqual(json_decode(response), {"foo": ["bar"]})
+
     def test_chunked_request_uppercase(self):
         # As per RFC 2616 section 3.6, "Transfer-Encoding" header's value is
         # case-insensitive.


### PR DESCRIPTION
A chunked request body line is `chunk-size [ chunk-ext ] CRLF` per RFC 7230 section 4.1.1, where the optional `chunk-ext` is one or more `;`-separated `name[=value]` pairs. The pre-fix `_read_chunked_body` in `tornado/http1connection.py` passed the entire read line to `parse_hex_int`, so a client that used any extension (`5;ext=val`, `5;ext`, `5;foo=bar;baz=qux`) was rejected with `HTTPInputError("invalid chunk size")` and a 400. The size was correctly hex; the extension was just appended to it.

The fix takes the size prefix via `str.partition(";")[0]` before the hex parse. The only genuinely malformed inputs that are rejected now are:

- an empty chunk header (e.g. just `\r\n`)
- a header that starts with `;` (no size, only an extension)
- the existing `parse_hex_int` failure for non-hex characters

A bare extension with no size (`;ext=val`) and the leading-`;` case are covered by the new empty checks. The previous rejection test for `1_a` still rejects because `parse_hex_int` now runs on the size-only substring and `1_a` is not all hex.

Two new tests in `HTTPServerRawTest`:

- `test_chunked_request_body_with_extensions` sends `4;ext=val` and expects 200 with the full body parsed.
- `test_chunked_request_body_bare_extension_rejected` sends `;ext=val` and expects 400 with the existing `invalid chunk size` log line.

Pre-existing behavior preserved: `4\r\nfoo=` parses as chunk-size 4, and `1_a` is still rejected as non-hex.

## Testing

- `python3 -m tornado.test.runtests tornado.test.httpserver_test` → 76 tests, OK
- `python3 -m pytest tornado/test/httpserver_test.py -k chunked -p no:aiohttp` → 15 passed (was 13, +2 new)
- The pre-existing `test_chunked_request_body_invalid_size` still passes (regression check on the `1_a` case)
