### PR TITLE
concurrent: format the run_on_executor bad-args ValueError message

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -131,7 +131,7 @@ def run_on_executor(*args: Any, **kwargs: Any) -> Callable:
     if len(args) == 1:
         return run_on_executor_decorator(args[0])
     elif len(args) != 0:
-        raise ValueError("expected 1 argument, got %d", len(args))
+        raise ValueError("expected 1 argument, got %d" % len(args))
     return run_on_executor_decorator
 
 

--- a/tornado/test/concurrent_test.py
+++ b/tornado/test/concurrent_test.py
@@ -227,5 +227,15 @@ class RunOnExecutorTest(AsyncTestCase):
         self.assertEqual(result, 42)
 
 
+class RunOnExecutorArgValidationTest(AsyncTestCase):
+    def test_run_on_executor_bad_args(self):
+        with self.assertRaisesRegex(ValueError, "expected 1 argument, got 2"):
+            @run_on_executor(1, 2)
+            def f():
+                pass
+
+        pass
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The pre-fix code in `tornado/concurrent.py` raised the bad-arg error with
two positional arguments to `ValueError`:

    raise ValueError("expected 1 argument, got %d", len(args))

`ValueError` (like all `Exception` subclasses) takes a single message
argument; any further positional arguments end up in `e.args` as a tuple
rather than being formatted into the message. The user-visible effect is
that `str(e)` is the literal `"('expected 1 argument, got %d', 2)"` and
the offending count is hidden in `e.args[1]`, so a simple
`assertRaisesRegex` for the formatted string fails, and any caller that
logs `str(e)` gets a useless tuple repr.

The fix is the same single-character change that landed in
[tornadoweb/tornado#3679](https://github.com/tornadoweb/tornado/pull/3679)
for `_convert_header_value` in `tornado/web.py`: `"expected 1 argument,
got %d" % len(args)` so the count is interpolated into the message
before the exception is raised.

Verified with a new test `test_run_on_executor_bad_args` in
`tornado/test/concurrent_test.py` that asserts the message contains
`"expected 1 argument, got 2"`. On the pre-fix code the assertion
fails with the exact tuple repr; on the fix the assertion passes.
All 12 `concurrent_test.py` tests pass.

Drafted with MiniMax M3; reviewed by keenrose.