### PR TITLE
Fix typo: afe -> safe in add_callback_from_signal docstring

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -654,7 +654,7 @@ class IOLoop(Configurable):
     ) -> None:
         """Calls the given callback on the next I/O loop iteration.
 
-        Intended to be afe for use from a Python signal handler; should not be
+        Intended to be safe for use from a Python signal handler; should not be
         used otherwise.
 
         .. deprecated:: 6.4


### PR DESCRIPTION
Fix a small typo in the `add_callback_from_signal` docstring in `tornado/ioloop.py`:

- `afe` → `safe` (line 657)

Found by running [codespell](https://github.com/codespell-project/codespell) over the repo.