### PR TITLE
Fix bare except in process.py: use except Exception

### DIFF
--- a/tornado/process.py
+++ b/tornado/process.py
@@ -229,7 +229,7 @@ class Subprocess:
             self.stderr = PipeIOStream(err_r)
         try:
             self.proc = subprocess.Popen(*args, **kwargs)
-        except:
+        except Exception:
             for fd in pipe_fds:
                 os.close(fd)
             raise


### PR DESCRIPTION
Fix a bare `except:` clause in `tornado/process.py` (line 232) that catches `BaseException` (including `SystemExit` and `KeyboardInterrupt`).

**`tornado/process.py`** line 232:
`except:` → `except Exception:`

This bare `except:` wraps a `subprocess.Popen()` call inside `Subprocess.__init__()`. When `Popen` fails, the except block closes open pipe file descriptors and then re-raises the exception. Using `except Exception:` is sufficient — `subprocess.Popen` raises `OSError` or `ValueError` on failure, and `KeyboardInterrupt` / `SystemExit` should propagate immediately without attempting pipe cleanup.

Bare `except:` is bad practice (PEP 8 / flake8 E722) because it silently interferes with `KeyboardInterrupt` and `SystemExit` signals.