### PR TITLE
queues: Preserve items when waiting consumers are canceled

### DIFF
--- a/tornado/queues.py
+++ b/tornado/queues.py
@@ -27,10 +27,11 @@ to those provided in the standard library's `asyncio package
 
 from __future__ import annotations
 
+import asyncio
 import collections
 import datetime
 import heapq
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Generator
 from typing import Any, Generic, TypeVar
 
 from tornado import gen, ioloop
@@ -64,6 +65,20 @@ def _set_timeout(future: Future, timeout: None | float | datetime.timedelta) -> 
         io_loop = ioloop.IOLoop.current()
         timeout_handle = io_loop.add_timeout(timeout, on_timeout)
         future.add_done_callback(lambda _: io_loop.remove_timeout(timeout_handle))
+
+
+class _QueueGetter(Future[_T]):
+    def __init__(self, queue: Queue[_T]) -> None:
+        super().__init__()
+        self.queue = queue
+
+    def __await__(self) -> Generator[Any, None, _T]:
+        try:
+            return (yield from super().__await__())
+        except asyncio.CancelledError:
+            if self.done() and not self.cancelled():
+                self.queue._put_cancelled(self.result())
+            raise
 
 
 class _QueueIterator(Generic[_T]):
@@ -248,7 +263,7 @@ class Queue(Generic[_T]):
            A ``timeout`` argument of zero will either return or raise immediately.
            Previously, zero was treated equivalent to ``None`` (wait forever).
         """
-        future: Future[_T] = Future()
+        future: Future[_T] = _QueueGetter(self)
         try:
             future.set_result(self.get_nowait())
         except QueueEmpty:
@@ -325,6 +340,15 @@ class Queue(Generic[_T]):
         self._unfinished_tasks += 1
         self._finished.clear()
         self._put(item)
+
+    def _put_cancelled(self, item: _T) -> None:
+        self._consume_expired()
+        if self._getters:
+            assert self.empty(), "queue non-empty, why are getters waiting?"
+            getter = self._getters.popleft()
+            future_set_result_unless_cancelled(getter, item)
+        else:
+            self._put(item)
 
     def _consume_expired(self) -> None:
         # Remove timed-out waiters.

--- a/tornado/test/queues_test.py
+++ b/tornado/test/queues_test.py
@@ -134,6 +134,22 @@ class QueueGetTest(AsyncTestCase):
         self.assertEqual(0, (yield get))
 
     @gen_test
+    async def test_cancelled_get_does_not_lose_item(self):
+        q: queues.Queue[int] = queues.Queue()
+
+        async def consume():
+            return await q.get()
+
+        consumer = asyncio.ensure_future(consume())
+        await asyncio.sleep(0)
+        q.put_nowait(0)
+        consumer.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await consumer
+        self.assertEqual(0, q.get_nowait())
+
+    @gen_test
     def test_get_clears_timed_out_putters(self):
         q: queues.Queue[int] = queues.Queue(1)
         # First putter succeeds, remainder block.


### PR DESCRIPTION
Fixes #2826.

A queue item can be assigned to a waiting getter just before its consumer task is canceled; cancellation then replaces the getter's completed result and silently drops the item. Queue getters now return completed items to the queue when cancellation wins that race, without changing the unfinished-task count.

The regression test reproduces the put-then-cancel ordering: it fails with `QueueEmpty` before the fix and passes afterward. The queues test module passes all 43 tests.
