### PR TITLE
http1connection: Hide compressed content length after decoding

### DIFF
--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -723,11 +723,15 @@ class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
     ) -> Awaitable[None] | None:
         if headers.get("Content-Encoding", "").lower() == "gzip":
             self._decompressor = GzipDecompressor()
-            # Downstream delegates will only see uncompressed data,
-            # so rename the content-encoding header.
+            # Keep the framing headers intact for HTTP1Connection while downstream
+            # delegates see headers that describe the uncompressed data.
+            headers = headers.copy()
             # (but note that curl_httpclient doesn't do this).
             headers.add("X-Consumed-Content-Encoding", headers["Content-Encoding"])
             del headers["Content-Encoding"]
+            if "Content-Length" in headers:
+                headers.add("X-Consumed-Content-Length", headers["Content-Length"])
+                del headers["Content-Length"]
         return self._delegate.headers_received(start_line, headers)
 
     async def data_received(self, chunk: bytes) -> None:

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -1,5 +1,6 @@
 import collections
 import errno
+import gzip
 import logging
 import os
 import re
@@ -47,11 +48,35 @@ from tornado.testing import (
 from tornado.web import Application, RequestHandler, stream_request_body, url
 
 
+class GzipContentLengthHandler(RequestHandler):
+    BODY = b"valid proxy payload" * 32
+    COMPRESSED_BODY = gzip.compress(BODY)
+
+    def get(self):
+        self.set_header("Content-Encoding", "gzip")
+        self.finish(self.COMPRESSED_BODY)
+
+
 class SimpleHTTPClientCommonTestCase(httpclient_test.HTTPClientCommonTestCase):
+    def get_app(self):
+        app = super().get_app()
+        app.add_handlers(".*$", [(r"/gzip_content_length", GzipContentLengthHandler)])
+        return app
+
     def get_http_client(self):
         client = SimpleAsyncHTTPClient(force_instance=True)
         self.assertTrue(isinstance(client, SimpleAsyncHTTPClient))
         return client
+
+    def test_decompressed_content_length(self):
+        response = self.fetch("/gzip_content_length")
+
+        self.assertEqual(response.body, GzipContentLengthHandler.BODY)
+        self.assertNotIn("Content-Length", response.headers)
+        self.assertEqual(
+            response.headers["X-Consumed-Content-Length"],
+            str(len(GzipContentLengthHandler.COMPRESSED_BODY)),
+        )
 
 
 class TriggerHandler(RequestHandler):


### PR DESCRIPTION
Automatic gzip decompression left the upstream `Content-Length` in response headers even though the body contained the decompressed bytes, so proxying the response could fail with `HTTPOutputError`.

Pass a header copy downstream to preserve the original framing metadata for `HTTP1Connection`, then rename `Content-Length` to `X-Consumed-Content-Length` alongside the existing `Content-Encoding` handling. The regression test fails on master and the affected client/server suites pass; the full suite's sole failure also reproduces on unmodified master on macOS/Python 3.14.

Fixes #2743
