### PR TITLE
gen: Support duplicate futures in WaitIterator

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -348,18 +348,21 @@ class WaitIterator:
 
     """
 
-    _unfinished: dict[Future, int | str] = {}
+    _unfinished: dict[Future, collections.deque[int | str]] = {}
 
     def __init__(self, *args: Future, **kwargs: Future) -> None:
         if args and kwargs:
             raise ValueError("You must provide args or kwargs, not both")
 
+        self._unfinished = {}
         if kwargs:
-            self._unfinished = {f: k for (k, f) in kwargs.items()}
             futures: Sequence[Future] = list(kwargs.values())
+            for key, future in kwargs.items():
+                self._unfinished.setdefault(future, collections.deque()).append(key)
         else:
-            self._unfinished = {f: i for (i, f) in enumerate(args)}
             futures = args
+            for index, future in enumerate(args):
+                self._unfinished.setdefault(future, collections.deque()).append(index)
 
         self._finished: collections.deque[Future] = collections.deque()
         self.current_index: str | int | None = None
@@ -407,7 +410,10 @@ class WaitIterator:
         res = self._running_future
         self._running_future = None
         self.current_future = done
-        self.current_index = self._unfinished.pop(done)
+        indices = self._unfinished[done]
+        self.current_index = indices.popleft()
+        if not indices:
+            del self._unfinished[done]
 
         return res
 

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -844,6 +844,25 @@ class WaitIteratorTest(AsyncTestCase):
         self.assertIsNone(g.current_index, "bad nil current index")
         self.assertIsNone(g.current_future, "bad nil current future")
 
+    @gen_test
+    def test_duplicate_futures(self):
+        future: Future[int] = Future()
+        future.set_result(42)
+
+        cases: list[tuple[gen.WaitIterator, list[int | str]]] = [
+            (gen.WaitIterator(future, future, future), [0, 1, 2]),
+            (gen.WaitIterator(first=future, second=future), ["first", "second"]),
+        ]
+        for iterator, expected_indices in cases:
+            results = []
+            indices = []
+            while not iterator.done():
+                results.append((yield iterator.next()))
+                indices.append(iterator.current_index)
+
+            self.assertEqual(results, [42] * len(expected_indices))
+            self.assertEqual(indices, expected_indices)
+
     def finish_coroutines(self, iteration, futures):
         if iteration == 3:
             futures[2].set_result(24)


### PR DESCRIPTION
`WaitIterator` stored unfinished inputs in a dict keyed by future, so passing the same future more than once collapsed its indices and the second completion raised `KeyError`. Keep a deque of indices for each future instead, preserving positional and keyword entries in input order.

Adds regression coverage for both constructor forms. Fixes #2029.
