### PR TITLE
Fix timeout propagation after redirects

### DIFF
--- a/tornado/simple_httpclient.py
+++ b/tornado/simple_httpclient.py
@@ -11,7 +11,7 @@ import urllib.parse
 from collections.abc import Awaitable, Callable
 from io import BytesIO
 from types import TracebackType
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, cast
 
 from tornado import gen, httputil, version
 from tornado.escape import _unicode
@@ -688,12 +688,13 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                     except KeyError:
                         pass
             new_request.original_request = original_request  # type: ignore
+            assert self.final_callback is not None
             final_callback = self.final_callback
             self.final_callback = None  # type: ignore
             self._release()
             assert self.client is not None
-            fut = self.client.fetch(new_request, raise_error=False)
-            fut.add_done_callback(lambda f: final_callback(f.result()))
+            request_proxy = _RequestProxy(new_request, self.client.defaults)
+            self.client.fetch_impl(cast(HTTPRequest, request_proxy), final_callback)
             self._on_end_request()
             return
         if self.request.streaming_callback:

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -570,6 +570,27 @@ class SimpleHTTPClientTestCase(AsyncHTTPTestCase, SimpleHTTPClientTestMixin):
     def create_client(self, **kwargs):
         return SimpleAsyncHTTPClient(force_instance=True, **kwargs)
 
+    @gen_test
+    def test_request_timeout_after_redirect(self):
+        timeout = 0.1
+        if os.name == "nt" or os.environ.get("EMULATION") == "1":
+            timeout = 0.5
+
+        with closing(self.create_client()) as client:
+            future = client.fetch(
+                self.get_url("/redirect?url=%2Ftrigger%3Fwake%3Dfalse"),
+                request_timeout=timeout,
+            )
+            try:
+                with self.assertRaisesRegex(HTTPTimeoutError, "Timeout during request"):
+                    yield gen.with_timeout(self.io_loop.time() + timeout * 5, future)
+            finally:
+                if not future.done():
+                    future.cancel()
+                if self.triggers:
+                    self.triggers.popleft()()
+                yield gen.sleep(0)
+
 
 class SimpleHTTPSClientTestCase(AsyncHTTPSTestCase, SimpleHTTPClientTestMixin):
     def setUp(self):


### PR DESCRIPTION
`SimpleAsyncHTTPClient` followed redirects through the public Future API, so a timeout on the redirected request was raised from a done callback and the original fetch never completed. Continue through `fetch_impl`'s response callback so the 599 error reaches the caller while retaining request defaults.

Adds a local redirect-to-stalled-handler regression test. Fixes #3064.
