### PR TITLE
web: Cap growing static files at Content-Length

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import socket
+import tempfile
 import typing
 import unittest
 import urllib.parse
@@ -1172,6 +1173,11 @@ class StaticFileTest(WebTestCase):
     )
     static_dir = os.path.join(os.path.dirname(__file__), "static")
 
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        super().setUp()
+
     def get_handlers(self):
         class StaticUrlHandler(RequestHandler):
             def get(self, path):
@@ -1202,10 +1208,23 @@ class StaticFileTest(WebTestCase):
                     result = check_override == -1 and check_regular == 0
                 self.write(str(result))
 
+        class GrowingStaticFileHandler(StaticFileHandler):
+            def get_content_size(self):
+                size = super().get_content_size()
+                assert self.absolute_path is not None
+                with open(self.absolute_path, "ab") as file:
+                    file.write(b"-grew")
+                return size
+
         return [
             ("/static_url/(.*)", StaticUrlHandler),
             ("/abs_static_url/(.*)", AbsoluteStaticUrlHandler),
             ("/override_static_url/(.*)", OverrideStaticUrlHandler),
+            (
+                "/growing_static/(.*)",
+                GrowingStaticFileHandler,
+                dict(path=self.temp_dir.name),
+            ),
             ("/root_static/(.*)", StaticFileHandler, dict(path="/")),
         ]
 
@@ -1219,6 +1238,19 @@ class StaticFileTest(WebTestCase):
         response = self.fetch("/static/robots.txt")
         self.assertIn(b"Disallow: /", response.body)
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
+
+    def test_static_file_growing_during_request(self):
+        initial_content = b"before"
+        path = os.path.join(self.temp_dir.name, "data.txt")
+        with open(path, "wb") as file:
+            file.write(initial_content)
+
+        response = self.fetch("/growing_static/data.txt")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(
+            response.headers.get("Content-Length"), str(len(initial_content))
+        )
+        self.assertEqual(response.body, initial_content)
 
     def test_static_files_cacheable(self):
         # Test that the version parameter triggers cache-control headers. This

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2840,11 +2840,18 @@ class StaticFileHandler(RequestHandler):
             content = self.get_content(self.absolute_path, start, end)
             if isinstance(content, bytes):
                 content = [content]
+            remaining = content_length
             for chunk in content:
-                try:
-                    self.write(chunk)
-                    await self.flush()
-                except iostream.StreamClosedError:
+                # The file may have grown since Content-Length was calculated.
+                chunk = chunk[:remaining]
+                if chunk:
+                    try:
+                        self.write(chunk)
+                        await self.flush()
+                    except iostream.StreamClosedError:
+                        return
+                    remaining -= len(chunk)
+                if remaining == 0:
                     return
         else:
             assert self.request.method == "HEAD"


### PR DESCRIPTION
Fixes #2769.

`StaticFileHandler` calculates `Content-Length` before streaming but reads the file to EOF, so a file that grows during the request overruns the advertised length and closes the connection. Limit emitted chunks to the calculated response length while preserving the existing `get_content(..., end=None)` override contract.

The live-server regression grows the file between sizing and streaming; it fails with `HTTPOutputError` before the fix and passes after it. `StaticFileTest` passes all 34 tests, and Black, flake8, and mypy (Linux/Windows) pass on both changed files. The full local Python 3.14 suite has one unrelated baseline failure in `test_no_open_redirect`.
