### PR TITLE
gen: Release frames after caught exceptions

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -776,12 +776,24 @@ class Runner:
                         future = None
 
                     if exc is not None:
+                        original_tb = exc.__traceback__
                         try:
                             yielded = self.gen.throw(exc)
+                        except (StopIteration, Return):
+                            # If the generator handled the exception and
+                            # returned, don't retain its frame through the
+                            # exception stored on the yielded Future.
+                            exc.__traceback__ = original_tb
+                            raise
+                        else:
+                            # gen.throw() adds the receiving generator's frame
+                            # to the traceback even if it handles the exception
+                            # and yields again.
+                            exc.__traceback__ = original_tb
                         finally:
-                            # Break up a circular reference for faster GC on
+                            # Break up circular references for faster GC on
                             # CPython.
-                            del exc
+                            del exc, original_tb
                     else:
                         yielded = self.gen.send(value)
 

--- a/tornado/test/gen_test.py
+++ b/tornado/test/gen_test.py
@@ -590,6 +590,37 @@ class GenCoroutineTest(AsyncTestCase):
         self.assertIsNone(self.local_ref())
         self.finished = True
 
+    @skipNotCPython
+    def test_coroutine_refcounting_caught_exception(self):
+        @gen.coroutine
+        def raise_exc():
+            yield gen.moment
+            raise ValueError("Some error")
+
+        for yield_after_catch in (False, True):
+            with self.subTest(yield_after_catch=yield_after_catch):
+
+                @gen.coroutine
+                def inner():
+                    class Foo:
+                        pass
+
+                    local_var = Foo()
+                    self.caught_local_ref = weakref.ref(local_var)
+                    try:
+                        yield raise_exc()
+                    except ValueError:
+                        if yield_after_catch:
+                            yield gen.moment
+
+                @gen.coroutine
+                def outer():
+                    yield inner()
+                    self.assertIsNone(self.caught_local_ref())
+
+                self.io_loop.run_sync(outer, timeout=3)
+        self.finished = True
+
     def test_asyncio_future_debug_info(self):
         self.finished = True
         # Enable debug mode


### PR DESCRIPTION
Fixes #3346.

When a `@gen.coroutine` catches an exception from a yielded Future, `gen.throw()` leaves the receiving generator frame on the exception traceback. The Future retains that exception, closing a cycle through the Runner callback stack and keeping frame locals alive until cyclic GC.

Restore the pre-throw traceback once the coroutine handles the exception, whether it returns or yields again. The regression test verifies CPython releases those locals immediately in both paths.

Tests: `gen_test` passes on Python 3.10, 3.13, and 3.14; flake8, black, and mypy pass. The full suite's sole failure (`StaticDefaultFilenameRootTest.test_no_open_redirect` on macOS) reproduces unchanged on master.
