### PR TITLE
web: Handle CancelledError from request handlers

### DIFF
--- a/tornado/test/web_test.py
+++ b/tornado/test/web_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import binascii
 import contextlib
 import copy
@@ -1126,10 +1127,15 @@ class ErrorResponseTest(WebTestCase):
             def write_error(self, status_code, **kwargs):
                 raise Exception("exception in write_error")
 
+        class CancelledErrorHandler(RequestHandler):
+            async def get(self):
+                raise asyncio.CancelledError()
+
         return [
             url("/default", DefaultHandler),
             url("/write_error", WriteErrorHandler),
             url("/failed_write_error", FailedWriteErrorHandler),
+            url("/cancelled_error", CancelledErrorHandler),
         ]
 
     def test_default(self):
@@ -1161,6 +1167,11 @@ class ErrorResponseTest(WebTestCase):
             response = self.fetch("/failed_write_error")
             self.assertEqual(response.code, 500)
             self.assertEqual(b"", response.body)
+
+    def test_cancelled_error(self):
+        with ExpectLog(app_log, "Uncaught exception"):
+            response = self.fetch("/cancelled_error", request_timeout=1.0)
+        self.assertEqual(response.code, 500)
 
 
 class StaticFileTest(WebTestCase):

--- a/tornado/web.py
+++ b/tornado/web.py
@@ -56,6 +56,7 @@ the executor do not refer to Tornado objects.
 
 """
 
+import asyncio
 import base64
 import binascii
 import datetime
@@ -1861,7 +1862,7 @@ class RequestHandler:
                 result = await result
             if self._auto_finish and not self._finished:
                 self.finish()
-        except Exception as e:
+        except (Exception, asyncio.CancelledError) as e:
             try:
                 self._handle_request_exception(e)
             except Exception:


### PR DESCRIPTION
`asyncio.CancelledError` moved outside `Exception` in Python 3.8, so a cancelled handler bypasses `RequestHandler._execute`'s error path and leaves the client waiting until its timeout. Catch it explicitly so Tornado returns its normal 500 response.

Fixes #2990.

Tested with `ErrorResponseTest` (including a regression that times out without the source fix), plus flake8, black, and mypy on the changed files. The full 1,244-test run had only the existing macOS `test_no_open_redirect` failure, reproduced unchanged on the base branch.
