### PR TITLE
Add missing trailing commas to Python version classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,13 +120,13 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         # [[[cog
         #   for minor in range(int(min_python_minor), int(max_python_minor) + 1):
-        #     cog.outl(f"\"Programming Language :: Python :: 3.{minor}\"")
+        #     cog.outl(f"\"Programming Language :: Python :: 3.{minor}\",")
         #   ]]]
-        "Programming Language :: Python :: 3.10"
-        "Programming Language :: Python :: 3.11"
-        "Programming Language :: Python :: 3.12"
-        "Programming Language :: Python :: 3.13"
-        "Programming Language :: Python :: 3.14"
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         # [[[end]]]
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Hi, and thank you for Tornado.

Small `setup.py` fix. The cog-generated Python-version classifiers are missing trailing commas, so the adjacent string literals concatenate into a single invalid classifier:

```python
classifiers=[
    ...
    "Programming Language :: Python :: 3.10"
    "Programming Language :: Python :: 3.11"
    "Programming Language :: Python :: 3.12"
    "Programming Language :: Python :: 3.13"
    "Programming Language :: Python :: 3.14"
    # [[[end]]]
    "Programming Language :: Python :: Implementation :: CPython",
```

Those five lines evaluate to one string — `"...3.10Programming Language :: Python :: 3.11...3.14"` — which isn't a valid PyPI classifier. The last released version on PyPI still shows the correct separate classifiers, so this looks like a recent regression that would ship malformed `Programming Language :: Python :: 3.x` metadata on the next release.

This PR adds the trailing commas, and also adds the comma to the `cog.outl(...)` template above so `cog -r setup.py` won't regenerate the bug.

For transparency: I used AI assistance to spot and draft this; I verified the source and the current PyPI metadata myself.
