### PR TITLE
Fall back to full format for future dates

### DIFF
--- a/tornado/locale.py
+++ b/tornado/locale.py
@@ -355,7 +355,7 @@ class Locale:
             date = date.replace(tzinfo=datetime.timezone.utc)
         now = datetime.datetime.now(datetime.timezone.utc)
         if date > now:
-            if relative and (date - now).seconds < 60:
+            if relative and (date - now).total_seconds() < 60:
                 # Due to click skew, things are some things slightly
                 # in the future. Round timestamps in the immediate
                 # future down to now in relative mode.

--- a/tornado/test/locale_test.py
+++ b/tornado/test/locale_test.py
@@ -141,6 +141,12 @@ class EnglishTest(unittest.TestCase):
                     "%s %d, %d" % (locale._months[date.month - 1], date.day, date.year),
                 )
 
+                date = now + datetime.timedelta(days=1, seconds=30)
+                self.assertEqual(
+                    locale.format_date(date, full_format=False, shorter=True),
+                    "%s %d, %d" % (locale._months[date.month - 1], date.day, date.year),
+                )
+
     def test_friendly_number(self):
         locale = tornado.locale.get("en_US")
         self.assertEqual(locale.friendly_number(1000000), "1,000,000")


### PR DESCRIPTION
`Locale.format_date` treats a future date as clock skew and rounds it down to now when `(date - now).seconds` is under 60, but `timedelta.seconds` holds only the sub-day remainder, so any date close to a whole number of days ahead passes that check. A timestamp one day in the future renders as `0 seconds ago` instead of the full format documented for future dates.

Compare the whole duration with `total_seconds()` so only dates that are genuinely less than a minute ahead are rounded down. Sub-minute clock skew still rounds to now, and past dates are unaffected.

Test: `python3 -m tornado.test.runtests tornado.test.locale_test` (Ran 8 tests, OK).