### PR TITLE
Allow AWS-LC/BoringSSL error strings in TestIOStreamCheckHostname

### DIFF
--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -1228,16 +1228,20 @@ class TestIOStreamCheckHostname(AsyncTestCase):
     @gen_test
     async def test_no_match(self):
         stream = SSLIOStream(socket.socket(), ssl_options=self.client_ssl_ctx)
+        # The exact error strings depend on the TLS implementation: OpenSSL
+        # spells them out in prose while AWS-LC (and BoringSSL) use the
+        # uppercase name of the error reason.
         with ExpectLog(
             gen_log,
-            ".*alert bad certificate",
+            ".*(alert bad certificate|SSLV3_ALERT_BAD_CERTIFICATE)",
             level=logging.WARNING,
             required=platform.system() != "Windows",
         ):
             with self.assertRaises(ssl.SSLCertVerificationError):
                 with ExpectLog(
                     gen_log,
-                    ".*(certificate verify failed: Hostname mismatch)",
+                    ".*(certificate verify failed|CERTIFICATE_VERIFY_FAILED)"
+                    ": Hostname mismatch",
                     level=logging.WARNING,
                 ):
                     await stream.connect(


### PR DESCRIPTION
AWS-LC (and BoringSSL) report the uppercase name of the error reason where OpenSSL emits lowercase prose, so test_no_match failed with "did not get expected log message" when Python is linked against AWS-LC:

  [SSL: CERTIFICATE_VERIFY_FAILED] CERTIFICATE_VERIFY_FAILED: Hostname
  mismatch, certificate is not valid for 'bar.example.com'.
  [SSL: SSLV3_ALERT_BAD_CERTIFICATE] SSLV3_ALERT_BAD_CERTIFICATE

Accept either spelling, following the same approach as CPython's python/cpython#116334.