### PR TITLE
test: make curl proxy tests immune to proxy environment variables

### DIFF
--- a/tornado/test/curl_httpclient_test.py
+++ b/tornado/test/curl_httpclient_test.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from hashlib import md5
 import os
 import ssl
@@ -144,6 +145,30 @@ class CurlHTTPClientTestCase(AsyncHTTPTestCase):
             self.fetch("/digest", streaming_callback=_async_recv_chunk)
 
 
+@contextmanager
+def _ignore_proxy_env_vars():
+    # libcurl consults the (lowercase or uppercase) *_proxy environment
+    # variables to decide whether and how to proxy a request, which can
+    # override or interfere with the proxy settings the tests configure
+    # explicitly. Hide them for the duration of the test so the results
+    # don't depend on the environment the tests happen to run in.
+    proxy_vars = [
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+    ]
+    saved = {name: os.environ.pop(name) for name in proxy_vars if name in os.environ}
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
+
+
 class ProxyAuthEchoHandler(RequestHandler):
     def get(self):
         if self.request.headers.get("Proxy-Authorization", None) is not None:
@@ -154,6 +179,10 @@ class ProxyAuthEchoHandler(RequestHandler):
 
 @unittest.skipIf(pycurl is None, "pycurl module not present")
 class CurlHTTPClientReuseProxyAuthTestCase(AsyncHTTPTestCase):
+    def setUp(self):
+        self.enterContext(_ignore_proxy_env_vars())
+        super().setUp()
+
     def get_app(self):
         # Note that we don't properly support proxy-style requests, but it works well enough
         # for this test if we start the url matcher with a wildcard.
@@ -201,6 +230,10 @@ class ClientCertEchoHandler(RequestHandler):
 
 @unittest.skipIf(pycurl is None, "pycurl module not present")
 class CurlHTTPClientReuseCertsTestCase(AsyncHTTPSTestCase):
+    def setUp(self):
+        self.enterContext(_ignore_proxy_env_vars())
+        super().setUp()
+
     def get_app(self):
         return Application([(".*/client_cert", ClientCertEchoHandler)])
 


### PR DESCRIPTION
libcurl consults http_proxy/https_proxy/no_proxy (and their uppercase variants) when deciding whether/how to proxy a request. If those are set in the environment running the tests, they can override or interfere with the explicit proxy settings the tests configure, causing spurious failures unrelated to the code under test.


Claude-Session: https://claude.ai/code/session_01CE6ruM72RTi7ephrsZ9gLz